### PR TITLE
xsimd_utils.hpp: Renamed a shadowing variable inside a macro

### DIFF
--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -284,8 +284,8 @@ namespace xsimd
 
 #define XSIMD_MACRO_UNROLL_BINARY(FUNC)                                                                   \
     constexpr std::size_t size = simd_batch_traits<batch_type>::size;                                     \
-    using value_type = typename simd_batch_traits<batch_type>::value_type;                                \
-    alignas(simd_batch_traits<batch_type>::align) value_type tmp_lhs[size], tmp_rhs[size], tmp_res[size]; \
+    using tmp_value_type = typename simd_batch_traits<batch_type>::value_type;                                \
+    alignas(simd_batch_traits<batch_type>::align) tmp_value_type tmp_lhs[size], tmp_rhs[size], tmp_res[size]; \
     lhs.store_aligned(tmp_lhs);                                                                           \
     rhs.store_aligned(tmp_rhs);                                                                           \
     unroller<size>([&](std::size_t i) {                                                                   \


### PR DESCRIPTION
# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [ ] Tests have been added for new features or bug fixes.
- [ ] API of new functions and classes are documented.

# Description

This PR addresses a very minor problem: Inside a function there is a shadowing declaration from the higher context. This PR renames the local declaration to clarify the intended meaning.