### PR TITLE
Implement remaining vector shift operators

### DIFF
--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -121,7 +121,7 @@
         #define XSIMD_AVX512BW_AVAILABLE 1
     #endif
 
-    #if __GNUC__ == 6 && __GNUC_MINOR__ == 4
+    #if __GNUC__ == 6
         #define XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY 1
     #endif
 #endif

--- a/include/xsimd/config/xsimd_instruction_set.hpp
+++ b/include/xsimd/config/xsimd_instruction_set.hpp
@@ -108,18 +108,22 @@
 #if !defined(XSIMD_X86_INSTR_SET) && (defined(__AVX512__) || defined(__KNCNI__) || defined(__AVX512F__)\
     && (!defined(__GNUC__) || __GNUC__ >= 6))
     #define XSIMD_X86_INSTR_SET XSIMD_X86_AVX512_VERSION
-#endif
 
-#if defined(__AVX512VL__)
-    #define XSIMD_AVX512VL_AVAILABLE 1
-#endif
+    #if defined(__AVX512VL__)
+        #define XSIMD_AVX512VL_AVAILABLE 1
+    #endif
 
-#if defined(__AVX512DQ__)
-    #define XSIMD_AVX512DQ_AVAILABLE 1
-#endif
+    #if defined(__AVX512DQ__)
+        #define XSIMD_AVX512DQ_AVAILABLE 1
+    #endif
 
-#if defined(__AVX512BW__)
-    #define XSIMD_AVX512BW_AVAILABLE 1
+    #if defined(__AVX512BW__)
+        #define XSIMD_AVX512BW_AVAILABLE 1
+    #endif
+
+    #if __GNUC__ == 6 && __GNUC_MINOR__ == 4
+        #define XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY 1
+    #endif
 #endif
 
 #if !defined(XSIMD_X86_INSTR_SET) && defined(__AVX2__)

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -190,11 +190,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 32)
     };
 
-    batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, int32_t rhs);
-    batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, int32_t rhs);
-    batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, int32_t rhs);
-    batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, int32_t rhs);
-
     /*************************************
      * batch<int16_t, 32> implementation *
      *************************************/
@@ -468,37 +463,112 @@ namespace xsimd
 
     inline batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_slli_epi16(lhs, rhs);
+#endif
+#else
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), tmp);
+#endif
     }
 
     inline batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_srai_epi16(lhs, rhs);
+#endif
+#else
+        return avx512_detail::shift_impl([](int16_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 32, 32)
-    XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 32, 32)
+    inline batch<int16_t, 32> operator<<(const batch<int16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_sllv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 32> operator>>(const batch<int16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_srav_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 32, 64)
+    XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 32, 64)
 
     inline batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_slli_epi16(lhs, rhs);
+#endif
+#else
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF << rhs), tmp);
+#endif
     }
 
     inline batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        return _mm512_srli_epi16(lhs, rhs);
+#endif
+#else
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_srli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi16(0xFFFF >> rhs), tmp);
+#endif
     }
 
-    XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 32, 32)
-    XSIMD_DEFINE_LOAD_STORE_LONG(uint16_t, 32, 32)
+    inline batch<uint16_t, 32> operator<<(const batch<uint16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_sllv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 32> operator>>(const batch<uint16_t, 32>& lhs, const batch<int16_t, 32>& rhs)
+    {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm512_srlv_epi16(lhs, rhs);
+#else
+        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 32, 64)
+    XSIMD_DEFINE_LOAD_STORE_LONG(uint16_t, 32, 64)
 
 #undef XSIMD_APPLY_AVX2_FUNCTION_INT16
 }

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -128,15 +128,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 16)
     };
 
-    batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, int32_t rhs);
-    batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, int32_t rhs);
-    batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, int32_t rhs);
-    batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, int32_t rhs);
-    batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-    batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs);
-
     /*************************************
      * batch<int32_t, 16> implementation *
      *************************************/
