### PR TITLE
add arange to xsimd

### DIFF
--- a/include/xsimd/routines/builder.hpp
+++ b/include/xsimd/routines/builder.hpp
@@ -33,7 +33,8 @@ namespace xsimd
 
 		simd_type operator[](std::size_t I)
 		{
-			return m_stepper + simd_type(I);
+			using namespace std;
+			return fma(simd_type(I), simd_type(m_step), m_stepper);
 		}
 
 		void store_aligned(T* dst, std::size_t size) const

--- a/include/xsimd/routines/builder.hpp
+++ b/include/xsimd/routines/builder.hpp
@@ -13,25 +13,25 @@
 
 namespace xsimd
 {
-	template <class T, std::size_t N>
-	inline void arange(batch<T, N>& batch, T start = 0, T step = 1)
-	{
-		T val = start;
-		alignas(32) T xrange[N];
-		for (auto it = std::begin(xrange); it != std::end(xrange); ++it)
-		{
-			*it = val;
-			val += step;
-		}
-		xsimd::load_aligned(xrange, batch);
-	}
+    template <class T, std::size_t N>
+    inline void arange(batch<T, N>& batch, T start = 0, T step = 1)
+    {
+        T val = start;
+        alignas(XSIMD_DEFAULT_ALIGNMENT) T xrange[N];
+        for (auto it = std::begin(xrange); it != std::end(xrange); ++it)
+        {
+            *it = val;
+            val += step;
+        }
+        xsimd::load_aligned(xrange, batch);
+    }
 
-	template <class I, class T>
-	inline void arange(I begin, I end, T start, T step)
-	{
-		using value_type = std::decay_t<decltype(*begin)>;
-		using traits = simd_traits<value_type>;
-		using batch_type = typename traits::type;
+    template <class I, class T>
+    inline void arange(I begin, I end, T start, T step)
+    {
+        using value_type = std::decay_t<decltype(*begin)>;
+        using traits = simd_traits<value_type>;
+        using batch_type = typename traits::type;
 
         std::size_t size = static_cast<std::size_t>(std::distance(begin, end));
         std::size_t simd_size = traits::size;
@@ -39,39 +39,39 @@ namespace xsimd
         value_type* ptr_begin = &(*begin);
         value_type* ptr_end = &(*end);
 
-		std::size_t align_begin = xsimd::get_alignment_offset(ptr_begin, size, simd_size);
-		std::size_t align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
+        std::size_t align_begin = xsimd::get_alignment_offset(ptr_begin, size, simd_size);
+        std::size_t align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
 
-		for (std::size_t i = 0; i < align_begin; ++i)
-		{
-		    *ptr_begin = start;
-		    ++ptr_begin;
-		    start += step;
-		}
+        for (std::size_t i = 0; i < align_begin; ++i)
+        {
+            *ptr_begin = start;
+            ++ptr_begin;
+            start += step;
+        }
 
-		batch_type brange, bstep(step * traits::size);
-		arange(brange, start, step);
+        batch_type brange, bstep(step * traits::size);
+        arange(brange, start, step);
 
-		for (std::size_t i = align_begin; i < align_end; i += simd_size)
-		{
-			xsimd::store_aligned(ptr_begin, brange);
-			brange += bstep;
-			ptr_begin += simd_size;
-		}
+        for (std::size_t i = align_begin; i < align_end; i += simd_size)
+        {
+            xsimd::store_aligned(ptr_begin, brange);
+            brange += bstep;
+            ptr_begin += simd_size;
+        }
 
-		start = *(ptr_begin - 1) + step;
-		for (std::size_t i = align_end; i < size; ++i)
-		{
-			*ptr_begin = start;
-			++ptr_begin;
-			start += step;
-		}
-	}
+        start = *(ptr_begin - 1) + step;
+        for (std::size_t i = align_end; i < size; ++i)
+        {
+            *ptr_begin = start;
+            ++ptr_begin;
+            start += step;
+        }
+    }
 
-	template <class I>
-	inline void arange(I begin, I end)
-	{
-		arange(begin, end, 0, 1);
-	}
+    template <class I>
+    inline void arange(I begin, I end)
+    {
+        arange(begin, end, 0, 1);
+    }
 }
 #endif

