### PR TITLE
Implement remaining vector shift operators

### DIFF
--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -164,6 +164,10 @@
     #define XSIMD_X86_INSTR_SET_AVAILABLE XSIMD_VERSION_NUMBER_AVAILABLE
 #endif
 
+#if __GNUC__ == 6 && __GNUC_MINOR__ == 4
+    #define XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY 1
+#endif
+
 /***************************
  * X86_AMD INSTRUCTION SET *
  ***************************/

--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -108,18 +108,22 @@
 #if !defined(XSIMD_X86_INSTR_SET) && (defined(__AVX512__) || defined(__KNCNI__) || defined(__AVX512F__)\
     && (!defined(__GNUC__) || __GNUC__ >= 6))
     #define XSIMD_X86_INSTR_SET XSIMD_X86_AVX512_VERSION
-#endif
 
-#if defined(__AVX512VL__)
-    #define XSIMD_AVX512VL_AVAILABLE 1
-#endif
+    #if defined(__AVX512VL__)
+        #define XSIMD_AVX512VL_AVAILABLE 1
+    #endif
 
-#if defined(__AVX512DQ__)
-    #define XSIMD_AVX512DQ_AVAILABLE 1
-#endif
+    #if defined(__AVX512DQ__)
+        #define XSIMD_AVX512DQ_AVAILABLE 1
+    #endif
 
-#if defined(__AVX512BW__)
-    #define XSIMD_AVX512BW_AVAILABLE 1
+    #if defined(__AVX512BW__)
+        #define XSIMD_AVX512BW_AVAILABLE 1
+    #endif
+
+    #if __GNUC__ == 6
+        #define XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY 1
+    #endif
 #endif
 
 #if !defined(XSIMD_X86_INSTR_SET) && defined(__AVX2__)
@@ -162,10 +166,6 @@
     #define XSIMD_X86_INSTR_SET XSIMD_VERSION_NUMBER_NOT_AVAILABLE
 #else
     #define XSIMD_X86_INSTR_SET_AVAILABLE XSIMD_VERSION_NUMBER_AVAILABLE
-#endif
-
-#if __GNUC__ == 6 && __GNUC_MINOR__ == 4
-    #define XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY 1
 #endif
 
 /***************************

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -470,7 +470,12 @@ namespace xsimd
         return _mm512_slli_epi16(lhs, rhs);
 #endif
 #else
-        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), tmp);
 #endif
     }
 
@@ -517,7 +522,12 @@ namespace xsimd
         return _mm512_slli_epi16(lhs, rhs);
 #endif
 #else
-        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), tmp);
 #endif
     }
 
@@ -530,7 +540,12 @@ namespace xsimd
         return _mm512_srli_epi16(lhs, rhs);
 #endif
 #else
-        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF >> rhs), _mm512_srli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_srli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF >> rhs), tmp);
 #endif
     }
 

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -190,11 +190,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 32)
     };
 
-    batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, int32_t rhs);
-    batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, int32_t rhs);
-    batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, int32_t rhs);
-    batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, int32_t rhs);
-
     /*************************************
      * batch<int16_t, 32> implementation *
      *************************************/
@@ -468,37 +463,97 @@ namespace xsimd
 
     inline batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_slli_epi16(lhs, rhs);
+#endif
+#else
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#endif
     }
 
     inline batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_srai_epi16(lhs, rhs);
+#endif
+#else
+        return avx512_detail::shift_impl([](int16_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 32, 32)
-    XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 32, 32)
+    inline batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_sllv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_srav_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 32, 64)
+    XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 32, 64)
 
     inline batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_slli_epi16(lhs, rhs);
+#endif
+#else
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#endif
     }
 
     inline batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_srli_epi16(lhs, rhs);
+#endif
+#else
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF >> rhs), _mm512_srli_epi32(lhs, rhs));
+#endif
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 32, 32)
-    XSIMD_DEFINE_LOAD_STORE_LONG(uint16_t, 32, 32)
+    inline batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_sllv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_srlv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 32, 64)
+    XSIMD_DEFINE_LOAD_STORE_LONG(uint16_t, 32, 64)
 
 #undef XSIMD_APPLY_AVX2_FUNCTION_INT16
 }

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -128,15 +128,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 16)
     };
 
