### PR TITLE
Fix build issue in Arm64 for missing the angle bracket

### DIFF
--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -675,7 +675,7 @@ namespace xsimd
 #endif
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
                                      ,
-                                     batch<std::complex<double, 2>
+                                     batch<std::complex<double>, 2>
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
                                      ,
                                      batch<xtl::xcomplex<double>, 2>


### PR DESCRIPTION
Missing angle bracket and failed to build on Arm64 when `-DBUILD_TESTS=ON`:

```
In file included from /home/linux/yuqi/xsimd/test/test_algorithms.cpp:12:
/home/linux/yuqi/xsimd/test/test_utils.hpp:678:38: error: template argument 2 is invalid
  678 |                                      batch<std::complex<double, 2>
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  679 | #ifdef XSIMD_ENABLE_XTL_COMPLEX
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  680 |                                      ,
      |                                      ~
  681 |                                      batch<xtl::xcomplex<double>, 2>
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  682 | #endif
      | ~~~~~~
  683 | #endif
      | ~~~~~~
  684 |     >;
      |     ~
```