@@ -354,16 +345,20 @@ namespace xsimd
 
     inline batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_slli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<int32_t, 16> operator>>(const batch<int32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_srai_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srav_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_srai_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<int32_t, 16> operator<<(const batch<int32_t, 16>& lhs, const batch<int32_t, 16>& rhs)
@@ -378,16 +373,20 @@ namespace xsimd
 
     inline batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi32(lhs, batch<uint32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_slli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<uint32_t, 16> operator>>(const batch<uint32_t, 16>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi32 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srlv_epi32(lhs, batch<int32_t, 16>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        return _mm512_srli_epi32(lhs, rhs);
+#endif
     }
 
     inline batch<uint32_t, 16> operator<<(const batch<uint32_t, 16>& lhs, const batch<int32_t, 16>& rhs)

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -110,7 +110,7 @@ namespace xsimd
 
         XSIMD_DECLARE_LOAD_STORE_INT64(int64_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(int64_t, 8)
-   };
+    };
 
     template <>
     class batch<uint64_t, 8> : public avx512_int_batch<uint64_t, 8>
@@ -126,16 +126,7 @@ namespace xsimd
 
         XSIMD_DECLARE_LOAD_STORE_INT64(uint64_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 8)
-   };
-
-    batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, int32_t rhs);
-    batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, int32_t rhs);
-    batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, int32_t rhs);
-    batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, int32_t rhs);
-    batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
-    batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs);
+    };
 
     /************************************
      * batch<int64_t, 8> implementation *
@@ -409,16 +400,20 @@ namespace xsimd
 
     inline batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi64(lhs, batch<int64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_slli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<int64_t, 8> operator>>(const batch<int64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_srai_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srav_epi64(lhs, batch<int64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srav_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_srai_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<int64_t, 8> operator<<(const batch<int64_t, 8>& lhs, const batch<int64_t, 8>& rhs)
@@ -433,16 +428,20 @@ namespace xsimd
 
     inline batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_slli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_sllv_epi64(lhs, batch<uint64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_sllv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_slli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<uint64_t, 8> operator>>(const batch<uint64_t, 8>& lhs, int32_t rhs)
     {
-        // _mm512_srli_epi64 expects its last argument to be known at compile time,
-        // which cannot be guaranteed here.
-        return _mm512_srlv_epi64(lhs, batch<uint64_t, 8>(rhs));
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        return _mm512_srlv_epi64(lhs, _mm512_set1_epi64(rhs));
+#else
+        return _mm512_srli_epi64(lhs, rhs);
+#endif
     }
 
     inline batch<uint64_t, 8> operator<<(const batch<uint64_t, 8>& lhs, const batch<int64_t, 8>& rhs)

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -190,11 +190,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 64)
     };
 
-    batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, int32_t rhs);
-    batch<int8_t, 64> operator>>(const batch<int8_t, 64>& lhs, int32_t rhs);
-    batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, int32_t rhs);
-    batch<uint8_t, 64> operator>>(const batch<uint8_t, 64>& lhs, int32_t rhs);
-
     /************************************
      * batch<int8_t, 64> implementation *
      ************************************/
