### PR TITLE
Add zip_lo/hi test cases for shuffling 128bit data.

### DIFF
--- a/include/xsimd/types/xsimd_avx512_double.hpp
+++ b/include/xsimd/types/xsimd_avx512_double.hpp
@@ -536,6 +536,16 @@ namespace xsimd
             {
                 return _mm512_cmp_pd_mask(x, x, _CMP_UNORD_Q);
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_pd(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_pd(lhs, rhs);
+            }
         };
     }
 

--- a/include/xsimd/types/xsimd_avx512_float.hpp
+++ b/include/xsimd/types/xsimd_avx512_float.hpp
@@ -595,6 +595,16 @@ namespace xsimd
             #endif
             }
 
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_ps(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_ps(lhs, rhs);
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -331,6 +331,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_AVX(res_lo, res_hi);
             #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_epi16(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_epi16(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -244,6 +244,17 @@ namespace xsimd
             {
                 return _mm512_mask_blend_epi32(cond, b, a);
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_epi32(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_epi32(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -313,6 +313,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_AVX(res_lo, res_hi);
             #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_epi64(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_epi64(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -335,6 +335,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_AVX(res_lo, res_hi);
             #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpacklo_epi8(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm512_unpackhi_epi8(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -665,6 +665,17 @@ namespace xsimd
                 return _mm256_blend_pd(b, a, mask);
             }
 
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_pd(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_pd(lhs, rhs);
+            }
+
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm256_cmp_pd(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -713,6 +713,16 @@ namespace xsimd
                 return _mm256_blend_ps(b, a, mask);
             }
 
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_ps(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_ps(lhs, rhs);
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm256_cmp_ps(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -277,6 +277,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi16(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi16(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -332,6 +332,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi32(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi32(lhs, rhs);
+            }
+
         };
 
         template <>
@@ -498,6 +509,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi32(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi32(lhs, rhs);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -322,6 +322,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi64(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi64(lhs, rhs);
+            }
+
         };
 
         template <>
@@ -479,6 +490,16 @@ namespace xsimd
                 __m128i res_high = _mm_blendv_epi8(b_high, a_high, cond_high);
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
+            }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi64(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi64(lhs, rhs);
             }
         };
     }

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -312,6 +312,17 @@ namespace xsimd
                 XSIMD_RETURN_MERGED_SSE(res_low, res_high);
 #endif
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpacklo_epi8(lhs, rhs);
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                return _mm256_unpackhi_epi8(lhs, rhs);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -928,6 +928,28 @@ namespace xsimd
             {
                 XSIMD_FALLBACK_MAPPING_LOOP(batch_bool, std::isnan(x[i]))
             }
+
+            static batch_type zip_lo(const batch_type& lhs, const batch_type& rhs)
+            {
+                batch_type b_lo;
+                for (std::size_t i = 0, j = 0; i < N/2; ++i, j = j + 2)
+                {
+                    b_lo[j] = lhs[i];
+                    b_lo[j + 1] = rhs[i];
+                }
+                return b_lo;
+            }
+
+            static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
+            {
+                batch_type b_hi;
+                for (std::size_t i = 0, j = 0; i < N/2; ++i, j = j + 2)
+                {
+                    b_hi[j] = lhs[i + N/2];
+                    b_hi[j + 1] = rhs[i+ N/2];
+                }
+                return b_hi;
+            }
         };
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,7 @@ set(XSIMD_TESTS
     test_power.cpp
     test_rounding.cpp
     test_select.cpp
+    test_shuffle_128.cpp
     test_trigonometric.cpp
     test_utils.hpp
     #[[    xsimd_api_test.hpp

--- a/test/test_shuffle_128.cpp
+++ b/test/test_shuffle_128.cpp
@@ -62,12 +62,12 @@ class shuffle_128_test : public testing::Test
 
     void shuffle_128_low_high()
     {
-        auto shuffle_base = xsimd::init_shuffle_128_base<value_type, size>{};
+        xsimd::init_shuffle_128_base<value_type, size> shuffle_base;
         auto shuffle_base_vecs = shuffle_base.create_vectors();
-	    auto v_lhs = shuffle_base_vecs[0];
-	    auto v_rhs = shuffle_base_vecs[1];
-	    auto v_exp_lo = shuffle_base_vecs[2];
-	    auto v_exp_hi = shuffle_base_vecs[3];
+        auto v_lhs = shuffle_base_vecs[0];
+        auto v_rhs = shuffle_base_vecs[1];
+        auto v_exp_lo = shuffle_base_vecs[2];
+        auto v_exp_hi = shuffle_base_vecs[3];
 
         B b_lhs, b_rhs, b_exp_lo, b_exp_hi, b_res_lo, b_res_hi;
         b_lhs.load_unaligned(v_lhs.data());

--- a/test/test_shuffle_128.cpp
+++ b/test/test_shuffle_128.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *                                                                          *
+ * Copyright (c) QuantStack                                                 *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+#include "test_utils.hpp"
+
+namespace xsimd
+{
+    template <typename T, std::size_t N>
+    struct init_shuffle_128_base
+    {
+        using shuffle_vector_type = std::array<T, N>;
+        shuffle_vector_type lhs_in, rhs_in, exp_lo, exp_hi;
+
+        std::vector<shuffle_vector_type> create_vectors()
+        {
+            std::vector<shuffle_vector_type> vects;
+            vects.reserve(4);
+
+            /* Generate input data: lhs, rhs */
+            for (size_t i = 0; i < N; ++i)
+            {
+                lhs_in[i] = 2*i + 1;
+                rhs_in[i] = 2*i + 2;
+            }
+            vects.push_back(std::move(lhs_in));
+            vects.push_back(std::move(rhs_in));
+
+            /* Expected shuffle data */
+            for (size_t i = 0, j= 0; i < N/2; ++i, j=j+2)
+            {
+                exp_lo[j] = lhs_in[i];
+                exp_hi[j] = lhs_in[i + N/2];
+
+                exp_lo[j + 1] = rhs_in[i];
+                exp_hi[j + 1] = rhs_in[i + N/2];
+            }
+            vects.push_back(std::move(exp_lo));
+            vects.push_back(std::move(exp_hi));
+
+            return vects;
+        }
+    };
+}
+
+template <class B>
+class shuffle_128_test : public testing::Test
+{
+  protected:
+    using batch_type = B;
+    using value_type = typename B::value_type;
+    static constexpr size_t size = B::size;
+
+    shuffle_128_test()
+    {
+        std::cout << "shuffle-128 test" << std::endl;
+    }
+
+    void shuffle_128_low_high()
+    {
+        auto shuffle_base = xsimd::init_shuffle_128_base<value_type, size>{};
+        auto shuffle_base_vecs = shuffle_base.create_vectors();
+	    auto v_lhs = shuffle_base_vecs[0];
+	    auto v_rhs = shuffle_base_vecs[1];
+	    auto v_exp_lo = shuffle_base_vecs[2];
+	    auto v_exp_hi = shuffle_base_vecs[3];
+
+        B b_lhs, b_rhs, b_exp_lo, b_exp_hi, b_res_lo, b_res_hi;
+        b_lhs.load_unaligned(v_lhs.data());
+        b_rhs.load_unaligned(v_rhs.data());
+        b_exp_lo.load_unaligned(v_exp_lo.data());
+        b_exp_hi.load_unaligned(v_exp_hi.data());
+
+        /* Only Test 128bit */
+        if ((sizeof(value_type) * size) == 16)
+        {
+            b_res_lo = xsimd::zip_lo(b_lhs, b_rhs);
+            EXPECT_BATCH_EQ(b_res_lo, b_exp_lo) << print_function_name("shuffle-128 low test");
+
+            b_res_hi = xsimd::zip_hi(b_lhs, b_rhs);
+            EXPECT_BATCH_EQ(b_res_hi, b_exp_hi) << print_function_name("shuffle-128 high test");
+        }
+    }
+};
+
+TYPED_TEST_SUITE(shuffle_128_test, batch_types, simd_test_names);
+
+TYPED_TEST(shuffle_128_test, shuffle_128_low_high)
+{
+    this->shuffle_128_low_high();
+}


### PR DESCRIPTION
As discussed in https://github.com/xtensor-stack/xsimd/pull/434,
this PR is to add zip_lo/hi test cases.
The related test cases are implemented just for Neon/SSE(128bit).





