### PR TITLE
Add extract_pair for shifting 128bit data

### DIFF
--- a/include/xsimd/types/xsimd_avx512_double.hpp
+++ b/include/xsimd/types/xsimd_avx512_double.hpp
@@ -556,6 +556,21 @@ namespace xsimd
             {
                 return _mm512_unpackhi_pd(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_avx512_float.hpp
+++ b/include/xsimd/types/xsimd_avx512_float.hpp
@@ -615,6 +615,20 @@ namespace xsimd
                 return _mm512_unpackhi_ps(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (16 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -362,7 +362,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
                 return _mm512_alignr_epi8(rhs, lhs, 2*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (32 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[32 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -360,18 +360,28 @@ namespace xsimd
                 return _mm512_unpackhi_epi16(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512BW_AVAILABLE)
-                return _mm512_alignr_epi8(rhs, lhs, 2*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 2 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_64_v2(_mm512_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (32 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[32 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[32 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx512_int16.hpp
+++ b/include/xsimd/types/xsimd_avx512_int16.hpp
@@ -360,6 +360,11 @@ namespace xsimd
                 return _mm512_unpackhi_epi16(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm512_alignr_epi8(rhs, lhs, 2*n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -270,7 +270,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
                 return _mm512_alignr_epi32(rhs, lhs, n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (16 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -268,18 +268,27 @@ namespace xsimd
                 return _mm512_unpackhi_epi32(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int n)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
-                return _mm512_alignr_epi32(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_16_v2(_mm512_alignr_epi32);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
                 for (int i = 0 ; i < (16 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[16 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx512_int32.hpp
+++ b/include/xsimd/types/xsimd_avx512_int32.hpp
@@ -268,6 +268,11 @@ namespace xsimd
                 return _mm512_unpackhi_epi32(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm512_alignr_epi32(rhs, lhs, n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -337,6 +337,11 @@ namespace xsimd
                 return _mm512_unpackhi_epi64(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm512_alignr_epi64(rhs, lhs, n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -337,18 +337,27 @@ namespace xsimd
                 return _mm512_unpackhi_epi64(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int n)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
-                return _mm512_alignr_epi64(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_8_v2(_mm512_alignr_epi64);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
                 for (int i = 0 ; i < (8 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[8 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx512_int64.hpp
+++ b/include/xsimd/types/xsimd_avx512_int64.hpp
@@ -339,7 +339,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
                 return _mm512_alignr_epi64(rhs, lhs, n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -364,6 +364,11 @@ namespace xsimd
                 return _mm512_unpackhi_epi8(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm512_alignr_epi8(rhs, lhs, n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -364,18 +364,26 @@ namespace xsimd
                 return _mm512_unpackhi_epi8(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int n)
             {
 #if defined(XSIMD_AVX512BW_AVAILABLE)
-                return _mm512_alignr_epi8(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_64_v2(_mm512_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
                 for (int i = 0 ; i < (64 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[64 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[64 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx512_int8.hpp
+++ b/include/xsimd/types/xsimd_avx512_int8.hpp
@@ -366,7 +366,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512BW_AVAILABLE)
                 return _mm512_alignr_epi8(rhs, lhs, n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (64 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[64 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_double.hpp
+++ b/include/xsimd/types/xsimd_avx_double.hpp
@@ -685,6 +685,19 @@ namespace xsimd
                 return _mm256_unpackhi_pd(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (4 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
 
             static batch_bool_type isnan(const batch_type& x)
             {

--- a/include/xsimd/types/xsimd_avx_float.hpp
+++ b/include/xsimd/types/xsimd_avx_float.hpp
@@ -733,6 +733,20 @@ namespace xsimd
                 return _mm256_unpackhi_ps(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return _mm256_cmp_ps(x, x, _CMP_UNORD_Q);

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -308,7 +308,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
                 return _mm256_alignr_epi8(rhs, lhs, 2*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (16 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -306,18 +306,29 @@ namespace xsimd
                 return _mm256_unpackhi_epi16(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, 2*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 2 * num;
+
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (16 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[16 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx_int16.hpp
+++ b/include/xsimd/types/xsimd_avx_int16.hpp
@@ -306,6 +306,11 @@ namespace xsimd
                 return _mm256_unpackhi_epi16(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi8(rhs, lhs, 2*n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -357,21 +357,40 @@ namespace xsimd
                 return _mm256_unpackhi_epi32(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512VL_AVAILABLE)
-                return _mm256_alignr_epi32(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_8_v2(_mm256_alignr_epi32);
+                    default: break;
+                }
+                return batch_type(int32_t(0));
 #else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, 4*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 4 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(int32_t(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (8 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[8 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;
@@ -569,21 +588,40 @@ namespace xsimd
                 return _mm256_unpackhi_epi32(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512VL_AVAILABLE)
-                return _mm256_alignr_epi32(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_8_v2(_mm256_alignr_epi32);
+                    default: break;
+                }
+                return batch_type(uint32_t(0));
 #else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, 4*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 4 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(uint32_t(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (8 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[8 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -359,7 +359,24 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm256_alignr_epi32(rhs, lhs, n);
+#else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+                return _mm256_alignr_epi8(rhs, lhs, 4*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
+#endif
             }
 
         };
@@ -554,7 +571,24 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm256_alignr_epi32(rhs, lhs, n);
+#else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+                return _mm256_alignr_epi8(rhs, lhs, 4*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_int32.hpp
+++ b/include/xsimd/types/xsimd_avx_int32.hpp
@@ -357,6 +357,11 @@ namespace xsimd
                 return _mm256_unpackhi_epi32(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi32(rhs, lhs, n);
+            }
+
         };
 
         template <>
@@ -545,6 +550,11 @@ namespace xsimd
             static batch_type zip_hi(const batch_type& lhs, const batch_type& rhs)
             {
                 return _mm256_unpackhi_epi32(lhs, rhs);
+            }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi32(rhs, lhs, n);
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -348,6 +348,11 @@ namespace xsimd
                 return _mm256_unpackhi_epi64(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi64(rhs, lhs, n);
+            }
+
         };
 
         template <>
@@ -529,6 +534,12 @@ namespace xsimd
             {
                 return _mm256_unpackhi_epi64(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi64(rhs, lhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -350,7 +350,24 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm256_alignr_epi64(rhs, lhs, n);
+#else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+                return _mm256_alignr_epi8(rhs, lhs, 8*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (4 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
+#endif
             }
 
         };
@@ -537,7 +554,24 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm256_alignr_epi64(rhs, lhs, n);
+#else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+                return _mm256_alignr_epi8(rhs, lhs, 8*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (4 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_int64.hpp
+++ b/include/xsimd/types/xsimd_avx_int64.hpp
@@ -348,21 +348,40 @@ namespace xsimd
                 return _mm256_unpackhi_epi64(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512VL_AVAILABLE)
-                return _mm256_alignr_epi64(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_4(_mm256_alignr_epi64);
+                    default: break;
+                }
+                return batch_type(uint64_t(0));
 #else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, 8*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 8 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(uint64_t(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (4 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[4 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;
@@ -552,21 +571,40 @@ namespace xsimd
                 return _mm256_unpackhi_epi64(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512VL_AVAILABLE)
-                return _mm256_alignr_epi64(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_4(_mm256_alignr_epi64);
+                    default: break;
+                }
+                return batch_type(int64_t(0));
 #else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, 8*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 8 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(int64_t(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (4 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[4 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -343,7 +343,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
                 return _mm256_alignr_epi8(rhs, lhs, n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (32 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[32 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -341,6 +341,11 @@ namespace xsimd
                 return _mm256_unpackhi_epi8(lhs, rhs);
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm256_alignr_epi8(rhs, lhs, n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_avx_int8.hpp
+++ b/include/xsimd/types/xsimd_avx_int8.hpp
@@ -341,18 +341,26 @@ namespace xsimd
                 return _mm256_unpackhi_epi8(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int n)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
-                return _mm256_alignr_epi8(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_32_v2(_mm256_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
                 for (int i = 0 ; i < (32 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[32 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[32 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -289,6 +289,9 @@ namespace xsimd
     batch_type_t<X> zip_hi(const simd_base<X>& lhs, const simd_base<X>& rhs);
 
     template <class X>
+    batch_type_t<X> extract_pair(const simd_base<X>& lhs, const simd_base<X>& rhs, const int n);
+
+    template <class X>
     typename simd_batch_traits<X>::batch_bool_type
     isnan(const simd_base<X>& x);
 
@@ -1920,6 +1923,24 @@ namespace xsimd
         using value_type = typename simd_batch_traits<X>::value_type;
         using kernel = detail::batch_kernel<value_type, simd_batch_traits<X>::size>;
         return kernel::zip_hi(lhs(), rhs());
+    }
+
+    /**
+     * Extract vector from pair of vectors
+     * extracts the lowest vector elements from the second source \c rhs
+     * and the highest vector elements from the first source \c lhs
+     * The index: 'n' specifies the lowest vector element to extract from the first source register.
+     * Concatenates the results into th Return value.
+     * @param lhs a batch of integer or floating point or double precision values.
+     * @param rhs a batch of integer or floating point or double precision values.
+     * @return.
+     */
+    template <class X>
+    inline batch_type_t<X> extract_pair(const simd_base<X>& lhs, const simd_base<X>& rhs, const int index)
+    {
+        using value_type = typename simd_batch_traits<X>::value_type;
+        using kernel = detail::batch_kernel<value_type, simd_batch_traits<X>::size>;
+        return kernel::extract_pair(lhs(), rhs(), index);
     }
 
     /**

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -967,7 +967,7 @@ namespace xsimd
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
                 batch_type b_concatenate;
-                for (int i = 0 ; i < (N - n); ++i)
+                for (int i = 0 ; i < static_cast<int>(N - n); ++i)
                 {
                     b_concatenate[i] = lhs[i + n];
                     if(i < n)

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -962,6 +962,21 @@ namespace xsimd
                 }
                 return b_hi;
             }
+
+            /* 0 <= n <= N/2 */
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (N - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[N - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_bool.hpp
+++ b/include/xsimd/types/xsimd_neon_bool.hpp
@@ -13,53 +13,6 @@
 
 #include "xsimd_base.hpp"
 
-#define EXPAND(...) __VA_ARGS__
-
-#define CASE(op, i)                   \
-    case i: return op(lhs, i);
-
-#define XSIMD_REPEAT_8_0(op, addx)    \
-    CASE(EXPAND(op), 1 + addx);       \
-    CASE(EXPAND(op), 2 + addx);       \
-    CASE(EXPAND(op), 3 + addx);       \
-    CASE(EXPAND(op), 4 + addx);       \
-    CASE(EXPAND(op), 5 + addx);       \
-    CASE(EXPAND(op), 6 + addx);       \
-    CASE(EXPAND(op), 7 + addx);
-
-#define XSIMD_REPEAT_8_N(op, addx)    \
-    CASE(EXPAND(op), 0 + addx);       \
-    XSIMD_REPEAT_8_0(op, addx);
-
-#define XSIMD_REPEAT_8(op)            \
-    XSIMD_REPEAT_8_0(op, 0);
-
-#define XSIMD_REPEAT_16_0(op, addx)   \
-    XSIMD_REPEAT_8_0(op, 0 + addx);   \
-    XSIMD_REPEAT_8_N(op, 8 + addx);
-
-#define XSIMD_REPEAT_16_N(op, addx)   \
-    XSIMD_REPEAT_8_N(op, 0 + addx);   \
-    XSIMD_REPEAT_8_N(op, 8 + addx);
-
-#define XSIMD_REPEAT_16(op)           \
-    XSIMD_REPEAT_16_0(op, 0);
-
-#define XSIMD_REPEAT_32_0(op, addx)   \
-    XSIMD_REPEAT_16_0(op, 0 + addx);  \
-    XSIMD_REPEAT_16_N(op, 16 + addx);
-
-#define XSIMD_REPEAT_32_N(op, addx)   \
-    XSIMD_REPEAT_16_N(op, 0 + addx);  \
-    XSIMD_REPEAT_16_N(op, 16 + addx);
-
-#define XSIMD_REPEAT_32(op)           \
-    XSIMD_REPEAT_32_0(op, 0);
-
-#define XSIMD_REPEAT_64(op)           \
-    XSIMD_REPEAT_32_0(op, 0);         \
-    XSIMD_REPEAT_32_N(op, 32);
-
 namespace xsimd
 {
     /********************

--- a/include/xsimd/types/xsimd_neon_double.hpp
+++ b/include/xsimd/types/xsimd_neon_double.hpp
@@ -608,6 +608,15 @@ namespace xsimd
 #endif
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+#if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
+                return vextq_f64(lhs, rhs, n);
+#else
+                return vcombine_f64(vget_high_f64(lhs), vget_low_f64(rhs));
+#endif
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return !(x == x);

--- a/include/xsimd/types/xsimd_neon_double.hpp
+++ b/include/xsimd/types/xsimd_neon_double.hpp
@@ -611,7 +611,13 @@ namespace xsimd
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
-                return vextq_f64(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_2(vextq_f64);
+                    default: break;
+                }
+                return batch_type(double(0));
 #else
                 return vcombine_f64(vget_high_f64(lhs), vget_low_f64(rhs));
 #endif

--- a/include/xsimd/types/xsimd_neon_float.hpp
+++ b/include/xsimd/types/xsimd_neon_float.hpp
@@ -671,7 +671,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_f32(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_4(vextq_f32);
+                    default: break;
+                }
+                return batch_type(float(0));
             }
 
             static batch_bool_type isnan(const batch_type& x)

--- a/include/xsimd/types/xsimd_neon_float.hpp
+++ b/include/xsimd/types/xsimd_neon_float.hpp
@@ -669,6 +669,11 @@ namespace xsimd
 #endif
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_f32(lhs, rhs, n);
+            }
+
             static batch_bool_type isnan(const batch_type& x)
             {
                 return !(x == x);

--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -377,7 +377,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_s16(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_8_v2(vextq_s16);
+                    default: break;
+                }
+                return batch_type(int16_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_int16.hpp
+++ b/include/xsimd/types/xsimd_neon_int16.hpp
@@ -374,6 +374,12 @@ namespace xsimd
                 return vcombine_s16(tmp.val[0], tmp.val[1]);
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_s16(lhs, rhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -457,7 +457,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_s32(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_4(vextq_s32);
+                    default: break;
+                }
+                return batch_type(int32_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_int32.hpp
+++ b/include/xsimd/types/xsimd_neon_int32.hpp
@@ -454,6 +454,12 @@ namespace xsimd
                 return vcombine_s32(tmp.val[0], tmp.val[1]);
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_s32(lhs, rhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -470,7 +470,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_s64(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_2(vextq_s64);
+                    default: break;
+                }
+                return batch_type(int64_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_int64.hpp
+++ b/include/xsimd/types/xsimd_neon_int64.hpp
@@ -467,6 +467,12 @@ namespace xsimd
                 return vcombine_s64(vget_high_s64(lhs), vget_high_s64(rhs));
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_s64(lhs, rhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -378,7 +378,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_s8(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_16_v2(vextq_s8);
+                    default: break;
+                }
+                return batch_type(int8_t(0));
             }
         };
     }

--- a/include/xsimd/types/xsimd_neon_int8.hpp
+++ b/include/xsimd/types/xsimd_neon_int8.hpp
@@ -375,6 +375,11 @@ namespace xsimd
                 return vcombine_s8(tmp.val[0], tmp.val[1]);
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_s8(lhs, rhs, n);
+            }
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -351,7 +351,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_u16(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_8_v2(vextq_u16);
+                    default: break;
+                }
+                return batch_type(uint16_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_uint16.hpp
+++ b/include/xsimd/types/xsimd_neon_uint16.hpp
@@ -348,6 +348,12 @@ namespace xsimd
                 return vcombine_u16(tmp.val[0], tmp.val[1]);
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_u16(lhs, rhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_uint32.hpp
+++ b/include/xsimd/types/xsimd_neon_uint32.hpp
@@ -447,7 +447,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_u32(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_4(vextq_u32);
+                    default: break;
+                }
+                return batch_type(uint32_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_uint32.hpp
+++ b/include/xsimd/types/xsimd_neon_uint32.hpp
@@ -445,6 +445,11 @@ namespace xsimd
 #endif
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_u32(lhs, rhs, n);
+            }
+
         };
 
         inline batch<uint32_t, 4> shift_left(const batch<uint32_t, 4>& lhs, int32_t n)

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -496,6 +496,11 @@ namespace xsimd
 #endif
             }
 
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_u64(lhs, rhs, n);
+            }
+
         };
 
         inline batch<uint64_t, 2> shift_left(const batch<uint64_t, 2>& lhs, int32_t n)

--- a/include/xsimd/types/xsimd_neon_uint64.hpp
+++ b/include/xsimd/types/xsimd_neon_uint64.hpp
@@ -498,7 +498,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_u64(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_2(vextq_u64);
+                    default: break;
+                }
+                return batch_type(uint64_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -349,6 +349,12 @@ namespace xsimd
                 return vcombine_u8(tmp.val[0], tmp.val[1]);
 #endif
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return vextq_u8(lhs, rhs, n);
+            }
+
         };
     }
 

--- a/include/xsimd/types/xsimd_neon_uint8.hpp
+++ b/include/xsimd/types/xsimd_neon_uint8.hpp
@@ -352,7 +352,13 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return vextq_u8(lhs, rhs, n);
+                switch(n)
+                {
+                    case 0: return lhs;
+                    XSIMD_REPEAT_16_v2(vextq_u8);
+                    default: break;
+                }
+                return batch_type(uint8_t(0));
             }
 
         };

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -669,18 +669,14 @@ namespace xsimd
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
                 batch_type b_concatenate;
+                /* Double: n = [0,1] */
                 if(n)
                 {
                    b_concatenate[0] = lhs[1];
                    b_concatenate[1] = rhs[0];
                    return b_concatenate;
                 }
-                else
-                {
-                   b_concatenate[0] = lhs[0];
-                   b_concatenate[1] = rhs[1];
-                   return b_concatenate;
-                }
+                return lhs;
             }
 
         };

--- a/include/xsimd/types/xsimd_sse_double.hpp
+++ b/include/xsimd/types/xsimd_sse_double.hpp
@@ -665,6 +665,24 @@ namespace xsimd
             {
                 return _mm_unpackhi_pd(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                if(n)
+                {
+                   b_concatenate[0] = lhs[1];
+                   b_concatenate[1] = rhs[0];
+                   return b_concatenate;
+                }
+                else
+                {
+                   b_concatenate[0] = lhs[0];
+                   b_concatenate[1] = rhs[1];
+                   return b_concatenate;
+                }
+            }
+
         };
     }
 }

--- a/include/xsimd/types/xsimd_sse_float.hpp
+++ b/include/xsimd/types/xsimd_sse_float.hpp
@@ -728,6 +728,20 @@ namespace xsimd
             {
                 return _mm_unpackhi_ps(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (4 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+            }
         };
     }
 }

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -213,18 +213,28 @@ namespace xsimd
                 return _mm_unpackhi_epi16(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
-                return _mm_alignr_epi8(rhs, lhs, 2*n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 2 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_16_v2(_mm_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (8 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[8 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -212,6 +212,12 @@ namespace xsimd
             {
                 return _mm_unpackhi_epi16(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm_alignr_epi8(rhs, lhs, 2 * n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_sse_int16.hpp
+++ b/include/xsimd/types/xsimd_sse_int16.hpp
@@ -215,7 +215,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-                return _mm_alignr_epi8(rhs, lhs, 2 * n);
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
+                return _mm_alignr_epi8(rhs, lhs, 2*n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (8 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[8 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -422,10 +422,23 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm_alignr_epi32(rhs, lhs, n);
 #else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
                 return _mm_alignr_epi8(rhs, lhs, 4 * n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (4 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[4 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
 #endif
             }
 

--- a/include/xsimd/types/xsimd_sse_int32.hpp
+++ b/include/xsimd/types/xsimd_sse_int32.hpp
@@ -419,6 +419,16 @@ namespace xsimd
             {
                 return _mm_unpackhi_epi32(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
+                return _mm_alignr_epi32(rhs, lhs, n);
+#else
+                return _mm_alignr_epi8(rhs, lhs, 4 * n);
+#endif
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -377,21 +377,40 @@ namespace xsimd
                 return _mm_unpackhi_epi64(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int num)
             {
 #if defined(XSIMD_AVX512VL_AVAILABLE)
-                return _mm_alignr_epi64(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_4(_mm_alignr_epi64);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
-                return _mm_alignr_epi8(rhs, lhs, 8 * n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                const int n = 8 * num;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_16_v2(_mm_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
+                const int n = num;
                 for (int i = 0 ; i < (2 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[2 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[2 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -376,6 +376,16 @@ namespace xsimd
             {
                 return _mm_unpackhi_epi64(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
+                return _mm_alignr_epi64(rhs, lhs, n);
+#else
+                return _mm_alignr_epi8(rhs, lhs, 8 * n);
+#endif
+            }
+
         };
 
 

--- a/include/xsimd/types/xsimd_sse_int64.hpp
+++ b/include/xsimd/types/xsimd_sse_int64.hpp
@@ -379,10 +379,23 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
-#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX512_VERSION
+#if defined(XSIMD_AVX512VL_AVAILABLE)
                 return _mm_alignr_epi64(rhs, lhs, n);
 #else
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
                 return _mm_alignr_epi8(rhs, lhs, 8 * n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (2 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[2 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
 #endif
             }
 

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -237,7 +237,20 @@ namespace xsimd
 
             static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
             {
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
                 return _mm_alignr_epi8(rhs, lhs, n);
+#else
+                batch_type b_concatenate;
+                for (int i = 0 ; i < (16 - n); ++i)
+                {
+                    b_concatenate[i] = lhs[i + n];
+                    if(i < n)
+                    {
+                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                    }
+                }
+                return b_concatenate;
+#endif
             }
 
         };

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -234,6 +234,12 @@ namespace xsimd
             {
                 return _mm_unpackhi_epi8(lhs, rhs);
             }
+
+            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            {
+                return _mm_alignr_epi8(rhs, lhs, n);
+            }
+
         };
 
         template <>

--- a/include/xsimd/types/xsimd_sse_int8.hpp
+++ b/include/xsimd/types/xsimd_sse_int8.hpp
@@ -235,18 +235,26 @@ namespace xsimd
                 return _mm_unpackhi_epi8(lhs, rhs);
             }
 
-            static batch_type extract_pair(const batch_type& lhs, const batch_type& rhs, const int n)
+            static batch_type extract_pair(const batch_type& v_lhs, const batch_type& v_rhs, const int n)
             {
 #if XSIMD_X86_INSTR_SET >= XSIMD_X86_SSSE3_VERSION
-                return _mm_alignr_epi8(rhs, lhs, n);
+                const batch_type lhs = v_rhs;
+                const batch_type rhs = v_lhs;
+                switch(n)
+                {
+                    case 0: return rhs;
+                    XSIMD_REPEAT_16_v2(_mm_alignr_epi8);
+                    default: break;
+                }
+                return batch_type(T(0));
 #else
                 batch_type b_concatenate;
                 for (int i = 0 ; i < (16 - n); ++i)
                 {
-                    b_concatenate[i] = lhs[i + n];
+                    b_concatenate[i] = v_lhs[i + n];
                     if(i < n)
                     {
-                        b_concatenate[16 - 1 - i] = rhs[n - 1 - i];
+                        b_concatenate[16 - 1 - i] = v_rhs[n - 1 - i];
                     }
                 }
                 return b_concatenate;

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -19,6 +19,124 @@
 #include "xtl/xcomplex.hpp"
 #endif
 
+/* For Shift instruction: vshlq_n_u8/vshrq_n_u8 (lhs, n),
+ * 'n' must be a constant and is the compile-time literal constant.
+ *
+ * This Macro is to fix compiling issues from llvm(clang):
+ * "argument must be a constant..."
+ *
+ */
+#define EXPAND(...) __VA_ARGS__
+#define CASE_LHS(op, i)                   \
+    case i: return op(lhs, i);
+
+#define XSIMD_REPEAT_8_0(op, addx)    \
+    CASE_LHS(EXPAND(op), 1 + addx);       \
+    CASE_LHS(EXPAND(op), 2 + addx);       \
+    CASE_LHS(EXPAND(op), 3 + addx);       \
+    CASE_LHS(EXPAND(op), 4 + addx);       \
+    CASE_LHS(EXPAND(op), 5 + addx);       \
+    CASE_LHS(EXPAND(op), 6 + addx);       \
+    CASE_LHS(EXPAND(op), 7 + addx);
+
+#define XSIMD_REPEAT_8_N(op, addx)    \
+    CASE_LHS(EXPAND(op), 0 + addx);       \
+    XSIMD_REPEAT_8_0(op, addx);
+
+#define XSIMD_REPEAT_8(op)            \
+    XSIMD_REPEAT_8_0(op, 0);
+
+#define XSIMD_REPEAT_16_0(op, addx)   \
+    XSIMD_REPEAT_8_0(op, 0 + addx);   \
+    XSIMD_REPEAT_8_N(op, 8 + addx);
+
+#define XSIMD_REPEAT_16_N(op, addx)   \
+    XSIMD_REPEAT_8_N(op, 0 + addx);   \
+    XSIMD_REPEAT_8_N(op, 8 + addx);
+
+#define XSIMD_REPEAT_16(op)           \
+    XSIMD_REPEAT_16_0(op, 0);
+
+#define XSIMD_REPEAT_32_0(op, addx)   \
+    XSIMD_REPEAT_16_0(op, 0 + addx);  \
+    XSIMD_REPEAT_16_N(op, 16 + addx);
+
+#define XSIMD_REPEAT_32_N(op, addx)   \
+    XSIMD_REPEAT_16_N(op, 0 + addx);  \
+    XSIMD_REPEAT_16_N(op, 16 + addx);
+
+#define XSIMD_REPEAT_32(op)           \
+    XSIMD_REPEAT_32_0(op, 0);
+
+#define XSIMD_REPEAT_64(op)           \
+    XSIMD_REPEAT_32_0(op, 0);         \
+    XSIMD_REPEAT_32_N(op, 32);
+
+/* The Macro is for vext (lhs, rhs, n)
+ *
+ * _mm_alignr_epi8, _mm_alignr_epi32 ...
+ */
+#define CASE_LHS_RHS(op, i)                   \
+    case i: return op(lhs, rhs, i);
+
+#define XSIMD_REPEAT_2_0(op, addx)    \
+    CASE_LHS_RHS(EXPAND(op), 1 + addx);
+
+#define XSIMD_REPEAT_2_N(op, addx)    \
+    CASE_LHS_RHS(EXPAND(op), 0 + addx);       \
+    XSIMD_REPEAT_2_0(op, addx);
+
+#define XSIMD_REPEAT_2(op)            \
+    XSIMD_REPEAT_2_0(op, 0);
+
+#define XSIMD_REPEAT_4_0(op, addx)   \
+    XSIMD_REPEAT_2_0(op, 0 + addx);   \
+    XSIMD_REPEAT_2_N(op, 2 + addx);
+
+#define XSIMD_REPEAT_4_N(op, addx)   \
+    XSIMD_REPEAT_2_N(op, 0 + addx);   \
+    XSIMD_REPEAT_2_N(op, 2 + addx);
+
+#define XSIMD_REPEAT_4(op)           \
+    XSIMD_REPEAT_4_0(op, 0);
+
+#define XSIMD_REPEAT_8_0_v2(op, addx)   \
+    XSIMD_REPEAT_4_0(op, 0 + addx);   \
+    XSIMD_REPEAT_4_N(op, 4 + addx);
+
+#define XSIMD_REPEAT_8_N_v2(op, addx)   \
+    XSIMD_REPEAT_4_N(op, 0 + addx);   \
+    XSIMD_REPEAT_4_N(op, 4 + addx);
+
+#define XSIMD_REPEAT_8_v2(op)           \
+    XSIMD_REPEAT_8_0_v2(op, 0);
+
+#define XSIMD_REPEAT_16_0_v2(op, addx)   \
+    XSIMD_REPEAT_8_0_v2(op, 0 + addx);   \
+    XSIMD_REPEAT_8_N_v2(op, 8 + addx);
+
+#define XSIMD_REPEAT_16_N_v2(op, addx)   \
+    XSIMD_REPEAT_8_N_v2(op, 0 + addx);   \
+    XSIMD_REPEAT_8_N_v2(op, 8 + addx);
+
+#define XSIMD_REPEAT_16_v2(op)           \
+    XSIMD_REPEAT_16_0_v2(op, 0);
+
+#define XSIMD_REPEAT_32_0_v2(op, addx)   \
+    XSIMD_REPEAT_16_0_v2(op, 0 + addx);   \
+    XSIMD_REPEAT_16_N_v2(op, 16 + addx);
+
+#define XSIMD_REPEAT_32_N_v2(op, addx)   \
+    XSIMD_REPEAT_16_N_v2(op, 0 + addx);   \
+    XSIMD_REPEAT_16_N_v2(op, 16 + addx);
+
+#define XSIMD_REPEAT_32_v2(op)           \
+    XSIMD_REPEAT_32_0_v2(op, 0);
+
+#define XSIMD_REPEAT_64_v2(op)           \
+    XSIMD_REPEAT_32_0_v2(op, 0);         \
+    XSIMD_REPEAT_32_N_v2(op, 32);
+
 namespace xsimd
 {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -162,6 +162,7 @@ set(XSIMD_TESTS
     test_conversion.cpp
     test_error_gamma.cpp
     test_exponential.cpp
+    test_extract_pair.cpp
     test_fp_manipulation.cpp
     test_hyperbolic.cpp
     test_load_store.cpp

--- a/test/test_extract_pair.cpp
+++ b/test/test_extract_pair.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+ *                                                                          *
+ * Copyright (c) QuantStack                                                 *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+#include "test_utils.hpp"
+
+namespace xsimd
+{
+    template <typename T, std::size_t N>
+    struct init_extract_pair_base
+    {
+        using extract_vector_type = std::array<T, N>;
+        extract_vector_type lhs_in, rhs_in, exped;
+
+        std::vector<extract_vector_type> create_extract_vectors(const int index)
+        {
+            std::vector<extract_vector_type> vects;
+            vects.reserve(3);
+
+            int num = static_cast<int>(N);
+            /* Generate input data: lhs, rhs */
+            for (int i = 0; i < num; ++i)
+            {
+                lhs_in[i] = 2*i + 1;
+                rhs_in[i] = 2*i + 2;
+            }
+            vects.push_back(std::move(lhs_in));
+            vects.push_back(std::move(rhs_in));
+
+            /* Expected shuffle data */
+            for (int i = 0 ; i < (num - index); ++i)
+            {
+                exped[i] = lhs_in[i + index];
+                if(i < index)
+                {
+                    exped[num - 1 - i] = rhs_in[index - 1 - i];
+                }
+            }
+            vects.push_back(std::move(exped));
+
+            return vects;
+        }
+    };
+}
+
+template <class B>
+class extract_pair_test : public testing::Test
+{
+  protected:
+    using batch_type = B;
+    using value_type = typename B::value_type;
+    static constexpr size_t size = B::size;
+
+    extract_pair_test()
+    {
+        std::cout << "shffle_extract_pair tests" << std::endl;
+    }
+
+    void extract_pair_128()
+    {
+        xsimd::init_extract_pair_base<value_type, size> extract_pair_base;
+        auto extract_pair_vecs = extract_pair_base.create_extract_vectors(1);
+        auto v_lhs = extract_pair_vecs[0];
+        auto v_rhs = extract_pair_vecs[1];
+        auto v_exped = extract_pair_vecs[2];
+
+        B b_lhs, b_rhs, b_exped, b_res;
+        b_lhs.load_unaligned(v_lhs.data());
+        b_rhs.load_unaligned(v_rhs.data());
+        b_exped.load_unaligned(v_exped.data());
+
+        /* Only Test 128bit */
+        if ((sizeof(value_type) * size) == 16)
+        {
+            b_res = xsimd::extract_pair(b_lhs, b_rhs, 1);
+            EXPECT_BATCH_EQ(b_res, b_exped) << print_function_name("extract_pair 128 test");
+        }
+    }
+};
+
+TYPED_TEST_SUITE(extract_pair_test, batch_types, simd_test_names);
+
+TYPED_TEST(extract_pair_test, extract_pair_128)
+{
+    this->extract_pair_128();
+}


### PR DESCRIPTION
Extracts the lowest vector elements from the second source and the highest vector
elements from the first source. The index: 'n' specifies the lowest vector element
to extract from the first source register.
Concatenates the results into th Return value.

