### PR TITLE
Provide batch_constant and batch_bool_constant, and use them to speci…

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,6 +77,7 @@ This software is licensed under the BSD-3-Clause license. See the LICENSE file f
    api/instr_macros
    api/batch_index
    api/data_transfer
+   api/batch_manip
    api/math_index
    api/aligned_allocator
 

--- a/include/xsimd/types/xsimd_avx512_int_base.hpp
+++ b/include/xsimd/types/xsimd_avx512_int_base.hpp
@@ -114,43 +114,62 @@ namespace xsimd
 
     namespace avx512_detail
     {
-        template<class Tup, std::size_t... Is>
-        __m512i revert_args_set_epi8(Tup&& t, detail::index_sequence<Is...>)
+        inline __m512i int_init(std::integral_constant<std::size_t, 1>,
+                         int8_t t0, int8_t t1, int8_t t2, int8_t t3,
+                         int8_t t4, int8_t t5, int8_t t6, int8_t t7,
+                         int8_t t8, int8_t t9, int8_t t10, int8_t t11,
+                         int8_t t12, int8_t t13, int8_t t14, int8_t t15,
+                         int8_t t16, int8_t t17, int8_t t18, int8_t t19,
+                         int8_t t20, int8_t t21, int8_t t22, int8_t t23,
+                         int8_t t24, int8_t t25, int8_t t26, int8_t t27,
+                         int8_t t28, int8_t t29, int8_t t30, int8_t t31,
+                         int8_t t32, int8_t t33, int8_t t34, int8_t t35,
+                         int8_t t36, int8_t t37, int8_t t38, int8_t t39,
+                         int8_t t40, int8_t t41, int8_t t42, int8_t t43,
+                         int8_t t44, int8_t t45, int8_t t46, int8_t t47,
+                         int8_t t48, int8_t t49, int8_t t50, int8_t t51,
+                         int8_t t52, int8_t t53, int8_t t54, int8_t t55,
+                         int8_t t56, int8_t t57, int8_t t58, int8_t t59,
+                         int8_t t60, int8_t t61, int8_t t62, int8_t t63)
         {
-            // funny, this instruction is not yet implemented in clang or gcc (will come in future versions)
 #if defined(__clang__) || __GNUC__
             return __extension__ (__m512i)(__v64qi)
             {
-                static_cast<char>(std::get<Is>(std::forward<Tup>(t)))...
+              t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15,
+              t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28, t29, t30, t31,
+              t32, t33, t34, t35, t36, t37, t38, t39, t40, t41, t42, t43, t44, t45, t46, t47,
+              t48, t49, t50, t51, t52, t53, t54, t55, t56, t57, t58, t59, t60, t61, t62, t63
             };
 #else
-            return _mm512_set_epi8(static_cast<char>(std::get<Is>(std::forward<Tup>(t)))...);
+            return _mm512_set_epi8(
+              t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15,
+              t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28, t29, t30, t31,
+              t32, t33, t34, t35, t36, t37, t38, t39, t40, t41, t42, t43, t44, t45, t46, t47,
+              t48, t49, t50, t51, t52, t53, t54, t55, t56, t57, t58, t59, t60, t61, t62, t63);
 #endif
         }
 
-        template<class Tup, std::size_t... Is>
-        __m512i revert_args_set_epi16(Tup&& t, detail::index_sequence<Is...>)
+        inline __m512i int_init(std::integral_constant<std::size_t, 2>,
+                         int16_t t0, int16_t t1, int16_t t2, int16_t t3,
+                         int16_t t4, int16_t t5, int16_t t6, int16_t t7,
+                         int16_t t8, int16_t t9, int16_t t10, int16_t t11,
+                         int16_t t12, int16_t t13, int16_t t14, int16_t t15,
+                         int16_t t16, int16_t t17, int16_t t18, int16_t t19,
+                         int16_t t20, int16_t t21, int16_t t22, int16_t t23,
+                         int16_t t24, int16_t t25, int16_t t26, int16_t t27,
+                         int16_t t28, int16_t t29, int16_t t30, int16_t t31)
         {
 #if defined(__clang__) || __GNUC__
             return __extension__ (__m512i)(__v32hi)
             {
-                static_cast<short>(std::get<Is>(std::forward<Tup>(t)))...
+              t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15,
+              t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28, t29, t30, t31
             };
 #else
-            return _mm512_set_epi16(static_cast<short>(std::get<Is>(std::forward<Tup>(t)))...);
+            return _mm512_set_epi16(
+              t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15,
+              t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28, t29, t30, t31);
 #endif
-        }
-
-        template <class... Args>
-        __m512i int_init(std::integral_constant<std::size_t, 1>, Args... args)
-        {
-            return revert_args_set_epi8(std::forward_as_tuple(args...), detail::make_index_sequence<sizeof...(Args)>{});
-        }
-
-        template <class... Args>
-        __m512i int_init(std::integral_constant<std::size_t, 2>, Args... args)
-        {
-            return revert_args_set_epi16(std::forward_as_tuple(args...), detail::make_index_sequence<sizeof...(Args)>{});
         }
 
         inline __m512i int_init(std::integral_constant<std::size_t, 4>,

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -658,6 +658,13 @@ namespace xsimd
                 return _mm256_blendv_pd(b, a, cond);
             }
 
+            template<bool... Values>
+            static batch_type select(const batch_bool_constant<value_type, Values...>&, const batch_type& a, const batch_type& b)
+            {
+                constexpr int mask = batch_bool_constant<value_type, Values...>::mask();
+                return _mm256_blend_pd(b, a, mask);
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm256_cmp_pd(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -706,6 +706,13 @@ namespace xsimd
                 return _mm256_blendv_ps(b, a, cond);
             }
 
+            template<bool... Values>
+            static batch_type select(const batch_bool_constant<value_type, Values...>& cond, const batch_type& a, const batch_type& b)
+            {
+                constexpr int mask = batch_bool_constant<value_type, Values...>::mask();
+                return _mm256_blend_ps(b, a, mask);
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm256_cmp_ps(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -25,6 +25,7 @@
 #include "../memory/xsimd_alignment.hpp"
 #include "xsimd_utils.hpp"
 #include "xsimd_base_bool.hpp"
+#include "xsimd_base_constant.hpp"
 
 namespace xsimd
 {
@@ -212,7 +213,7 @@ namespace xsimd
         simd_batch(simd_batch&&) = default;
         simd_batch& operator=(simd_batch&&) = default;
 
-        simd_batch(storage_type value);
+        constexpr simd_batch(storage_type value);
 
         using char_itype =
             typename std::conditional<std::is_signed<char>::value, int8_t, uint8_t>::type;
@@ -671,7 +672,7 @@ namespace xsimd
      *****************************/
 
     template <class X>
-    inline simd_batch<X>::simd_batch(storage_type value)
+    constexpr inline simd_batch<X>::simd_batch(storage_type value)
         : m_value(value)
     {
     }
@@ -1698,6 +1699,28 @@ namespace xsimd
         using value_type = typename simd_batch_traits<X>::value_type;
         using kernel = detail::batch_kernel<value_type, simd_batch_traits<X>::size>;
         return kernel::select(cond(), a(), b());
+    }
+
+    /**
+     * @ingroup simd_batch_miscellaneous
+     *
+     * Ternary operator for batches: selects values from the batches \c a or \c b
+     * depending on the boolean values in the constant batch \c cond. Equivalent to
+     * \code{.cpp}
+     * for(std::size_t i = 0; i < N; ++i)
+     *     res[i] = cond[i] ? a[i] : b[i];
+     * \endcode
+     * @param cond constant batch condition.
+     * @param a batch values for truthy condition.
+     * @param b batch value for falsy condition.
+     * @return the result of the selection.
+     */
+    template <class X, bool... Masks>
+    inline batch_type_t<X> select(const batch_bool_constant<typename simd_batch_traits<X>::value_type, Masks...>& cond, const simd_base<X>& a, const simd_base<X>& b)
+    {
+        using value_type = typename simd_batch_traits<X>::value_type;
+        using kernel = detail::batch_kernel<value_type, simd_batch_traits<X>::size>;
+        return kernel::select(cond, a(), b());
     }
 
     /**

--- a/include/xsimd/types/xsimd_base_constant.hpp
+++ b/include/xsimd/types/xsimd_base_constant.hpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+* Copyright (c) Serge Guelton                                              *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XSIMD_BASE_CONSTANT_HPP
+#define XSIMD_BASE_CONSTANT_HPP
+
+namespace xsimd
+{
+    template <class X>
+    class simd_base;
+
+    template <class T, bool... Values>
+    struct batch_bool_constant
+    {
+        static constexpr std::size_t size = sizeof...(Values);
+        using value_type = bool;
+        using batch_type =
+            typename simd_batch_traits<batch<T, size>>::batch_bool_type;
+
+        batch_type operator()() const { return *this; }
+
+        operator batch_type() const { return {Values...}; }
+
+        bool operator[](size_t i) const
+        {
+            return std::array<value_type, size>{Values...}[i];
+        }
+        static constexpr int mask()
+        {
+            return mask_helper(0, static_cast<int>(Values)...);
+        }
+
+      private:
+        static constexpr int mask_helper(int acc) { return acc; }
+        template <class... Tys>
+        static constexpr int mask_helper(int acc, int mask, Tys... masks)
+        {
+            return mask_helper(acc | mask, (masks << 1)...);
+        }
+    };
+
+    template <class T, T... Values>
+    struct batch_constant
+    {
+        static constexpr std::size_t size = sizeof...(Values);
+        using value_type = T;
+        using batch_type = batch<T, size>;
+
+        batch_type operator()() const { return *this; }
+
+        operator batch_type() const { return {Values...}; }
+
+        constexpr T operator[](size_t i) const
+        {
+            return std::array<value_type, size>{Values...}[i];
+        }
+    };
+
+    namespace detail
+    {
+        template <class G, std::size_t... Is>
+        constexpr auto make_batch_constant(detail::index_sequence<Is...>)
+            -> batch_constant<decltype(G::get(0, 0)),
+                              G::get(Is, sizeof...(Is))...>
+        {
+            return {};
+        }
+        template <class T, class G, std::size_t... Is>
+        constexpr auto make_batch_bool_constant(detail::index_sequence<Is...>)
+            -> batch_bool_constant<T, G::get(Is, sizeof...(Is))...>
+        {
+            return {};
+        }
+        template <class T, T value, std::size_t... Is>
+        constexpr auto make_batch_constant(detail::index_sequence<Is...>)
+            -> batch_constant<T, (Is, value)...>
+        {
+            return {};
+        }
+        template <class T, T value, std::size_t... Is>
+        constexpr auto make_batch_bool_constant(detail::index_sequence<Is...>)
+            -> batch_bool_constant<T, (Is, value)...>
+        {
+            return {};
+        }
+    } // namespace detail
+
+    template <class G, std::size_t N>
+    constexpr auto make_batch_constant() -> decltype(
+        detail::make_batch_constant<G>(detail::make_index_sequence<N>()))
+    {
+        return detail::make_batch_constant<G>(detail::make_index_sequence<N>());
+    }
+
+    template <class T, class G, std::size_t N>
+    constexpr auto make_batch_bool_constant()
+        -> decltype(detail::make_batch_bool_constant<T, G>(
+            detail::make_index_sequence<N>()))
+    {
+        return detail::make_batch_bool_constant<T, G>(
+            detail::make_index_sequence<N>());
+    }
+
+} // namespace xsimd
+
+#endif

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -917,6 +917,12 @@ namespace xsimd
                 XSIMD_FALLBACK_MAPPING_LOOP(batch, (cond[i] ? a[i] : b[i]))
             }
 
+            template<bool... Values>
+            static batch_type select(const batch_bool_constant<value_type, Values...>& cond, const batch_type& a, const batch_type& b)
+            {
+                XSIMD_FALLBACK_MAPPING_LOOP(batch, (cond[i] ? a[i] : b[i]))
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 XSIMD_FALLBACK_MAPPING_LOOP(batch_bool, std::isnan(x[i]))

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -629,6 +629,17 @@ namespace xsimd
 #endif
             }
 
+            template<bool... Values>
+            static batch_type select(const batch_bool_constant<value_type, Values...>& cond, const batch_type& a, const batch_type& b)
+            {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE4_1_VERSION
+                constexpr int mask = batch_bool_constant<value_type, Values...>::mask();
+                return _mm_blend_pd(b, a, mask);
+#else
+                return select(cond(), a, b);
+#endif
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm_cmpunord_pd(x, x);

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -692,6 +692,18 @@ namespace xsimd
 #endif
             }
 
+            template<bool... Values>
+            static batch_type select(const batch_bool_constant<value_type, Values...>& cond, const batch_type& a, const batch_type& b)
+            {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSE4_1_VERSION
+                (void)cond;
+                constexpr int mask = batch_bool_constant<value_type, Values...>::mask();
+                return _mm_blend_ps(b, a, mask);
+#else
+                return select((batch_bool_type)cond, a, b);
+#endif
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm_cmpunord_ps(x, x);

--- a/include/xsimd/types/xsimd_sse_int_base.hpp
+++ b/include/xsimd/types/xsimd_sse_int_base.hpp
@@ -70,7 +70,7 @@ namespace xsimd
         sse_int_batch();
         explicit sse_int_batch(T i);
         template <class... Args, class Enable = detail::is_array_initializer_t<T, N, Args...>>
-        sse_int_batch(Args... args);
+        constexpr sse_int_batch(Args... args);
         explicit sse_int_batch(const T* src);
         sse_int_batch(const T* src, aligned_mode);
         sse_int_batch(const T* src, unaligned_mode);
@@ -324,7 +324,7 @@ namespace xsimd
 
     template <class T, std::size_t N>
     template <class... Args, class>
-    inline sse_int_batch<T, N>::sse_int_batch(Args... args)
+    constexpr inline sse_int_batch<T, N>::sse_int_batch(Args... args)
         : base_type(sse_detail::int_init(std::integral_constant<std::size_t, sizeof(T)>{}, args...))
     {
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,6 +152,7 @@ set(XSIMD_TESTS
     test_batch_float.cpp
     test_batch_int.cpp
     test_bitwise_cast.cpp
+    test_constant_batch.cpp
     test_complex_exponential.cpp
     test_complex_hyperbolic.cpp
     test_complex_power.cpp
@@ -166,6 +167,7 @@ set(XSIMD_TESTS
     test_poly_evaluation.cpp
     test_power.cpp
     test_rounding.cpp
+    test_select.cpp
     test_trigonometric.cpp
     test_utils.hpp
     #[[    xsimd_api_test.hpp

--- a/test/test_constant_batch.cpp
+++ b/test/test_constant_batch.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+ * Copyright (c) Serge Guelton * Copyright (c) QuantStack *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+
+#include "test_utils.hpp"
+
+using namespace std::placeholders;
+
+template <class B>
+class constant_batch_test : public testing::Test
+{
+  protected:
+    using batch_type = B;
+    using value_type = typename B::value_type;
+    static constexpr size_t size = B::size;
+    using array_type = std::array<value_type, size>;
+    using bool_array_type = std::array<bool, size>;
+
+    struct generator
+    {
+        static constexpr value_type get(size_t index, size_t /*size*/)
+        {
+            return index % 2 ? 0 : 1;
+        }
+    };
+
+    void test_init_from_generator() const
+    {
+        array_type expected;
+        size_t i = 0;
+        std::generate(expected.begin(), expected.end(),
+                      [&i]() { return generator::get(i++, size); });
+        constexpr auto b = xsimd::make_batch_constant<generator, size>();
+        EXPECT_BATCH_EQ(b(), expected)
+            << print_function_name("batch(value_type)");
+    }
+
+    struct arange
+    {
+        static constexpr value_type get(size_t index, size_t /*size*/)
+        {
+            return index;
+        }
+    };
+
+    void test_init_from_generator_arange() const
+    {
+        array_type expected;
+        size_t i = 0;
+        std::generate(expected.begin(), expected.end(),
+                      [&i]() { return arange::get(i++, size); });
+        constexpr auto b = xsimd::make_batch_constant<arange, size>();
+        EXPECT_BATCH_EQ(b(), expected)
+            << print_function_name("batch(value_type)");
+    }
+
+    struct constant
+    {
+        static constexpr value_type get(size_t /*index*/, size_t /*size*/)
+        {
+            return 3;
+        }
+    };
+
+    void test_init_from_constant() const
+    {
+        array_type expected;
+        std::fill(expected.begin(), expected.end(), constant::get(0, 0));
+        constexpr auto b = xsimd::make_batch_constant<constant, size>();
+        EXPECT_BATCH_EQ(b(), expected)
+            << print_function_name("batch(value_type)");
+    }
+};
+
+TYPED_TEST_SUITE(constant_batch_test, batch_int_types, simd_test_names);
+
+TYPED_TEST(constant_batch_test, init_from_generator)
+{
+    this->test_init_from_generator();
+}
+
+TYPED_TEST(constant_batch_test, init_from_generator_arange)
+{
+    this->test_init_from_generator_arange();
+}
+
+TYPED_TEST(constant_batch_test, init_from_constant)
+{
+    this->test_init_from_constant();
+}
+
+template <class B>
+class constant_bool_batch_test : public testing::Test
+{
+  protected:
+    using batch_type = B;
+    using value_type = typename B::value_type;
+    static constexpr size_t size = B::size;
+    using array_type = std::array<value_type, size>;
+    using bool_array_type = std::array<bool, size>;
+
+    struct generator
+    {
+        static constexpr bool get(size_t index, size_t /*size*/)
+        {
+            return index % 2;
+        }
+    };
+
+    void test_init_from_generator() const
+    {
+        bool_array_type expected;
+        size_t i = 0;
+        std::generate(expected.begin(), expected.end(),
+                      [&i]() { return generator::get(i++, size); });
+        constexpr auto b =
+            xsimd::make_batch_bool_constant<value_type, generator, size>();
+        EXPECT_BATCH_EQ(b(), expected)
+            << print_function_name("batch_bool_constant(value_type)");
+    }
+
+    struct split
+    {
+        static constexpr bool get(size_t index, size_t size)
+        {
+            return index < size / 2;
+        }
+    };
+
+    void test_init_from_generator_split() const
+    {
+        bool_array_type expected;
+        size_t i = 0;
+        std::generate(expected.begin(), expected.end(),
+                      [&i]() { return split::get(i++, size); });
+        constexpr auto b =
+            xsimd::make_batch_bool_constant<value_type, split, size>();
+        EXPECT_BATCH_EQ(b(), expected)
+            << print_function_name("batch_bool_constant(value_type)");
+    }
+};
+
+TYPED_TEST_SUITE(constant_bool_batch_test, batch_int_types, simd_test_names);
+
+TYPED_TEST(constant_bool_batch_test, init_from_generator)
+{
+    this->test_init_from_generator();
+}
+
+TYPED_TEST(constant_bool_batch_test, init_from_generator_split)
+{
+    this->test_init_from_generator_split();
+}

--- a/test/test_select.cpp
+++ b/test/test_select.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+ * Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+ * Martin Renou                                                             *
+ * Copyright (c) QuantStack                                                 *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+
+#include "test_utils.hpp"
+
+template <class B>
+class select_test : public testing::Test
+{
+  protected:
+    using batch_type = B;
+    using value_type = typename B::value_type;
+    static constexpr size_t size = B::size;
+    using vector_type = std::vector<value_type>;
+
+    size_t nb_input;
+    vector_type lhs_input;
+    vector_type rhs_input;
+    vector_type expected;
+    vector_type res;
+
+    select_test()
+    {
+        nb_input = size * 10000;
+        lhs_input.resize(nb_input);
+        rhs_input.resize(nb_input);
+        for (size_t i = 0; i < nb_input; ++i)
+        {
+            lhs_input[i] = value_type(i) / 4 +
+                           value_type(1.2) * std::sqrt(value_type(i + 0.25));
+            rhs_input[i] = value_type(10.2) / (i + 2) + value_type(0.25);
+        }
+        expected.resize(nb_input);
+        res.resize(nb_input);
+    }
+
+    void test_select_dynamic()
+    {
+        for (size_t i = 0; i < nb_input; ++i)
+        {
+            expected[i] =
+                lhs_input[i] > value_type(3) ? lhs_input[i] : rhs_input[i];
+        }
+
+        batch_type lhs_in, rhs_in, out;
+        for (size_t i = 0; i < nb_input; i += size)
+        {
+            detail::load_batch(lhs_in, lhs_input, i);
+            detail::load_batch(rhs_in, rhs_input, i);
+            out = xsimd::select(lhs_in > value_type(3), lhs_in, rhs_in);
+            detail::store_batch(out, res, i);
+        }
+        size_t diff = detail::get_nb_diff(res, expected);
+        EXPECT_EQ(diff, 0) << print_function_name("pow");
+    }
+    struct pattern
+    {
+        static constexpr bool get(std::size_t i, std::size_t) { return i % 2; }
+    };
+
+    void test_select_static()
+    {
+        constexpr auto mask =
+            xsimd::make_batch_bool_constant<value_type, pattern, size>();
+
+        for (size_t i = 0; i < nb_input; ++i)
+        {
+            expected[i] = mask[i % size] ? lhs_input[i] : rhs_input[i];
+        }
+
+        batch_type lhs_in, rhs_in, out;
+        for (size_t i = 0; i < nb_input; i += size)
+        {
+            detail::load_batch(lhs_in, lhs_input, i);
+            detail::load_batch(rhs_in, rhs_input, i);
+            out = xsimd::select(mask, lhs_in, rhs_in);
+            detail::store_batch(out, res, i);
+        }
+        size_t diff = detail::get_nb_diff(res, expected);
+        EXPECT_EQ(diff, 0) << print_function_name("pow");
+    }
+};
+
+TYPED_TEST_SUITE(select_test, batch_types, simd_test_names);
+
+TYPED_TEST(select_test, select_dynamic) { this->test_select_dynamic(); }
+TYPED_TEST(select_test, select_static) { this->test_select_static(); }


### PR DESCRIPTION
…alize the select function

in SSE4 and AVX, it's possible to pass an immediate to the blending intrinsic
instead of a register. Provide the required support in terms of batch_constant
and batch_bool_constant, and fallback to the vector version otherwise.