-    batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, int32_t rhs);
-    batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, int32_t rhs);
-    batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, int32_t rhs);
-    batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, int32_t rhs);
-    batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-
     /*************************************
      * batch<int32_t, 16> implementation *
      *************************************/
@@ -354,16 +345,20 @@ namespace xsimd
 
     inline batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_slli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_srai_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srav_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_srai_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs)
@@ -378,16 +373,20 @@ namespace xsimd
 
     inline batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi32(lhs, batch<uint32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_slli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srlv_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_srli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs)

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -110,7 +110,7 @@ namespace xsimd
 
         XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 8)
-   };
+    };
 
     template <>
     class batch<uint64_t, 8> : public avx512_int_batch<uint64_t, 8>
@@ -126,16 +126,7 @@ namespace xsimd
 
         XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 8)
-   };
-
-    batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, int32_t rhs);
-    batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, int32_t rhs);
-    batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, int32_t rhs);
-    batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, int32_t rhs);
-    batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
+    };
 
     /************************************
      * batch<int64_t, 8> implementation *
@@ -409,16 +400,20 @@ namespace xsimd
 
     inline batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi64(lhs, batch<int64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_slli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_srai_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srav_epi64(lhs, batch<int64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_srai_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs)
@@ -433,16 +428,20 @@ namespace xsimd
 
     inline batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi64(lhs, batch<uint64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_slli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srlv_epi64(lhs, batch<uint64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_srli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs)

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -465,7 +465,12 @@ namespace xsimd
 
     inline batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, int32_t rhs)
     {
-        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), tmp);
     }
 
     inline batch<int8_t, 64> operator>>(const batch<int8_t, 64>& lhs, int32_t rhs)
@@ -501,12 +506,22 @@ namespace xsimd
 
     inline batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, int32_t rhs)
     {
-        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), _mm512_slli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), tmp);
     }
 
     inline batch<uint8_t, 64> operator>>(const batch<uint8_t, 64>& lhs, int32_t rhs)
     {
-        return _mm512_and_si512(_mm512_set1_epi8(0xFF >> rhs), _mm512_srli_epi32(lhs, rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_srli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF >> rhs), tmp);
     }
 
     inline batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, const batch<int8_t, 64>& rhs)

--- a/include/xsimd/types/xsimd_avx512_int_base.hpp
+++ b/include/xsimd/types/xsimd_avx512_int_base.hpp
@@ -328,6 +328,19 @@ namespace xsimd
             });
             return batch<T, N>(tmp_res, aligned_mode());
         }
+
+        template <class F, class T, class S, std::size_t N>
+        inline batch<T, N> shift_impl(F&& f, const batch<T, N>& lhs, const batch<S, N>& rhs)
+        {
+            alignas(64) T tmp_lhs[N], tmp_res[N];
+            alignas(64) S tmp_rhs[N];
+            lhs.store_aligned(&tmp_lhs[0]);
+            rhs.store_aligned(&tmp_rhs[0]);
+            unroller<N>([&](std::size_t i) {
+              tmp_res[i] = f(tmp_lhs[i], tmp_rhs[i]);
+            });
+            return batch<T, N>(tmp_res, aligned_mode());
+        }
     }
 }
 

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -328,19 +328,46 @@ namespace xsimd
     XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 16, 32)
     XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 16, 32)
 
-    // TODO implement by converting to int16
     inline batch<int16_t, 16> operator<<(const batch<int16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_slli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_slli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_slli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
     }
 
     inline batch<int16_t, 16> operator>>(const batch<int16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srai_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_srai_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_srai_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<int16_t, 16> operator<<(const batch<int16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_sllv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 16> operator>>(const batch<int16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_srav_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 16, 32)
@@ -348,16 +375,44 @@ namespace xsimd
 
     inline batch<uint16_t, 16> operator<<(const batch<uint16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_slli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_slli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_slli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
     }
 
     inline batch<uint16_t, 16> operator>>(const batch<uint16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_srli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_srli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint16_t, 16> operator<<(const batch<uint16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_sllv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 16> operator>>(const batch<uint16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_srlv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -109,9 +109,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 8)
    };
 
-    batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, int32_t rhs);
-    batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, int32_t rhs);
-
     template <>
     class batch<uint32_t, 8> : public avx_int_batch<uint32_t, 8>
     {
@@ -127,9 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 8)
     };
-
-    batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, int32_t rhs);
-    batch<uint32_t, 8> operator>>(const batch<uint32_t, 8>& lhs, int32_t rhs);
 
     /************************************
      * batch<int32_t, 8> implementation *
@@ -521,6 +515,24 @@ namespace xsimd
 #endif
     }
 
+    inline batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srav_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, int32_t rhs)
     {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
@@ -542,6 +554,24 @@ namespace xsimd
         __m128i res_low = _mm_srli_epi32(lhs_low, rhs);
         __m128i res_high = _mm_srli_epi32(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint32_t, 8> operator>>(const batch<uint32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srlv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
 #endif
     }
 }

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -126,11 +126,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 4)
     };
 
-    batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, int32_t rhs);
-    batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, int32_t rhs);
-    batch<uint64_t, 4> operator<<(const batch<uint64_t, 4>& lhs, int32_t rhs);
-    batch<uint64_t, 4> operator>>(const batch<uint64_t, 4>& lhs, int32_t rhs);
-
     /************************************
      * batch<int64_t, 4> implementation *
      ************************************/
