### PR TITLE
rem_pio2: undef `ONCE0`

### DIFF
--- a/include/xsimd/math/xsimd_rem_pio2.hpp
+++ b/include/xsimd/math/xsimd_rem_pio2.hpp
@@ -638,4 +638,5 @@ namespace xsimd
 #undef GET_HIGH_WORD
 #undef HIGH_WORD_IDX
 #undef LOW_WORD_IDX
+#undef ONCE0
 }


### PR DESCRIPTION
`ONCE0` is defined, but not undefined. this causes possible name clashes downstream