@@ -470,16 +465,40 @@ namespace xsimd
 
     inline batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int8_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), tmp);
     }
 
     inline batch<int8_t, 64> operator>>(const batch<int8_t, 64>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int8_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+        __m512i sign_mask = _mm512_set1_epi16((0xFF00 >> rhs) & 0x00FF);
+        __m512i zeros = _mm512_setzero_si512();
+        __mmask64 cmp_is_negative_mask = _mm512_cmpgt_epi8_mask(zeros, lhs);
+        __m512i cmp_sign_mask = _mm512_mask_blend_epi8(cmp_is_negative_mask, zeros, sign_mask);
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i res = _mm512_srav_epi16(lhs, _mm512_set1_epi16(rhs));
+#else
+        __m512i res = _mm512_srai_epi16(lhs, rhs);
+#endif
+        return _mm512_or_si512(cmp_sign_mask, _mm512_andnot_si512(sign_mask, res));
+#else
+        return avx512_detail::shift_impl([](int8_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
+    {
+        return avx512_detail::shift_impl([](int8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+    }
+
+    inline batch<int8_t, 64> operator>>(const batch<int8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
+    {
+        return avx512_detail::shift_impl([](int8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(int8_t, 64, 64)
@@ -487,16 +506,32 @@ namespace xsimd
 
     inline batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint8_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_sllv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_slli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF << rhs), tmp);
     }
 
     inline batch<uint8_t, 64> operator>>(const batch<uint8_t, 64>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint8_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if defined(XSIMD_AVX512_SHIFT_INTRINSICS_IMM_ONLY)
+        __m512i tmp = _mm512_srlv_epi32(lhs, _mm512_set1_epi32(rhs));
+#else
+        __m512i tmp = _mm512_srli_epi32(lhs, rhs);
+#endif
+        return _mm512_and_si512(_mm512_set1_epi8(0xFF >> rhs), tmp);
+    }
+
+    inline batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
+    {
+        return avx512_detail::shift_impl([](uint8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+    }
+
+    inline batch<uint8_t, 64> operator>>(const batch<uint8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
+    {
+        return avx512_detail::shift_impl([](uint8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 64, 64)

--- a/include/xsimd/types/xsimd_avx512_int_base.hpp
+++ b/include/xsimd/types/xsimd_avx512_int_base.hpp
@@ -328,6 +328,19 @@ namespace xsimd
             });
             return batch<T, N>(tmp_res, aligned_mode());
         }
+
+        template <class F, class T, class S, std::size_t N>
+        inline batch<T, N> shift_impl(F&& f, const batch<T, N>& lhs, const batch<S, N>& rhs)
+        {
+            alignas(64) T tmp_lhs[N], tmp_res[N];
+            alignas(64) S tmp_rhs[N];
+            lhs.store_aligned(&tmp_lhs[0]);
+            rhs.store_aligned(&tmp_rhs[0]);
+            unroller<N>([&](std::size_t i) {
+              tmp_res[i] = f(tmp_lhs[i], tmp_rhs[i]);
+            });
+            return batch<T, N>(tmp_res, aligned_mode());
+        }
     }
 }
 

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -328,19 +328,46 @@ namespace xsimd
     XSIMD_DEFINE_LOAD_STORE_INT16(int16_t, 16, 32)
     XSIMD_DEFINE_LOAD_STORE_LONG(int16_t, 16, 32)
 
-    // TODO implement by converting to int16
     inline batch<int16_t, 16> operator<<(const batch<int16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_slli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_slli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_slli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
     }
 
     inline batch<int16_t, 16> operator>>(const batch<int16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](int16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srai_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_srai_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_srai_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<int16_t, 16> operator<<(const batch<int16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_sllv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 16> operator>>(const batch<int16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_srav_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 16, 32)
@@ -348,16 +375,44 @@ namespace xsimd
 
     inline batch<uint16_t, 16> operator<<(const batch<uint16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val << rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_slli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_slli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_slli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
     }
 
     inline batch<uint16_t, 16> operator>>(const batch<uint16_t, 16>& lhs, int32_t rhs)
     {
-        return avx_detail::shift_impl([](uint16_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srli_epi16(lhs, rhs);
+#else
+        XSIMD_SPLIT_AVX(lhs);
+        __m128i res_low = _mm_srli_epi16(lhs_low, rhs);
+        __m128i res_high = _mm_srli_epi16(lhs_high, rhs);
+        XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint16_t, 16> operator<<(const batch<uint16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_sllv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 16> operator>>(const batch<uint16_t, 16>& lhs, const batch<int16_t, 16>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm256_srlv_epi16(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -109,9 +109,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int32_t, 8)
    };
 
-    batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, int32_t rhs);
-    batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, int32_t rhs);
-
     template <>
     class batch<uint32_t, 8> : public avx_int_batch<uint32_t, 8>
     {
@@ -127,9 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_INT32(uint32_t, 8)
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 8)
     };
-
-    batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, int32_t rhs);
-    batch<uint32_t, 8> operator>>(const batch<uint32_t, 8>& lhs, int32_t rhs);
 
     /************************************
      * batch<int32_t, 8> implementation *
@@ -521,6 +515,24 @@ namespace xsimd
 #endif
     }
 
+    inline batch<int32_t, 8> operator<<(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int32_t, 8> operator>>(const batch<int32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srav_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, int32_t rhs)
     {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
@@ -542,6 +554,24 @@ namespace xsimd
         __m128i res_low = _mm_srli_epi32(lhs_low, rhs);
         __m128i res_high = _mm_srli_epi32(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint32_t, 8> operator<<(const batch<uint32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint32_t, 8> operator>>(const batch<uint32_t, 8>& lhs, const batch<int32_t, 8>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srlv_epi32(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
 #endif
     }
 }

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -126,11 +126,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 4)
     };
 
-    batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, int32_t rhs);
-    batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, int32_t rhs);
-    batch<uint64_t, 4> operator<<(const batch<uint64_t, 4>& lhs, int32_t rhs);
-    batch<uint64_t, 4> operator>>(const batch<uint64_t, 4>& lhs, int32_t rhs);
-
     /************************************
      * batch<int64_t, 4> implementation *
      ************************************/
@@ -496,9 +491,25 @@ namespace xsimd
 #if defined(XSIMD_AVX512VL_AVAILABLE)
         return _mm256_srai_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](int64_t val, int32_t rhs) {
-            return val >> rhs;
-        }, lhs, rhs);
+        return avx_detail::shift_impl([](int64_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 4> operator<<(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 4> operator>>(const batch<int64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm256_srav_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
 #endif
     }
 
@@ -523,6 +534,24 @@ namespace xsimd
         __m128i res_low = _mm_srli_epi64(lhs_low, rhs);
         __m128i res_high = _mm_srli_epi64(lhs_high, rhs);
         XSIMD_RETURN_MERGED_SSE(res_low, res_high);
+#endif
+    }
+
+    inline batch<uint64_t, 4> operator<<(const batch<uint64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_sllv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint64_t, 4> operator>>(const batch<uint64_t, 4>& lhs, const batch<int64_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm256_srlv_epi64(lhs, rhs);
+#else
+        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
 #endif
     }
 }

--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -85,9 +85,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int16_t, 8)
     };
 
-    batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int16_t rhs);
-    batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int16_t rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -365,7 +362,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int16_t, 8> shift_left(const batch<int16_t, 8>& lhs, const int n)
+        inline batch<int16_t, 8> shift_left(const batch<int16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -376,7 +373,7 @@ namespace xsimd
             return batch<int16_t, 8>(int16_t(0));
         }
 
-        inline batch<int16_t, 8> shift_right(const batch<int16_t, 8>& lhs, const int n)
+        inline batch<int16_t, 8> shift_right(const batch<int16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -388,12 +385,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int16_t rhs)
+    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int16_t rhs)
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -401,6 +398,11 @@ namespace xsimd
     inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
     {
         return vshlq_s16(lhs, rhs);
+    }
+
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+        return vshlq_s16(lhs, vnegq_s16(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -70,10 +70,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
-
     /************************************
      * batch<int32_t, 4> implementation *
      ************************************/
@@ -472,7 +468,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int32_t, 4> shift_left(const batch<int32_t, 4>& lhs, const int n)
+        inline batch<int32_t, 4> shift_left(const batch<int32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -483,7 +479,7 @@ namespace xsimd
             return batch<int32_t, 4>(int32_t(0));
         }
 
-        inline batch<int32_t, 4> shift_right(const batch<int32_t, 4>& lhs, const int n)
+        inline batch<int32_t, 4> shift_right(const batch<int32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -508,6 +504,11 @@ namespace xsimd
     inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
     {
         return vshlq_s32(lhs, rhs);
+    }
+
+    inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return vshlq_s32(lhs, vnegq_s32(rhs));
     }
 
 }

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -67,10 +67,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int64_t rhs);
-    batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int64_t rhs);
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
-
     /***********************************
     * batch<int64_t, 2> implementation *
     ************************************/
@@ -471,7 +467,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int64_t, 2> shift_left(const batch<int64_t, 2>& lhs, const int n)
+        inline batch<int64_t, 2> shift_left(const batch<int64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -482,7 +478,7 @@ namespace xsimd
             return batch<int64_t, 2>(int64_t(0));
         }
 
-        inline batch<int64_t, 2> shift_right(const batch<int64_t, 2>& lhs, const int n)
+        inline batch<int64_t, 2> shift_right(const batch<int64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -494,12 +490,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int64_t rhs)
+    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int64_t rhs)
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -507,6 +503,15 @@ namespace xsimd
     inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
         return vshlq_s64(lhs, rhs);
+    }
+
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
+        return vshlq_s64(lhs, vnegq_s64(rhs));
+#else
+        return batch<int64_t, 2>(lhs[0] >> rhs[0], lhs[1] >> rhs[1]);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -85,9 +85,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(int8_t, 16)
     };
 