@@ -496,9 +491,25 @@ namespace xsimd
 #if defined(XSIMD_AVX512VL_AVAILABLE)
         return _mm256_srai_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](int64_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+        return avx_detail::shift_impl([](int64_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm256_srav_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
 #endif
     }
 
@@ -523,6 +534,24 @@ namespace xsimd
         __m128i res_low = _mm_srli_epi64(lhs_low, rhs);
         __m128i res_high = _mm_srli_epi64(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint64_t, 4> operator<<(const batch<uint64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint64_t, 4> operator>>(const batch<uint64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srlv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
 #endif
     }
 }

--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -85,9 +85,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8)
     };
 
-    batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int16_t rhs);
-    batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int16_t rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -365,7 +362,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int16_t, 8> shift_left(const batch<int16_t, 8>& lhs, const int n)
+        inline batch<int16_t, 8> shift_left(const batch<int16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -376,7 +373,7 @@ namespace xsimd
             return batch<int16_t, 8>(int16_t(0));
         }
 
-        inline batch<int16_t, 8> shift_right(const batch<int16_t, 8>& lhs, const int n)
+        inline batch<int16_t, 8> shift_right(const batch<int16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -388,12 +385,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int16_t rhs)
+    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int16_t rhs)
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -401,6 +398,11 @@ namespace xsimd
     inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
     {
         return vshlq_s16(lhs, rhs);
+    }
+
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+        return vshlq_s16(lhs, vnegq_s16(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -493,14 +493,12 @@ namespace xsimd
 
     inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
-//        return detail::shift_left(lhs, rhs);
-        return vshlq_n_s32(lhs, rhs);
+        return detail::shift_left(lhs, rhs);
     }
 
     inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
-//        return detail::shift_right(lhs, rhs);
-        return vshrq_n_s32(lhs, rhs);
+        return detail::shift_right(lhs, rhs);
     }
 
     inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -70,10 +70,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
-
     /************************************
      * batch<int32_t, 4> implementation *
      ************************************/
@@ -472,7 +468,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int32_t, 4> shift_left(const batch<int32_t, 4>& lhs, const int n)
+        inline batch<int32_t, 4> shift_left(const batch<int32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -483,7 +479,7 @@ namespace xsimd
             return batch<int32_t, 4>(int32_t(0));
         }
 
-        inline batch<int32_t, 4> shift_right(const batch<int32_t, 4>& lhs, const int n)
+        inline batch<int32_t, 4> shift_right(const batch<int32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -497,17 +493,24 @@ namespace xsimd
 
     inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
-        return detail::shift_left(lhs, rhs);
+//        return detail::shift_left(lhs, rhs);
+        return vshlq_n_s32(lhs, rhs);
     }
 
     inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs)
     {
-        return detail::shift_right(lhs, rhs);
+//        return detail::shift_right(lhs, rhs);
+        return vshrq_n_s32(lhs, rhs);
     }
 
     inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
     {
         return vshlq_s32(lhs, rhs);
+    }
+
+    inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return vshlq_s32(lhs, vnegq_s32(rhs));
     }
 
 }

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -67,10 +67,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int64_t rhs);
-    batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int64_t rhs);
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
-
     /***********************************
     * batch<int64_t, 2> implementation *
     ************************************/
