### PR TITLE
Clean up abs implementation for Intel intrinsics

### DIFF
--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -336,7 +336,14 @@ namespace xsimd
         {
             static batch_type abs(const batch_type& rhs)
             {
+            #if defined(XSIMD_AVX512BW_AVAILABLE)
                 return _mm512_abs_epi16(rhs);
+            #else
+                XSIMD_SPLIT_AVX512(rhs);
+                __m256i res_low = _mm256_abs_epi16(rhs_low);
+                __m256i res_high = _mm256_abs_epi16(rhs_high);
+                XSIMD_RETURN_MERGED_AVX(res_low, res_high);
+            #endif
             }
 
             static batch_type min(const batch_type& lhs, const batch_type& rhs)

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -338,7 +338,14 @@ namespace xsimd
         {
             static batch_type abs(const batch_type& rhs)
             {
+            #if defined(XSIMD_AVX512BW_AVAILABLE)
                 return _mm512_abs_epi8(rhs);
+            #else
+                XSIMD_SPLIT_AVX512(rhs);
+                __m256i res_low = _mm256_abs_epi8(rhs_low);
+                __m256i res_high = _mm256_abs_epi8(rhs_high);
+                XSIMD_RETURN_MERGED_AVX(res_low, res_high);
+            #endif
             }
 
             static batch_type min(const batch_type& lhs, const batch_type& rhs)

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -234,11 +234,11 @@ namespace xsimd
             static batch_type abs(const batch_type& rhs)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_sign_epi16(rhs, rhs);
+                return _mm256_abs_epi16(rhs);
 #else
                 XSIMD_SPLIT_AVX(rhs);
-                __m128i res_low = _mm_sign_epi16(rhs_low, rhs_low);
-                __m128i res_high = _mm_sign_epi16(rhs_high, rhs_high);
+                __m128i res_low = _mm_abs_epi16(rhs_low);
+                __m128i res_high = _mm_abs_epi16(rhs_high);
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -289,11 +289,11 @@ namespace xsimd
             static batch_type abs(const batch_type& rhs)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_sign_epi32(rhs, rhs);
+                return _mm256_abs_epi32(rhs);
 #else
                 XSIMD_SPLIT_AVX(rhs);
-                __m128i res_low = _mm_sign_epi32(rhs_low, rhs_low);
-                __m128i res_high = _mm_sign_epi32(rhs_high, rhs_high);
+                __m128i res_low = _mm_abs_epi32(rhs_low);
+                __m128i res_high = _mm_abs_epi32(rhs_high);
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -260,7 +260,9 @@ namespace xsimd
 
             static batch_type abs(const batch_type& rhs)
             {
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+                return _mm256_abs_epi64(rhs);
+#elif XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
                 __m256i sign = _mm256_cmpgt_epi64(_mm256_setzero_si256(), rhs);
                 __m256i inv = _mm256_xor_si256(rhs, sign);
                 return _mm256_sub_epi64(inv, sign);

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -343,11 +343,11 @@ namespace xsimd
             static batch_type abs(const batch_type& rhs)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_sign_epi8(rhs, rhs);
+                return _mm256_abs_epi8(rhs);
 #else
                 XSIMD_SPLIT_AVX(rhs);
-                __m128i res_low = _mm_sign_epi8(rhs_low, rhs_low);
-                __m128i res_high = _mm_sign_epi8(rhs_high, rhs_high);
+                __m128i res_low = _mm_abs_epi8(rhs_low);
+                __m128i res_high = _mm_abs_epi8(rhs_high);
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -424,7 +424,7 @@ namespace xsimd
             static batch_type abs(const batch_type& rhs)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
-                return _mm_sign_epi32(rhs, rhs);
+                return _mm_abs_epi32(rhs);
 #else
                 __m128i sign = _mm_srai_epi32(rhs, 31);
                 __m128i inv = _mm_xor_si128(rhs, sign);

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -370,6 +370,9 @@ namespace xsimd
 
             static batch_type abs(const batch_type& rhs)
             {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+                return _mm_abs_epi64(rhs);
+#else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE4_2_VERSION
                 __m128i sign = _mm_cmpgt_epi64(_mm_setzero_si128(), rhs);
 #else
@@ -378,6 +381,7 @@ namespace xsimd
 #endif
                 __m128i inv = _mm_xor_si128(rhs, sign);
                 return _mm_sub_epi64(inv, sign);
+#endif
             }
         };
 

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -231,7 +231,6 @@ namespace xsimd
 
             static batch_type max(const batch_type& lhs, const batch_type& rhs)
             {
-
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE4_1_VERSION
                 return _mm_max_epi8(lhs, rhs);
 #else
@@ -244,7 +243,7 @@ namespace xsimd
             static batch_type abs(const batch_type& rhs)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
-                return _mm_sign_epi8(rhs, rhs);
+                return _mm_abs_epi8(rhs);
 #else
                 __m128i neg = _mm_sub_epi8(_mm_setzero_si128(), rhs);
                 return _mm_min_epu8(rhs, neg);


### PR DESCRIPTION
This includes:
1. Using the abs intrinsics instead of the sign intrinsics for 8, 16,
and 32 bit arithmetic, e.g. _mm_abs_epi8/16/32 instead of
_mm_sign_epi8/16/32 (both are SSSE3), using _mm256_abs_epi8/16/32
instead of _mm256_sign_epi8/16/32 (both are AVX2).
2. Add 64 bit abs intrinsics that came with AVX512VL to SSE and AVX
3. Add guards around 8 and 16 bit AVX512 abs intrinsics that require
AVX512BL