-    batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int8_t rhs);
-    batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int8_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -366,7 +363,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<int8_t, 16> shift_left(const batch<int8_t, 16>& lhs, const int n)
+        inline batch<int8_t, 16> shift_left(const batch<int8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -377,7 +374,7 @@ namespace xsimd
             return batch<int8_t, 16>(int8_t(0));
         }
 
-        inline batch<int8_t, 16> shift_right(const batch<int8_t, 16>& lhs, const int n)
+        inline batch<int8_t, 16> shift_right(const batch<int8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -389,12 +386,12 @@ namespace xsimd
         }
     }
 
-    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int8_t rhs)
+    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int8_t rhs)
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -404,6 +401,10 @@ namespace xsimd
         return vshlq_s8(lhs, rhs);
     }
 
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return vshlq_s8(lhs, vnegq_s8(rhs));
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -81,10 +81,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
     };
 
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int16_t rhs);
-    batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int16_t rhs);
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -340,7 +336,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<uint16_t, 8> shift_left(const batch<uint16_t, 8>& lhs, const int n)
+        inline batch<uint16_t, 8> shift_left(const batch<uint16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -351,7 +347,7 @@ namespace xsimd
             return batch<uint16_t, 8>(uint16_t(0));
         }
 
-        inline batch<uint16_t, 8> shift_right(const batch<uint16_t, 8>& lhs, const int n)
+        inline batch<uint16_t, 8> shift_right(const batch<uint16_t, 8>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -363,12 +359,12 @@ namespace xsimd
         }
     }
 