@@ -471,7 +467,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int64_t, 2> shift_left(const batch<int64_t, 2>& lhs, const int n)
+        inline batch<int64_t, 2> shift_left(const batch<int64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -482,7 +478,7 @@ namespace xsimd
             return batch<int64_t, 2>(int64_t(0));
         }
 
-        inline batch<int64_t, 2> shift_right(const batch<int64_t, 2>& lhs, const int n)
+        inline batch<int64_t, 2> shift_right(const batch<int64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -494,12 +490,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int64_t rhs)
+    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int64_t rhs)
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -507,6 +503,11 @@ namespace xsimd
     inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
         return vshlq_s64(lhs, rhs);
+    }
+
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+        return vshlq_s64(lhs, vnegq_s64(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -507,7 +507,11 @@ namespace xsimd
 
     inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
         return vshlq_s64(lhs, vnegq_s64(rhs));
+#else
+        return batch<int64_t, 2>(lhs[0] >> rhs[0]), lhs[1] >> rhs[1]);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -85,9 +85,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16)
     };
 
-    batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int8_t rhs);
-    batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int8_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -366,7 +363,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int8_t, 16> shift_left(const batch<int8_t, 16>& lhs, const int n)
+        inline batch<int8_t, 16> shift_left(const batch<int8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -377,7 +374,7 @@ namespace xsimd
             return batch<int8_t, 16>(int8_t(0));
         }
 
-        inline batch<int8_t, 16> shift_right(const batch<int8_t, 16>& lhs, const int n)
+        inline batch<int8_t, 16> shift_right(const batch<int8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -389,12 +386,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int8_t rhs)
+    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int8_t rhs)
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -404,6 +401,10 @@ namespace xsimd
         return vshlq_s8(lhs, rhs);
     }
 
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return vshlq_s8(lhs, vnegq_s8(rhs));
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -81,10 +81,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
     };
 
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int16_t rhs);
-    batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int16_t rhs);
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -340,7 +336,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<uint16_t, 8> shift_left(const batch<uint16_t, 8>& lhs, const int n)
+        inline batch<uint16_t, 8> shift_left(const batch<uint16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -351,7 +347,7 @@ namespace xsimd
             return batch<uint16_t, 8>(uint16_t(0));
         }
 
-        inline batch<uint16_t, 8> shift_right(const batch<uint16_t, 8>& lhs, const int n)
+        inline batch<uint16_t, 8> shift_right(const batch<uint16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -363,12 +359,12 @@ namespace xsimd
         }
     }
 
-    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int16_t rhs)
+    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int16_t rhs)
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -376,6 +372,11 @@ namespace xsimd
     inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
     {
         return vshlq_u16(lhs, rhs);
+    }
+
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+        return vshlq_u16(lhs, vnegq_s16(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint32.hpp
+++ b/include/xsimd/types/xsimd_neon_uint32.hpp
@@ -69,10 +69,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
-
     /*************************************
      * batch<uint32_t, 4> implementation *
      *************************************/
@@ -433,7 +429,7 @@ namespace xsimd
             }
         };
 
-        inline batch<uint32_t, 4> shift_left(const batch<uint32_t, 4>& lhs, const int n)
+        inline batch<uint32_t, 4> shift_left(const batch<uint32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -444,7 +440,7 @@ namespace xsimd
             return batch<uint32_t, 4>(uint32_t(0));
         }
 
-        inline batch<uint32_t, 4> shift_right(const batch<uint32_t, 4>& lhs, const int n)
+        inline batch<uint32_t, 4> shift_right(const batch<uint32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -469,6 +465,11 @@ namespace xsimd
     inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
     {
         return vshlq_u32(lhs, rhs);
+    }
+
+    inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return vshlq_u32(lhs, vnegq_s32(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -67,10 +67,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int64_t rhs);
-    batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int64_t rhs);
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
-
     /************************************
     * batch<uint64_t, 2> implementation *
     *************************************/
@@ -485,7 +481,7 @@ namespace xsimd
             }
         };
 
-        inline batch<uint64_t, 2> shift_left(const batch<uint64_t, 2>& lhs, const int n)
+        inline batch<uint64_t, 2> shift_left(const batch<uint64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -496,7 +492,7 @@ namespace xsimd
             return batch<uint64_t, 2>(uint64_t(0));
         }
 
-        inline batch<uint64_t, 2> shift_right(const batch<uint64_t, 2>& lhs, const int n)
+        inline batch<uint64_t, 2> shift_right(const batch<uint64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -508,12 +504,12 @@ namespace xsimd
         }
     }
 
