### PR TITLE
detect sincos() availability at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,37 @@ target_include_directories(xsimd INTERFACE
 
 target_compile_features(xsimd INTERFACE cxx_std_11)
 
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+    "
+    #include <cmath>
+    int main() {
+        { double s, c; ::sincos(0.0, &s, &c); }
+        { float s, c; ::sincosf(0.0f, &s, &c); }
+	return 0;
+    };
+    "
+    HAS_SINCOS)
+
+if(HAS_SINCOS)
+   add_definitions(-DXSIMD_HAS_SINCOS=1)
+endif()
+
+check_cxx_source_compiles(
+    "
+    #include <cmath>
+    int main() {
+        { double s, c; __sincos(0.0, &s, &c); }
+        { float s, c; __sincosf(0.0f, &s, &c); }
+	return 0;
+    };
+    "
+    HAS_DOUBLE_UNDERLINE_SINCOS)
+
+if(HAS_DOUBLE_UNDERLINE_SINCOS)
+   add_definitions(-DXSIMD_HAS_DOUBLE_UNDERLINE_SINCOS=1)
+endif()
+
 OPTION(ENABLE_FALLBACK "build tests/benchmarks with fallback implementation" OFF)
 OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
 OPTION(BUILD_TESTS "xsimd test suite" OFF)

--- a/include/xsimd/types/xsimd_scalar.hpp
+++ b/include/xsimd/types/xsimd_scalar.hpp
@@ -408,9 +408,9 @@ namespace xsimd
 
     inline void sincos(float val, float&s, float& c)
     {
-#if defined(__APPLE__)
+#if XSIMD_HAS_DOUBLE_UNDERLINE_SINCOS
         __sincosf(val, &s, &c);
-#elif defined(_GNU_SOURCE)
+#elif XSIMD_HAS_SINCOS
         ::sincosf(val, &s, &c);
 #else
         s = std::sin(val);
@@ -420,9 +420,9 @@ namespace xsimd
 
     inline void sincos(double val, double&s, double& c)
     {
-#if defined(__APPLE__)
+#if XSIMD_HAS_DOUBLE_UNDERLINE_SINCOS
         __sincos(val, &s, &c);
-#elif defined(_GNU_SOURCE)
+#elif XSIMD_HAS_SINCOS
         ::sincos(val, &s, &c);
 #else
         s = std::sin(val);


### PR DESCRIPTION
The `__sincosf` is a part of Apple SDK and may not be available in an arbitrary toolchain for C++. This switches to compile-time detection of intrinsics presence.