### PR TITLE
Fix missing include for gcc-11

### DIFF
--- a/include/xsimd/types/xsimd_complex_base.hpp
+++ b/include/xsimd/types/xsimd_complex_base.hpp
@@ -13,6 +13,7 @@
 
 #include <complex>
 #include <cstddef>
+#include <limits>
 #include <ostream>
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX


### PR DESCRIPTION
Required for std::numeric_limits