-    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int16_t rhs)
+    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int16_t rhs)
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -376,6 +372,11 @@ namespace xsimd
     inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
     {
         return vshlq_u16(lhs, rhs);
+    }
+
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+        return vshlq_u16(lhs, vnegq_s16(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint32.hpp
+++ b/include/xsimd/types/xsimd_neon_uint32.hpp
@@ -69,10 +69,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs);
-
     /*************************************
      * batch<uint32_t, 4> implementation *
      *************************************/
@@ -433,7 +429,7 @@ namespace xsimd
             }
         };
 
-        inline batch<uint32_t, 4> shift_left(const batch<uint32_t, 4>& lhs, const int n)
+        inline batch<uint32_t, 4> shift_left(const batch<uint32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -444,7 +440,7 @@ namespace xsimd
             return batch<uint32_t, 4>(uint32_t(0));
         }
 
-        inline batch<uint32_t, 4> shift_right(const batch<uint32_t, 4>& lhs, const int n)
+        inline batch<uint32_t, 4> shift_right(const batch<uint32_t, 4>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -469,6 +465,11 @@ namespace xsimd
     inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
     {
         return vshlq_u32(lhs, rhs);
+    }
+
+    inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+        return vshlq_u32(lhs, vnegq_s32(rhs));
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -67,10 +67,6 @@ namespace xsimd
         using base_type::store_unaligned;
     };
 
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int64_t rhs);
-    batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int64_t rhs);
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs);
-
     /************************************
     * batch<uint64_t, 2> implementation *
     *************************************/
@@ -485,7 +481,7 @@ namespace xsimd
             }
         };
 
-        inline batch<uint64_t, 2> shift_left(const batch<uint64_t, 2>& lhs, const int n)
+        inline batch<uint64_t, 2> shift_left(const batch<uint64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -496,7 +492,7 @@ namespace xsimd
             return batch<uint64_t, 2>(uint64_t(0));
         }
 
-        inline batch<uint64_t, 2> shift_right(const batch<uint64_t, 2>& lhs, const int n)
+        inline batch<uint64_t, 2> shift_right(const batch<uint64_t, 2>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -508,12 +504,12 @@ namespace xsimd
         }
     }
 
-    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int64_t rhs)
+    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int64_t rhs)
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
@@ -521,6 +517,15 @@ namespace xsimd
     inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
     {
         return vshlq_u64(lhs, rhs);
+    }
+
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
+        return vshlq_u64(lhs, vnegq_s64(rhs));
+#else
+        return batch<uint64_t, 2>(lhs[0] >> rhs[0], lhs[1] >> rhs[1]);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -81,9 +81,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
     };
 
