### PR TITLE
Add new batch_cast function to expand support for type conversion

### DIFF
--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -114,6 +114,10 @@
     #define XSIMD_AVX512VL_AVAILABLE 1
 #endif
 
+#if defined(__AVX512DQ__)
+    #define XSIMD_AVX512DQ_AVAILABLE 1
+#endif
+
 #if defined(__AVX512BW__)
     #define XSIMD_AVX512BW_AVAILABLE 1
 #endif

--- a/include/xsimd/types/xsimd_avx512_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx512_conversion.hpp
@@ -13,10 +13,10 @@
 
 #include "xsimd_avx512_double.hpp"
 #include "xsimd_avx512_float.hpp"
+#include "xsimd_avx512_int8.hpp"
+#include "xsimd_avx512_int16.hpp"
 #include "xsimd_avx512_int32.hpp"
 #include "xsimd_avx512_int64.hpp"
-#include "xsimd_avx512_int16.hpp"
-#include "xsimd_avx512_int8.hpp"
 
 namespace xsimd
 {
@@ -57,7 +57,18 @@ namespace xsimd
 
     inline batch<int64_t, 8> to_int(const batch<double, 8>& x)
     {
-        return _mm512_cvtepi32_epi64(_mm512_cvttpd_epi32(x));
+#if defined(XSIMD_AVX512DQ_AVAILABLE)
+        return _mm512_cvttpd_epi64(x);
+#else
+        return batch<int64_t, 8>(static_cast<int64_t>(x[0]),
+                                 static_cast<int64_t>(x[1]),
+                                 static_cast<int64_t>(x[2]),
+                                 static_cast<int64_t>(x[3]),
+                                 static_cast<int64_t>(x[4]),
+                                 static_cast<int64_t>(x[5]),
+                                 static_cast<int64_t>(x[6]),
+                                 static_cast<int64_t>(x[7]));
+#endif
     }
 
     inline batch<float, 16> to_float(const batch<int32_t, 16>& x)
@@ -67,8 +78,106 @@ namespace xsimd
 
     inline batch<double, 8> to_float(const batch<int64_t, 8>& x)
     {
+#if defined(XSIMD_AVX512DQ_AVAILABLE)
         return _mm512_cvtepi64_pd(x);
+#else
+        return batch<double, 8>(static_cast<double>(x[0]),
+                                static_cast<double>(x[1]),
+                                static_cast<double>(x[2]),
+                                static_cast<double>(x[3]),
+                                static_cast<double>(x[4]),
+                                static_cast<double>(x[5]),
+                                static_cast<double>(x[6]),
+                                static_cast<double>(x[7]));
+#endif
     }
+
+    /*****************************************
+     * batch cast functions implementation *
+     *****************************************/
+
+    XSIMD_BATCH_CAST_IMPLICIT(int8_t, uint8_t, 64);
+    XSIMD_BATCH_CAST_IMPLICIT(uint8_t, int8_t, 64);
+    XSIMD_BATCH_CAST_IMPLICIT(int16_t, uint16_t, 32);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, int32_t, 16, _mm512_cvtepi16_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint32_t, 16, _mm512_cvtepi16_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, int64_t, 8, _mm512_cvtepi16_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint64_t, 8, _mm512_cvtepi16_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC2(int16_t, float, 16, _mm512_cvtepi16_epi32, _mm512_cvtepi32_ps);
+    XSIMD_BATCH_CAST_IMPLICIT(uint16_t, int16_t, 32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int32_t, 16, _mm512_cvtepu16_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, uint32_t, 16, _mm512_cvtepu16_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int64_t, 8, _mm512_cvtepu16_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, uint64_t, 8, _mm512_cvtepu16_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC2(uint16_t, float, 16, _mm512_cvtepu16_epi32, _mm512_cvtepi32_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, int8_t, 16, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint8_t, 16, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, int16_t, 16, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint16_t, 16, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_IMPLICIT(int32_t, uint32_t, 16);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, int64_t, 8, _mm512_cvtepi32_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint64_t, 8, _mm512_cvtepi32_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, float, 16, _mm512_cvtepi32_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, double, 8, _mm512_cvtepi32_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int8_t, 16, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, uint8_t, 16, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int16_t, 16, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, uint16_t, 16, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_IMPLICIT(uint32_t, int32_t, 16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int64_t, 8, _mm512_cvtepu32_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, uint64_t, 8, _mm512_cvtepu32_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, float, 16, _mm512_cvtepu32_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, double, 8, _mm512_cvtepu32_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, int16_t, 8, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, uint16_t, 8, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, int32_t, 8, _mm512_cvtepi64_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, uint32_t, 8, _mm512_cvtepi64_epi32);
+    XSIMD_BATCH_CAST_IMPLICIT(int64_t, uint64_t, 8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, int16_t, 8, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, uint16_t, 8, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, int32_t, 8, _mm512_cvtepi64_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, uint32_t, 8, _mm512_cvtepi64_epi32);
+    XSIMD_BATCH_CAST_IMPLICIT(uint64_t, int64_t, 8);
+    XSIMD_BATCH_CAST_INTRINSIC2(float, int8_t, 16, _mm512_cvttps_epi32, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC2(float, uint8_t, 16, _mm512_cvttps_epi32, _mm512_cvtepi32_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC2(float, int16_t, 16, _mm512_cvttps_epi32, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC2(float, uint16_t, 16, _mm512_cvttps_epi32, _mm512_cvtepi32_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(float, int32_t, 16, _mm512_cvttps_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(float, uint32_t, 16, _mm512_cvttps_epu32);
+    XSIMD_BATCH_CAST_INTRINSIC(float, double, 8, _mm512_cvtps_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(double, int32_t, 8, _mm512_cvttpd_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(double, uint32_t, 8, _mm512_cvttpd_epu32);
+    XSIMD_BATCH_CAST_INTRINSIC(double, float, 8, _mm512_cvtpd_ps);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, int16_t, 32, _mm512_cvtepi8_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, uint16_t, 32, _mm512_cvtepi8_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, int32_t, 16, _mm512_cvtepi8_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, uint32_t, 16, _mm512_cvtepi8_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC2(int8_t, float, 16, _mm512_cvtepi8_epi32, _mm512_cvtepi32_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, int16_t, 32, _mm512_cvtepu8_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, uint16_t, 32, _mm512_cvtepu8_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, int32_t, 16, _mm512_cvtepu8_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, uint32_t, 16, _mm512_cvtepu8_epi32);
+    XSIMD_BATCH_CAST_INTRINSIC2(uint8_t, float, 16, _mm512_cvtepu8_epi32, _mm512_cvtepi32_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, int8_t, 32, _mm512_cvtepi16_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint8_t, 32, _mm512_cvtepi16_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int8_t, 32, _mm512_cvtepi16_epi8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, uint8_t, 32, _mm512_cvtepi16_epi8);
+#endif
+#if defined(XSIMD_AVX512DQ_AVAILABLE)
+    XSIMD_BATCH_CAST_INTRINSIC2(int16_t, double, 8, _mm512_cvtepi16_epi64, _mm512_cvtepi64_pd);
+    XSIMD_BATCH_CAST_INTRINSIC2(uint16_t, double, 8, _mm512_cvtepu16_epi64, _mm512_cvtepi64_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, float, 8, _mm512_cvtepi64_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, double, 8, _mm512_cvtepi64_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, float, 8, _mm512_cvtepu64_ps);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, double, 8, _mm512_cvtepu64_pd);
+    XSIMD_BATCH_CAST_INTRINSIC(float, int64_t, 8, _mm512_cvttps_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(float, uint64_t, 8, _mm512_cvttps_epu64);
+    XSIMD_BATCH_CAST_INTRINSIC2(double, int16_t, 8, _mm512_cvttpd_epi64, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC2(double, uint16_t, 8, _mm512_cvttpd_epi64, _mm512_cvtepi64_epi16);
+    XSIMD_BATCH_CAST_INTRINSIC(double, int64_t, 8, _mm512_cvttpd_epi64);
+    XSIMD_BATCH_CAST_INTRINSIC(double, uint64_t, 8, _mm512_cvttpd_epu64);
+#endif
 
     /**************************
      * boolean cast functions *

--- a/include/xsimd/types/xsimd_neon_conversion.hpp
+++ b/include/xsimd/types/xsimd_neon_conversion.hpp
@@ -13,10 +13,10 @@
 
 #include "xsimd_neon_bool.hpp"
 #include "xsimd_neon_float.hpp"
+#include "xsimd_neon_int8.hpp"
+#include "xsimd_neon_int16.hpp"
 #include "xsimd_neon_int32.hpp"
 #include "xsimd_neon_int64.hpp"
-#include "xsimd_neon_int16.hpp"
-#include "xsimd_neon_int8.hpp"
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
     #include "xsimd_neon_double.hpp"
 #endif
@@ -93,6 +93,29 @@ namespace xsimd
     {
         return vcvtq_f64_s64(x);
     }
+#endif
+
+    /*****************************************
+     * batch cast functions implementation *
+     *****************************************/
+
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, uint8_t, 16, vreinterpretq_u8_s8);
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, int8_t, 16, vreinterpretq_s8_u8);
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint16_t, 8, vreinterpretq_u16_s16);
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int16_t, 8, vreinterpretq_s16_u16);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint32_t, 4, vreinterpretq_u32_s32);
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, float, 4, vcvtq_f32_s32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int32_t, 4, vreinterpretq_s32_u32);
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, float, 4, vcvtq_f32_u32);
+    XSIMD_BATCH_CAST_INTRINSIC(float, int32_t, 4, vcvtq_s32_f32);
+    XSIMD_BATCH_CAST_INTRINSIC(float, uint32_t, 4, vcvtq_u32_f32);
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, uint64_t, 2, vreinterpretq_u64_s64);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, double, 2, vcvtq_f64_s64);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, int64_t, 2, vreinterpretq_s64_u64);
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, double, 2, vcvtq_f64_u64);
+    XSIMD_BATCH_CAST_INTRINSIC(double, int64_t, 2, vcvtq_s64_f64);
+    XSIMD_BATCH_CAST_INTRINSIC(double, uint64_t, 2, vcvtq_u64_f64);
 #endif
 
     /**************************

--- a/test/xsimd_basic_test.cpp
+++ b/test/xsimd_basic_test.cpp
@@ -49,10 +49,25 @@ namespace xsimd
     }
 
     template <size_t N, size_t A>
-    bool test_simd_cast(std::ostream& out, const std::string& name)
+    bool test_simd_batch_cast(std::ostream& out, const std::string& name)
     {
-        simd_cast_tester<N, A> tester(name);
-        return test_simd_cast(out, tester);
+        simd_batch_cast_tester<N, A> tester(name);
+        bool res = true;
+        res &= test_simd_batch_cast(out, tester);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX_VERSION
+        res &= test_simd_batch_cast_sizeshift1(out, tester);
+#endif
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
+        res &= test_simd_batch_cast_sizeshift2(out, tester);
+#endif
+        return res;
+    }
+
+    template <size_t N, size_t A>
+    bool test_simd_bitwise_cast(std::ostream& out, const std::string& name)
+    {
+        simd_bitwise_cast_tester<N, A> tester(name);
+        return test_simd_bitwise_cast(out, tester);
     }
 
     template <class T, size_t N, size_t A>
@@ -286,10 +301,17 @@ TEST(xsimd, sse_conversion)
     EXPECT_TRUE(res);
 }
 
-TEST(xsimd, sse_cast)
+TEST(xsimd, sse_batch_cast)
 {
-    std::ofstream out("log/sse_cast.log", std::ios_base::out);
-    bool res = xsimd::test_simd_cast<2, 16>(out, "sse cast");
+    std::ofstream out("log/sse_batch_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_batch_cast<2, 16>(out, "sse batch cast");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, sse_bitwise_cast)
+{
+    std::ofstream out("log/sse_bitwise_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_bitwise_cast<2, 16>(out, "sse bitwise cast");
     EXPECT_TRUE(res);
 }
 
@@ -492,10 +514,17 @@ TEST(xsimd, avx_conversion)
     EXPECT_TRUE(res);
 }
 
-TEST(xsimd, avx_cast)
+TEST(xsimd, avx_batch_cast)
 {
-    std::ofstream out("log/avx_cast.log", std::ios_base::out);
-    bool res = xsimd::test_simd_cast<4, 32>(out, "avx cast");
+    std::ofstream out("log/avx_batch_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_batch_cast<4, 32>(out, "avx batch cast");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, avx_bitwise_cast)
+{
+    std::ofstream out("log/avx_bitwise_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_bitwise_cast<4, 32>(out, "avx bitwise cast");
     EXPECT_TRUE(res);
 }
 
@@ -698,10 +727,17 @@ TEST(xsimd, avx512_conversion)
     EXPECT_TRUE(res);
 }
 
-TEST(xsimd, avx512_cast)
+TEST(xsimd, avx512_batch_cast)
 {
-    std::ofstream out("log/avx512_cast.log", std::ios_base::out);
-    bool res = xsimd::test_simd_cast<8, 64>(out, "avx512 cast");
+    std::ofstream out("log/avx512_batch_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_batch_cast<8, 64>(out, "avx512 batch cast");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, avx512_bitwise_cast)
+{
+    std::ofstream out("log/avx512_bitwise_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_bitwise_cast<8, 64>(out, "avx512 bitwise cast");
     EXPECT_TRUE(res);
 }
 
@@ -907,10 +943,17 @@ TEST(xsimd, neon_conversion)
     EXPECT_TRUE(res);
 }
 
-TEST(xsimd, neon_cast)
+TEST(xsimd, neon_batch_cast)
 {
-    std::ofstream out("log/neon_cast.log", std::ios_base::out);
-    bool res = xsimd::test_simd_cast<2, 16>(out, "neon cast");
+    std::ofstream out("log/neon_batch_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_batch_cast<2, 16>(out, "neon batch cast");
+    EXPECT_TRUE(res);
+}
+
+TEST(xsimd, neon_bitwise_cast)
+{
+    std::ofstream out("log/neon_bitwise_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_bitwise_cast<2, 16>(out, "neon bitwise cast");
     EXPECT_TRUE(res);
 }
 
@@ -1017,10 +1060,10 @@ TEST(xsimd, fallback_conversion)
     EXPECT_TRUE(res);
 }
 
-TEST(xsimd, fallback_cast)
+TEST(xsimd, fallback_bitwise_cast)
 {
-    std::ofstream out("log/fallback_cast.log", std::ios_base::out);
-    bool res = xsimd::test_simd_cast<3, 32>(out, "fallback cast");
+    std::ofstream out("log/fallback_bitwise_cast.log", std::ios_base::out);
+    bool res = xsimd::test_simd_bitwise_cast<3, 32>(out, "fallback bitwise cast");
     EXPECT_TRUE(res);
 }
 

--- a/test/xsimd_test_utils.hpp
+++ b/test/xsimd_test_utils.hpp
@@ -295,6 +295,44 @@ namespace xsimd
             return false;
         }
     }
+
+    template <class T_out, class T_in>
+    inline typename std::enable_if<std::is_unsigned<T_in>::value && std::is_integral<T_out>::value, bool>::type
+    is_convertible(T_in value)
+    {
+        return static_cast<uint64_t>(value) <= static_cast<uint64_t>(std::numeric_limits<T_out>::max());
+    }
+
+    template <class T_out, class T_in>
+    inline typename std::enable_if<std::is_integral<T_in>::value && std::is_signed<T_in>::value && std::is_integral<T_out>::value && std::is_signed<T_out>::value, bool>::type
+    is_convertible(T_in value)
+    {
+        int64_t signed_value = static_cast<int64_t>(value);
+        return signed_value <= static_cast<int64_t>(std::numeric_limits<T_out>::max()) &&
+               signed_value >= static_cast<int64_t>(std::numeric_limits<T_out>::lowest());
+    }
+
+    template <class T_out, class T_in>
+    inline typename std::enable_if<std::is_integral<T_in>::value && std::is_signed<T_in>::value && std::is_unsigned<T_out>::value, bool>::type
+    is_convertible(T_in value)
+    {
+        return value >= 0 && is_convertible<T_out>(static_cast<uint64_t>(value));
+    }
+
+    template <class T_out, class T_in>
+    inline typename std::enable_if<std::is_floating_point<T_in>::value && std::is_integral<T_out>::value, bool>::type
+    is_convertible(T_in value)
+    {
+        return value <= static_cast<T_in>(std::numeric_limits<T_out>::max()) &&
+               value >= static_cast<T_in>(std::numeric_limits<T_out>::lowest());
+    }
+
+    template <class T_out, class T_in>
+    inline typename std::enable_if<std::is_floating_point<T_out>::value, bool>::type
+    is_convertible(T_in)
+    {
+        return true;
+    }
 }
 
 #endif


### PR DESCRIPTION
Hi guys. I really hope you're ok with me adding such a big new feature.
I think this is a nice addition to the API and I actually have a use
case for this on a personal project I'm working on.

Currently there is support for converting floats to ints (to_int) and
ints to floats (to_float) but there is no way to do the equivalent of a
static_cast, i.e. request a value of some specific type be converted to
another specific type. The new batch_cast function will allow you to do
this and leverage any intrinsics that exist to accelerate that
conversion.

Example usage:
```C++
xsimd::batch<int32_t, 4> b_int(...);
xsimd::batch<float, 4> f_float = xsimd::batch_cast<float>(b_int);
```

Let me know if you would prefer to have the batch_cast template type to
take a full batch type instead of just the underlying type, e.g.
```C++
xsimd::batch<int32_t, 4> b_int(...);
xsimd::batch<float, 4> f_float = xsimd::batch_cast<batch<float, 4>>(b_int);
```
I implemented it the way it is now as I think it provides a simpler API
to users, i.e. if they want to convert some other vector to a vector of
floats, they wouldn't be required to write something like
```C++
auto b_other = ...;
auto b_float = xsimd::batch_cast<batch<float, b_other.size>>(b_other);
```
The downside of this is that it can potentially result in confusing
compiler errors if the user attempts to cast to an unrepresentable
vector, i.e. cast a `batch<double, 2>` to an `int8_t` (i.e.
`batch<int8_t, 2>`). If the user is forced to specify this type
themselves (e.g. `batch_cast<batch<int8_t, 2>)(...)>`), it may result in
simpler compiler errors and therefore be easier them to understand
what error they have made. It would also make the API consistent between
bitwise_cast and batch_cast.

Finally, I also fixed some of the exiting double-to-int64 to_int and
int64-to-double to_float fallback implementations as they produced
incorrect results when converting values outside the representable range
of int32. This was due to the fact that these conversions were done via
int32, i.e. double-to-int64 was actually double-to-int32-to-int64 and
int64-to-double was actually int64-to-int32-to-double.