-    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int64_t rhs)
+    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int64_t rhs)
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -521,6 +517,11 @@ namespace xsimd
     inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
         return vshlq_u64(lhs, rhs);
+    }
+
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+        return vshlq_u64(lhs, vnegq_s64(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -521,7 +521,11 @@ namespace xsimd
 
     inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
         return vshlq_u64(lhs, vnegq_s64(rhs));
+#else
+        return batch<uint64_t, 2>(lhs[0] >> rhs[0]), lhs[1] >> rhs[1]);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -81,9 +81,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
     };
 
-    batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, uint8_t rhs);
-    batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, uint8_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -340,7 +337,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<uint8_t, 16> shift_left(const batch<uint8_t, 16>& lhs, const int n)
+        inline batch<uint8_t, 16> shift_left(const batch<uint8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -351,7 +348,7 @@ namespace xsimd
             return batch<uint8_t, 16>(uint8_t(0));
         }
 
-        inline batch<uint8_t, 16> shift_right(const batch<uint8_t, 16>& lhs, const int n)
+        inline batch<uint8_t, 16> shift_right(const batch<uint8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -363,21 +360,25 @@ namespace xsimd
         }
     }
 
-    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, uint8_t rhs)
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, uint8_t rhs)
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
 
-    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<uint8_t, 16>& rhs)
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
     {
-        return vshlq_u8(lhs, vreinterpretq_s8_u8(rhs));
+        return vshlq_u8(lhs, rhs);
     }
 
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return vshlq_u8(lhs, vnegq_s8(rhs));
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -126,11 +126,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
     };
 
-    batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs);
-    batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs);
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs);
-    batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -263,12 +258,30 @@ namespace xsimd
 
     inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int16_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_slli_epi16(lhs, rhs);
     }
 
     inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int16_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_srai_epi16(lhs, rhs);
+    }
+
+    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_sllv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_srav_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 8, 16)
@@ -276,12 +289,30 @@ namespace xsimd
 
     inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint16_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_slli_epi16(lhs, rhs);
     }
 
     inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint16_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_srli_epi16(lhs, rhs);
+    }
+
+    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_sllv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_srlv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -124,11 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4)
     };
 
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs);
-
     /************************************
      * batch<int32_t, 4> implementation *
      ************************************/
@@ -481,6 +476,24 @@ namespace xsimd
         return _mm_srai_epi32(lhs, rhs);
     }
 
+    inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srav_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs)
     {
         return _mm_slli_epi32(lhs, rhs);
@@ -489,6 +502,24 @@ namespace xsimd
     inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs)
     {
         return _mm_srli_epi32(lhs, rhs);
+    }
+
+    inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srlv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -124,11 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2)
     };
 
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs);
-    batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs);
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs);
-    batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs);
-
     /************************************
      * batch<int64_t, 2> implementation *
      ************************************/
@@ -428,6 +423,24 @@ namespace xsimd
 #endif
     }
 
+    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int64_t lhs, int64_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm_srav_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int64_t lhs, int64_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return _mm_slli_epi64(lhs, rhs);
@@ -436,6 +449,24 @@ namespace xsimd
     inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return _mm_srli_epi64(lhs, rhs);
+    }
+
+    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint64_t lhs, int64_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srlv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint64_t lhs, int64_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -143,11 +143,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
     };
 
-    batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs);
-    batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs);
-    batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs);
-    batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -291,12 +286,25 @@ namespace xsimd
 
     inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int8_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF << rhs), _mm_slli_epi32(lhs, rhs));
     }
 
     inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int8_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        __m128i sign_mask = _mm_set1_epi16((0xFF00 >> rhs) & 0x00FF);
+        __m128i cmp_is_negative = _mm_cmpgt_epi8(_mm_setzero_si128(), lhs);
+        __m128i res = _mm_srai_epi16(lhs, rhs);
+        return _mm_or_si128(_mm_and_si128(sign_mask, cmp_is_negative), _mm_andnot_si128(sign_mask, res));
+    }
+
+    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](int8_t lhs, int8_t s) { return lhs << s; }, lhs, rhs);
+    }
+
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](int8_t lhs, int8_t s) { return lhs >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 16, 16)
@@ -304,12 +312,22 @@ namespace xsimd
 
     inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint8_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF << rhs), _mm_slli_epi32(lhs, rhs));
     }
 
     inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint8_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF >> rhs), _mm_srli_epi32(lhs, rhs));
