### PR TITLE
Fix missing include for gcc-11

### DIFF
--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -12,6 +12,7 @@
 #define XSIMD_SSE_INT8_HPP
 
 #include <cstdint>
+#include <limits>
 
 #include "xsimd_base.hpp"
 #include "xsimd_sse_int_base.hpp"


### PR DESCRIPTION
Required for std::numeric_limits