-    batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, uint8_t rhs);
-    batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, uint8_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -340,7 +337,7 @@ namespace xsimd
 
     namespace detail
     {
-        inline batch<uint8_t, 16> shift_left(const batch<uint8_t, 16>& lhs, const int n)
+        inline batch<uint8_t, 16> shift_left(const batch<uint8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -351,7 +348,7 @@ namespace xsimd
             return batch<uint8_t, 16>(uint8_t(0));
         }
 
-        inline batch<uint8_t, 16> shift_right(const batch<uint8_t, 16>& lhs, const int n)
+        inline batch<uint8_t, 16> shift_right(const batch<uint8_t, 16>& lhs, int32_t n)
         {
             switch(n)
             {
@@ -363,21 +360,25 @@ namespace xsimd
         }
     }
 
-    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, uint8_t rhs)
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_left(lhs, rhs);
     }
 
-    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, uint8_t rhs)
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
         return detail::shift_right(lhs, rhs);
     }
 
-    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<uint8_t, 16>& rhs)
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
     {
-        return vshlq_u8(lhs, vreinterpretq_s8_u8(rhs));
+        return vshlq_u8(lhs, rhs);
     }
 
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return vshlq_u8(lhs, vnegq_s8(rhs));
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -126,11 +126,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint16_t, 8)
     };
 
-    batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs);
-    batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs);
-    batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs);
-    batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs);
-
     /************************************
      * batch<int16_t, 8> implementation *
      ************************************/
@@ -263,12 +258,30 @@ namespace xsimd
 
     inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int16_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_slli_epi16(lhs, rhs);
     }
 
     inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int16_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_srai_epi16(lhs, rhs);
+    }
+
+    inline batch<int16_t, 8> operator<<(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_sllv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int16_t, 8> operator>>(const batch<int16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_srav_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT16(uint16_t, 8, 16)
@@ -276,12 +289,30 @@ namespace xsimd
 
     inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint16_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_slli_epi16(lhs, rhs);
     }
 
     inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint16_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_srli_epi16(lhs, rhs);
+    }
+
+    inline batch<uint16_t, 8> operator<<(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_sllv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint16_t, 8> operator>>(const batch<uint16_t, 8>& lhs, const batch<int16_t, 8>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE) && defined(XSIMD_AVX512BW_AVAILABLE)
+        return _mm_srlv_epi16(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint16_t lhs, int16_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -124,11 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint32_t, 4)
     };
 
-    batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs);
-    batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs);
-
     /************************************
      * batch<int32_t, 4> implementation *
      ************************************/
@@ -481,6 +476,24 @@ namespace xsimd
         return _mm_srai_epi32(lhs, rhs);
     }
 
+    inline batch<int32_t, 4> operator<<(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int32_t, 4> operator>>(const batch<int32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srav_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, int32_t rhs)
     {
         return _mm_slli_epi32(lhs, rhs);
@@ -489,6 +502,24 @@ namespace xsimd
     inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, int32_t rhs)
     {
         return _mm_srli_epi32(lhs, rhs);
+    }
+
+    inline batch<uint32_t, 4> operator<<(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint32_t, 4> operator>>(const batch<uint32_t, 4>& lhs, const batch<int32_t, 4>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srlv_epi32(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint32_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -124,11 +124,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint64_t, 2)
     };
 
-    batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, int32_t rhs);
-    batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, int32_t rhs);
-    batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs);
-    batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs);
-
     /************************************
      * batch<int64_t, 2> implementation *
      ************************************/
@@ -428,6 +423,24 @@ namespace xsimd
 #endif
     }
 
+    inline batch<int64_t, 2> operator<<(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int64_t lhs, int64_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<int64_t, 2> operator>>(const batch<int64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
+        return _mm_srav_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](int64_t lhs, int64_t s) { return lhs >> s; }, lhs, rhs);
+#endif
+    }
+
     inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return _mm_slli_epi64(lhs, rhs);
@@ -436,6 +449,24 @@ namespace xsimd
     inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, int32_t rhs)
     {
         return _mm_srli_epi64(lhs, rhs);
+    }
+
+    inline batch<uint64_t, 2> operator<<(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_sllv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint64_t lhs, int64_t s) { return lhs << s; }, lhs, rhs);
+#endif
+    }
+
+    inline batch<uint64_t, 2> operator>>(const batch<uint64_t, 2>& lhs, const batch<int64_t, 2>& rhs)
+    {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+        return _mm_srlv_epi64(lhs, rhs);
+#else
+        return sse_detail::shift_impl([](uint64_t lhs, int64_t s) { return lhs >> s; }, lhs, rhs);
+#endif
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -143,11 +143,6 @@ namespace xsimd
         XSIMD_DECLARE_LOAD_STORE_LONG(uint8_t, 16)
     };
 
