### PR TITLE
Fix segmentation fault on mingw

### DIFF
--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -229,7 +229,7 @@ int main()
     const float y1            = 1;
     const int maxIters        = 256;
 
-    alignas(64) std::vector<int> buf(width * height);
+    std::vector<int, xsimd::aligned_allocator<int, XSIMD_DEFAULT_ALIGNMENT>> buf(width * height);
 
     auto bencher = pico_bench::Benchmarker<milliseconds>{64, seconds{10}};
 

--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "pico_bench.hpp"
 
@@ -228,7 +229,7 @@ int main()
     const float y1            = 1;
     const int maxIters        = 256;
 
-    static alignas(64) std::array<int, width * height> buf;
+    alignas(64) std::vector<int> buf(width * height);
 
     auto bencher = pico_bench::Benchmarker<milliseconds>{64, seconds{10}};
 

--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -228,7 +228,7 @@ int main()
     const float y1            = 1;
     const int maxIters        = 256;
 
-    alignas(64) std::array<int, width * height> buf;
+    static alignas(64) std::array<int, width * height> buf;
 
     auto bencher = pico_bench::Benchmarker<milliseconds>{64, seconds{10}};
 


### PR DESCRIPTION
On Windows, using msys2/mingw64 compiler, examples always crash with SEGV on ___chkstk_ms. This can be avoid with making static variable.