+    }
+
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](uint8_t lhs, int8_t s) { return lhs << s; }, lhs, rhs);
+    }
+
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](uint8_t lhs, int8_t s) { return lhs >> s; }, lhs, rhs);
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int_base.hpp
+++ b/include/xsimd/types/xsimd_sse_int_base.hpp
@@ -526,6 +526,19 @@ namespace xsimd
             });
             return batch<T, N>(tmp_res, aligned_mode());
         }
+
+        template <class F, class T, class S, std::size_t N>
+        inline batch<T, N> shift_impl(F&& f, const batch<T, N>& lhs, const batch<S, N>& rhs)
+        {
+            alignas(16) T tmp_lhs[N], tmp_res[N];
+            alignas(16) S tmp_rhs[N];
+            lhs.store_aligned(&tmp_lhs[0]);
+            rhs.store_aligned(&tmp_rhs[0]);
+            unroller<N>([&](std::size_t i) {
+              tmp_res[i] = f(tmp_lhs[i], tmp_rhs[i]);
+            });
+            return batch<T, N>(tmp_res, aligned_mode());
+        }
     }
 }
 

--- a/test/xsimd_basic_test.hpp
+++ b/test/xsimd_basic_test.hpp
@@ -197,6 +197,9 @@ namespace xsimd
         using vector_type = typename base_type::vector_type;
         using value_type = typename base_type::value_type;
         using res_type = typename base_type::res_type;
+        using signed_value_type = typename std::make_signed<value_type>::type;
+        using signed_vector_type = batch<signed_value_type, N>;
+        using signed_res_type = std::vector<signed_value_type, aligned_allocator<signed_value_type, A>>;
 
         std::string name;
 
@@ -205,6 +208,7 @@ namespace xsimd
         res_type lhs;
         res_type rhs;
         res_type mix_lhs_rhs;
+        signed_res_type shift;
 
         value_type extract_res;
         res_type minus_res;
@@ -237,8 +241,10 @@ namespace xsimd
         res_type fnma_res;
         res_type fnms_res;
         value_type hadd_res;
-        res_type sl_res;
-        res_type sr_res;
+        res_type sl_s_res;
+        res_type sl_v_res;
+        res_type sr_s_res;
+        res_type sr_v_res;
         res_type false_res;
         res_type true_res;
 
@@ -257,6 +263,7 @@ namespace xsimd
         lhs.resize(N);
         rhs.resize(N);
         mix_lhs_rhs.resize(N);
+        shift.resize(N);
         minus_res.resize(N);
         plus_res.resize(N);
         add_vv_res.resize(N);
@@ -286,8 +293,10 @@ namespace xsimd
         fms_res.resize(N);
         fnma_res.resize(N);
         fnms_res.resize(N);
-        sl_res.resize(N);
-        sr_res.resize(N);
+        sl_s_res.resize(N);
+        sl_v_res.resize(N);
+        sr_s_res.resize(N);
+        sr_v_res.resize(N);
         false_res.resize(N);
         true_res.resize(N);
 
@@ -298,7 +307,8 @@ namespace xsimd
         {
             bool negative_lhs = std::is_signed<T>::value && (i % 2 == 1);
             lhs[i] = value_type(i) * (negative_lhs ? -10 : 10);
-            rhs[i] = value_type(4) + value_type(i);
+            rhs[i] = value_type(i) + value_type(4);
+            shift[i] = signed_value_type(i);
             extract_res = lhs[1];
             minus_res[i] = -lhs[i];
             plus_res[i] = +lhs[i];
@@ -330,8 +340,10 @@ namespace xsimd
             fnma_res[i] = -lhs[i] * rhs[i] + rhs[i];
             fnms_res[i] = -lhs[i] * rhs[i] - rhs[i];
             hadd_res += lhs[i];
-            sl_res[i] = lhs[i] << sh_nb;
-            sr_res[i] = lhs[i] >> sh_nb;
+            sl_s_res[i] = lhs[i] << sh_nb;
+            sl_v_res[i] = lhs[i] << shift[i];
+            sr_s_res[i] = lhs[i] >> sh_nb;
+            sr_v_res[i] = lhs[i] >> shift[i];
             false_res[i] = value_type(0);
             true_res[i] = value_type(1);
         }