-    batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs);
-    batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs);
-    batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs);
-    batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs);
-
     /************************************
      * batch<int8_t, 16> implementation *
      ************************************/
@@ -291,12 +286,25 @@ namespace xsimd
 
     inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int8_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF << rhs), _mm_slli_epi32(lhs, rhs));
     }
 
     inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](int8_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        __m128i sign_mask = _mm_set1_epi16((0xFF00 >> rhs) & 0x00FF);
+        __m128i cmp_is_negative = _mm_cmpgt_epi8(_mm_setzero_si128(), lhs);
+        __m128i res = _mm_srai_epi16(lhs, rhs);
+        return _mm_or_si128(_mm_and_si128(sign_mask, cmp_is_negative), _mm_andnot_si128(sign_mask, res));
+    }
+
+    inline batch<int8_t, 16> operator<<(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](int8_t lhs, int8_t s) { return lhs << s; }, lhs, rhs);
+    }
+
+    inline batch<int8_t, 16> operator>>(const batch<int8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](int8_t lhs, int8_t s) { return lhs >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 16, 16)
@@ -304,12 +312,22 @@ namespace xsimd
 
     inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint8_t lhs, int32_t s) { return lhs << s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF << rhs), _mm_slli_epi32(lhs, rhs));
     }
 
     inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, int32_t rhs)
     {
-        return sse_detail::shift_impl([](uint8_t lhs, int32_t s) { return lhs >> s; }, lhs, rhs);
+        return _mm_and_si128(_mm_set1_epi8(0xFF >> rhs), _mm_srli_epi32(lhs, rhs));
+    }
+
+    inline batch<uint8_t, 16> operator<<(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](uint8_t lhs, int8_t s) { return lhs << s; }, lhs, rhs);
+    }
+
+    inline batch<uint8_t, 16> operator>>(const batch<uint8_t, 16>& lhs, const batch<int8_t, 16>& rhs)
+    {
+        return sse_detail::shift_impl([](uint8_t lhs, int8_t s) { return lhs >> s; }, lhs, rhs);
     }
 }
 

--- a/include/xsimd/types/xsimd_sse_int_base.hpp
+++ b/include/xsimd/types/xsimd_sse_int_base.hpp
@@ -526,6 +526,19 @@ namespace xsimd
             });
             return batch<T, N>(tmp_res, aligned_mode());
         }
+
+        template <class F, class T, class S, std::size_t N>
+        inline batch<T, N> shift_impl(F&& f, const batch<T, N>& lhs, const batch<S, N>& rhs)
+        {
+            alignas(16) T tmp_lhs[N], tmp_res[N];
+            alignas(16) S tmp_rhs[N];
+            lhs.store_aligned(&tmp_lhs[0]);
+            rhs.store_aligned(&tmp_rhs[0]);
+            unroller<N>([&](std::size_t i) {
+              tmp_res[i] = f(tmp_lhs[i], tmp_rhs[i]);
+            });
+            return batch<T, N>(tmp_res, aligned_mode());
+        }
     }
 }
 


### PR DESCRIPTION
I have implemented the remaining shift operators, primarily the vector shift ones. I have also provided intrinsics-based implementations for some shift operators where single intrinsics don't exist, e.g. the int8 Intel ones.

The final change I made was to the AVX512 shift intrinsics. I narrowed down the requirement to know the shift arg at compile time to a limitation that only exists in GCC 6.4. I believe this is a compiler bug as:

other versions of the same compiler plus all other compilers all support a variable arg (thanks compiler explorer), and
the underlying AVX512 instructions support getting the shift arg from a register. For example, _mm512_slli_epi32 maps to the vpslld instruction, and as per this documentation, there is a version of the instruction that takes an immediate and a version that takes a register.
Given this is limited to GCC 6.4, I have put your fix inside a preprocessor directive so that the performance of programs compiled with other compilers and other GCC versions are not negatively impacted.

This is take 2 of the pull request after the first one turned into a mess of commits.