--- a/include/xsimd/routines/builder.hpp
+++ b/include/xsimd/routines/builder.hpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+* Copyright (c) 2016, Wolf Vollprecht, Johan Mabille and Sylvain Corlay    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSIMD_BUILDER_HPP
+#define XSIMD_BUILDER_HPP
+
+namespace xsimd
+{
+	template <class T>
+	struct arange
+	{
+		using simd_type = typename simd_traits<T>::type;
+		constexpr static std::size_t batch_size = simd_traits<T>::size;
+
+		arange(T start, T step)
+			: m_start(start), m_step(step)
+		{
+			T val = m_start;
+			T steps[batch_size];
+			for (auto it = std::begin(steps); it != std::end(steps); ++it)
+			{
+				*it = val;
+				val += m_step;
+			}
+			xsimd::load_aligned(steps, m_stepper);
+			m_step_increment = simd_type(m_step * batch_size);
+		}
+
+		simd_type operator[](std::size_t I)
+		{
+			return m_stepper + simd_type(I);
+		}
+
+		void store_aligned(T* dst, std::size_t size) const
+		{
+			std::size_t simd_size = size / simd_traits<T>::size;
+			std::size_t simd_rest = size % simd_traits<T>::size;
+
+			simd_type stepper = m_stepper;
+
+			for (std::size_t i = 0; i < simd_size; ++i)
+			{
+				xsimd::store_aligned(dst, stepper);
+				stepper += m_step_increment;
+				dst += batch_size;
+			}
+
+			T val = simd_size != 0 ? dst[-1] : m_start;  // get last value
+			for (std::size_t i = 0; i < simd_rest; ++i)
+			{
+				val += m_step;
+				*(dst++) = val;
+			}
+		}
+
+	private:
+		simd_type m_stepper, m_step_increment;
+		T m_start, m_step;
+	};
+}
+
+#endif

--- a/include/xsimd/routines/builder.hpp
+++ b/include/xsimd/routines/builder.hpp
@@ -9,60 +9,69 @@
 #ifndef XSIMD_BUILDER_HPP
 #define XSIMD_BUILDER_HPP
 
+#include "xsimd/xsimd.hpp"
+
 namespace xsimd
 {
-	template <class T>
-	struct arange
+	template <class T, std::size_t N>
+	inline void arange(batch<T, N>& batch, T start = 0, T step = 1)
 	{
-		using simd_type = typename simd_traits<T>::type;
-		constexpr static std::size_t batch_size = simd_traits<T>::size;
-
-		arange(T start, T step)
-			: m_start(start), m_step(step)
+		T val = start;
+		alignas(32) T xrange[N];
+		for (auto it = std::begin(xrange); it != std::end(xrange); ++it)
 		{
-			T val = m_start;
-			T steps[batch_size];
-			for (auto it = std::begin(steps); it != std::end(steps); ++it)
-			{
-				*it = val;
-				val += m_step;
-			}
-			xsimd::load_aligned(steps, m_stepper);
-			m_step_increment = simd_type(m_step * batch_size);
+			*it = val;
+			val += step;
+		}
+		xsimd::load_aligned(xrange, batch);
+	}
+
+	template <class I, class T>
+	inline void arange(I begin, I end, T start, T step)
+	{
+		using value_type = std::decay_t<decltype(*begin)>;
+		using traits = simd_traits<value_type>;
+		using batch_type = typename traits::type;
+
+        std::size_t size = static_cast<std::size_t>(std::distance(begin, end));
+        std::size_t simd_size = traits::size;
+
+        value_type* ptr_begin = &(*begin);
+        value_type* ptr_end = &(*end);
+
+		std::size_t align_begin = xsimd::get_alignment_offset(ptr_begin, size, simd_size);
+		std::size_t align_end = align_begin + ((size - align_begin) & ~(simd_size - 1));
+
+		for (std::size_t i = 0; i < align_begin; ++i)
+		{
+		    *ptr_begin = start;
+		    ++ptr_begin;
+		    start += step;
 		}
 
-		simd_type operator[](std::size_t I)
+		batch_type brange, bstep(step * traits::size);
+		arange(brange, start, step);
+
+		for (std::size_t i = align_begin; i < align_end; i += simd_size)
 		{
-			using namespace std;
-			return fma(simd_type(I), simd_type(m_step), m_stepper);
+			xsimd::store_aligned(ptr_begin, brange);
+			brange += bstep;
+			ptr_begin += simd_size;
 		}
 
-		void store_aligned(T* dst, std::size_t size) const
+		start = *(ptr_begin - 1) + step;
+		for (std::size_t i = align_end; i < size; ++i)
 		{
-			std::size_t simd_size = size / simd_traits<T>::size;
-			std::size_t simd_rest = size % simd_traits<T>::size;
-
-			simd_type stepper = m_stepper;
-
-			for (std::size_t i = 0; i < simd_size; ++i)
-			{
-				xsimd::store_aligned(dst, stepper);
-				stepper += m_step_increment;
-				dst += batch_size;
-			}
-
-			T val = simd_size != 0 ? dst[-1] : m_start;  // get last value
-			for (std::size_t i = 0; i < simd_rest; ++i)
-			{
-				val += m_step;
-				*(dst++) = val;
-			}
+			*ptr_begin = start;
+			++ptr_begin;
+			start += step;
 		}
+	}
 
-	private:
-		simd_type m_stepper, m_step_increment;
-		T m_start, m_step;
-	};
+	template <class I>
+	inline void arange(I begin, I end)
+	{
+		arange(begin, end, 0, 1);
+	}
 }
-
 #endif


### PR DESCRIPTION
This is supposed to be used in the arange `assign_to` as well as a potential `simd_step`.