@@ -1273,6 +1285,9 @@ namespace xsimd
         using vector_type = typename tester_type::vector_type;
         using value_type = typename tester_type::value_type;
         using res_type = typename tester_type::res_type;
+        using signed_vector_type = typename tester_type::signed_vector_type;
+        using signed_value_type = typename tester_type::signed_value_type;
+        using signed_res_type = typename tester_type::signed_res_type;
 
         using vector_bool_type = typename simd_batch_traits<vector_type>::batch_bool_type;
         using bool_traits = simd_batch_traits<vector_bool_type>;
@@ -1283,6 +1298,7 @@ namespace xsimd
         vector_type lhs;
         vector_type rhs;
         vector_type mix_lhs_rhs;
+        signed_vector_type shift;
         vector_type vres;
         res_type res(tester_type::size);
         value_type s = tester.s;
@@ -1290,15 +1306,15 @@ namespace xsimd
         bool tmp_success = true;
 
         std::string val_type = value_type_name<vector_type>();
-        std::string shift = std::string(val_type.size(), '-');
+        std::string val_type_shift = std::string(val_type.size(), '-');
         std::string name = tester.name;
         std::string name_shift = std::string(name.size(), '-');
         std::string dash(8, '-');
         std::string space(8, ' ');
 
-        out << dash << name_shift << '-' << shift << dash << std::endl;
+        out << dash << name_shift << '-' << val_type_shift << dash << std::endl;
         out << space << name << " " << val_type << std::endl;
-        out << dash << name_shift << '-' << shift << dash << std::endl
+        out << dash << name_shift << '-' << val_type_shift << dash << std::endl
             << std::endl;
 
         std::string topic = "operator[]               : ";
@@ -1326,6 +1342,7 @@ namespace xsimd
         detail::load_vec(lhs, tester.lhs);
         detail::load_vec(rhs, tester.rhs);
         detail::load_vec(mix_lhs_rhs, tester.mix_lhs_rhs);
+        detail::load_vec(shift, tester.shift);
 
         topic = "unary operator-          : ";
         vres = -lhs;
@@ -1523,13 +1540,25 @@ namespace xsimd
         topic = "shift left(simd, int)    : ";
         vres = lhs << tester.sh_nb;
         detail::store_vec(vres, res);
-        tmp_success = check_almost_equal(topic, res, tester.sl_res, out);
+        tmp_success = check_almost_equal(topic, res, tester.sl_s_res, out);
+        success = success && tmp_success;
+
+        topic = "shift left(simd, simd)    : ";
+        vres = lhs << shift;
+        detail::store_vec(vres, res);
+        tmp_success = check_almost_equal(topic, res, tester.sl_v_res, out);
         success = success && tmp_success;
 
         topic = "shift right(simd, int)   : ";
         vres = lhs >> tester.sh_nb;
         detail::store_vec(vres, res);
-        tmp_success = check_almost_equal(topic, res, tester.sr_res, out);
+        tmp_success = check_almost_equal(topic, res, tester.sr_s_res, out);
+        success = success && tmp_success;
+
+        topic = "shift right(simd, simd)   : ";
+        vres = lhs >> shift;
+        detail::store_vec(vres, res);
+        tmp_success = check_almost_equal(topic, res, tester.sr_v_res, out);
         success = success && tmp_success;
 
         topic = "conversion from true     : ";


### PR DESCRIPTION
I have implemented the remaining shift operators, primarily the vector shift ones. I have also provided intrinsics-based implementations for some shift operators where single intrinsics don't exist, e.g. the int8 Intel ones.

The final change I made was to the AVX512 shift intrinsics. I narrowed down the requirement to know the shift arg at compile time to a limitation that only exists in GCC 6.4. I believe this is a compiler bug as:
1. other versions of the same compiler plus all other compilers all support a variable arg (thanks [compiler explorer](https://godbolt.org/z/W8KGJt)), and
2. the underlying AVX512 instructions support getting the shift arg from a register. For example, _mm512_slli_epi32 maps to the vpslld instruction, and as per [this documentation](https://www.felixcloutier.com/x86/psllw:pslld:psllq), there is a version of the instruction that takes an immediate and a version that takes a register.

Given this is limited to GCC 6.4, I have put your fix inside a preprocessor directive so that the performance of programs compiled with other compilers and other GCC versions are not negatively impacted.