### PR TITLE
Fix avx512_fallback_batch_bool constructor and load_values

### DIFF
--- a/include/xsimd/types/xsimd_avx512_bool.hpp
+++ b/include/xsimd/types/xsimd_avx512_bool.hpp
@@ -305,8 +305,8 @@ namespace xsimd
     template <class T, std::size_t N>
     template <class... Args, class>
     inline avx512_fallback_batch_bool<T, N>::avx512_fallback_batch_bool(Args... args)
-        : m_value(avx512_detail::int_init(std::integral_constant<std::size_t, sizeof(int8_t)>{},
-                  static_cast<int8_t>(-static_cast<bool>(args))...))
+        : m_value(avx512_detail::int_init(std::integral_constant<std::size_t, sizeof(T)>{},
+                  static_cast<T>(-static_cast<bool>(args))...))
     {
     }
 
@@ -345,8 +345,8 @@ namespace xsimd
     template <class... Args>
     inline batch_bool<T, N>& avx512_fallback_batch_bool<T, N>::load_values(Args... b)
     {
-        m_value = avx512_detail::int_init(std::integral_constant<std::size_t, sizeof(int8_t)>{},
-                                          static_cast<int8_t>(-static_cast<bool>(b))...);
+        m_value = avx512_detail::int_init(std::integral_constant<std::size_t, sizeof(T)>{},
+                                          static_cast<T>(-static_cast<bool>(b))...);
         return (*this)();
     }
     


### PR DESCRIPTION
This caused avx512 int16_t and uint16_t unit tests to fail when avx512bw
was not enabled (only avx512f enabled)