### PR TITLE
Rename shadowing variables

### DIFF
--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -498,7 +498,7 @@ namespace xsimd
         return _mm512_srai_epi16(lhs, rhs);
 #endif
 #else
-        return avx512_detail::shift_impl([](int16_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int16_t val, int32_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
@@ -507,7 +507,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512BW_AVAILABLE)
         return _mm512_sllv_epi16(lhs, rhs);
 #else
-        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int16_t val, int16_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -516,7 +516,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512BW_AVAILABLE)
         return _mm512_srav_epi16(lhs, rhs);
 #else
-        return avx512_detail::shift_impl([](int16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int16_t val, int16_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
@@ -564,7 +564,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512BW_AVAILABLE)
         return _mm512_sllv_epi16(lhs, rhs);
 #else
-        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](uint16_t val, int16_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -573,7 +573,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512BW_AVAILABLE)
         return _mm512_srlv_epi16(lhs, rhs);
 #else
-        return avx512_detail::shift_impl([](uint16_t val, int16_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](uint16_t val, int16_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -497,18 +497,18 @@ namespace xsimd
 #endif
         return _mm512_or_si512(cmp_sign_mask, _mm512_andnot_si512(sign_mask, res));
 #else
-        return avx512_detail::shift_impl([](int8_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int8_t val, int32_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
     inline batch<int8_t, 64> operator<<(const batch<int8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
     {
-        return avx512_detail::shift_impl([](int8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int8_t val, int8_t s) { return val << s; }, lhs, rhs);
     }
 
     inline batch<int8_t, 64> operator>>(const batch<int8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
     {
-        return avx512_detail::shift_impl([](int8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](int8_t val, int8_t s) { return val >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(int8_t, 64, 64)
@@ -536,12 +536,12 @@ namespace xsimd
 
     inline batch<uint8_t, 64> operator<<(const batch<uint8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
     {
-        return avx512_detail::shift_impl([](uint8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](uint8_t val, int8_t s) { return val << s; }, lhs, rhs);
     }
 
     inline batch<uint8_t, 64> operator>>(const batch<uint8_t, 64>& lhs, const batch<int8_t, 64>& rhs)
     {
-        return avx512_detail::shift_impl([](uint8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx512_detail::shift_impl([](uint8_t val, int8_t s) { return val >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 64, 64)

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -500,7 +500,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512VL_AVAILABLE)
         return _mm256_srai_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](int64_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int64_t val, int32_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
@@ -509,7 +509,7 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_sllv_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int64_t val, int64_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -518,7 +518,7 @@ namespace xsimd
 #if defined(XSIMD_AVX512VL_AVAILABLE)
         return _mm256_srav_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](int64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int64_t val, int64_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
@@ -551,7 +551,7 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_sllv_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](uint64_t val, int64_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -560,7 +560,7 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_srlv_epi64(lhs, rhs);
 #else
-        return avx_detail::shift_impl([](uint64_t val, int64_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](uint64_t val, int64_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 }

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -410,7 +410,7 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_and_si256(_mm256_set1_epi8(0xFF << rhs), _mm256_slli_epi32(lhs, rhs));
 #else
-        return avx_detail::shift_impl([](int8_t val, int32_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int8_t val, int32_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -422,18 +422,18 @@ namespace xsimd
         __m256i res = _mm256_srai_epi16(lhs, rhs);
         return _mm256_or_si256(_mm256_and_si256(sign_mask, cmp_is_negative), _mm256_andnot_si256(sign_mask, res));
 #else
-        return avx_detail::shift_impl([](int8_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int8_t val, int32_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
     inline batch<int8_t, 32> operator<<(const batch<int8_t, 32>& lhs, const batch<int8_t, 32>& rhs)
     {
-        return avx_detail::shift_impl([](int8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int8_t val, int8_t s) { return val << s; }, lhs, rhs);
     }
 
     inline batch<int8_t, 32> operator>>(const batch<int8_t, 32>& lhs, const batch<int8_t, 32>& rhs)
     {
-        return avx_detail::shift_impl([](int8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int8_t val, int8_t s) { return val >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(int8_t, 32, 32)
@@ -444,7 +444,7 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_and_si256(_mm256_set1_epi8(0xFF << rhs), _mm256_slli_epi32(lhs, rhs));
 #else
-        return avx_detail::shift_impl([](int8_t val, int32_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](int8_t val, int32_t s) { return val << s; }, lhs, rhs);
 #endif
     }
 
@@ -453,18 +453,18 @@ namespace xsimd
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
         return _mm256_and_si256(_mm256_set1_epi8(0xFF >> rhs), _mm256_srli_epi32(lhs, rhs));
 #else
-        return avx_detail::shift_impl([](uint8_t val, int32_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](uint8_t val, int32_t s) { return val >> s; }, lhs, rhs);
 #endif
     }
 
     inline batch<uint8_t, 32> operator<<(const batch<uint8_t, 32>& lhs, const batch<int8_t, 32>& rhs)
     {
-        return avx_detail::shift_impl([](uint8_t val, int8_t rhs) { return val << rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](uint8_t val, int8_t s) { return val << s; }, lhs, rhs);
     }
 
     inline batch<uint8_t, 32> operator>>(const batch<uint8_t, 32>& lhs, const batch<int8_t, 32>& rhs)
     {
-        return avx_detail::shift_impl([](uint8_t val, int8_t rhs) { return val >> rhs; }, lhs, rhs);
+        return avx_detail::shift_impl([](uint8_t val, int8_t s) { return val >> s; }, lhs, rhs);
     }
 
     XSIMD_DEFINE_LOAD_STORE_INT8(uint8_t, 32, 32)


### PR DESCRIPTION
Fix warnings using either `$ g++ -Wshadow=compatible-local` or `$ clang++ -Wshadow-uncaptured-local`.
```bash
[...]/include/xsimd/types/xsimd_avx_int8.hpp:413:62: warning: declaration of ‘int32_t rhs’ shadows a parameter [-Wshadow=compatible-local]
  413 |         return avx_detail::shift_impl([](int8_t val, int32_t rhs) { return val << rhs; }, lhs, rhs);
      |                                                      ~~~~~~~~^~~
[...]/include/xsimd/types/xsimd_avx_int8.hpp:408:79: note: shadowed declaration is here
  408 |     inline batch<int8_t, 32> operator<<(const batch<int8_t, 32>& lhs, int32_t rhs)
      |                                                                       ~~~~~~~~^~~
```