### PR TITLE
Pins breathe 4.16.0 in docs/environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
 
 dependencies:
-  - breathe
+  - breathe==4.16.0


### PR DESCRIPTION
Documentation only, no need to wait for CI.