### PR TITLE
use arithmetic right shift SSE/AVX intrinsics for signed integer >>

### DIFF
--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -110,6 +110,10 @@
     #define XSIMD_X86_INSTR_SET XSIMD_X86_AVX512_VERSION
 #endif
 
+#if defined(__AVX512VL__)
+    #define XSIMD_AVX512VL_AVAILABLE 1
+#endif
+
 #if defined(__AVX512BW__)
     #define XSIMD_AVX512BW_AVAILABLE 1
 #endif

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -361,9 +361,9 @@ namespace xsimd
 
     inline batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi32 expects its last argument to be known at compile time,
+        // _mm512_srai_epi32 expects its last argument to be known at compile time,
         // which cannot be guaranteed here.
-        return _mm512_srlv_epi32(lhs, batch<int32_t, 16>(rhs));
+        return _mm512_srav_epi32(lhs, batch<int32_t, 16>(rhs));
     }
 
     inline batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs)
@@ -373,7 +373,7 @@ namespace xsimd
 
     inline batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs)
     {
-        return _mm512_srlv_epi32(lhs, rhs);
+        return _mm512_srav_epi32(lhs, rhs);
     }
 
     inline batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, int32_t rhs)

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -416,9 +416,9 @@ namespace xsimd
 
     inline batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi64 expects its last argument to be known at compile time,
+        // _mm512_srai_epi64 expects its last argument to be known at compile time,
         // which cannot be guaranteed here.
-        return _mm512_srlv_epi64(lhs, batch<int64_t, 8>(rhs));
+        return _mm512_srav_epi64(lhs, batch<int64_t, 8>(rhs));
     }
 
     inline batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs)
@@ -428,7 +428,7 @@ namespace xsimd
 
     inline batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs)
     {
-        return _mm512_srlv_epi64(lhs, rhs);
+        return _mm512_srav_epi64(lhs, rhs);
     }
 
     inline batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, int32_t rhs)

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -512,11 +512,11 @@ namespace xsimd
     inline batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, int32_t rhs)
     {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-        return _mm256_srli_epi32(lhs, rhs);
+        return _mm256_srai_epi32(lhs, rhs);
 #else
         XSIMD_SPLIT_AVX(lhs);
-        __m128i res_low = _mm_srli_epi32(lhs_low, rhs);
-        __m128i res_high = _mm_srli_epi32(lhs_high, rhs);
+        __m128i res_low = _mm_srai_epi32(lhs_low, rhs);
+        __m128i res_high = _mm_srai_epi32(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
     }

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -491,13 +491,12 @@ namespace xsimd
 
     inline batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, int32_t rhs)
     {
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-        return _mm256_srli_epi64(lhs, rhs);
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm256_srai_epi64(lhs, rhs);
 #else
-        XSIMD_SPLIT_AVX(lhs);
-        __m128i res_low = _mm_srli_epi64(lhs_low, rhs);
-        __m128i res_high = _mm_srli_epi64(lhs_high, rhs);
-        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+        return avx_detail::shift_impl([](int64_t val, int32_t rhs) {
+            return val >> rhs;
+        }, lhs, rhs);
 #endif
     }
 

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -478,7 +478,7 @@ namespace xsimd
 
     inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
-        return _mm_srli_epi32(lhs, rhs);
+        return _mm_srai_epi32(lhs, rhs);
     }
 
     inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs)

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -417,7 +417,11 @@ namespace xsimd
 
     inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
-        return _mm_srli_epi64(lhs, rhs);
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm_srai_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int64_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 
     inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs)

--- a/test/xsimd_basic_test.hpp
+++ b/test/xsimd_basic_test.hpp
@@ -296,7 +296,8 @@ namespace xsimd
         hadd_res = value_type(0);
         for (size_t i = 0; i < N; ++i)
         {
-            lhs[i] = value_type(i) * 10;
+            bool negative_lhs = std::is_signed<T>::value && (i % 2 == 1);
+            lhs[i] = value_type(i) * (negative_lhs ? -10 : 10);
             rhs[i] = value_type(4) + value_type(i);
             extract_res = lhs[1];
             minus_res[i] = -lhs[i];


### PR DESCRIPTION
The signed integer right shift operators (operator>>) for SSE, AVX, and AVX512 use the logical right shift intrinsics, not the arithmetic right shift intrinsics. This results in incorrect shift result for negative numbers and is also inconsistent with the neon right shift operators which correctly use the signed right shift intrinsics.
I have also modified the basic integer test to make every second test value negative when testing signed integers in order to increase test coverage to negative numbers.