### PR TITLE
fix missing cassert header

### DIFF
--- a/include/xsimd/memory/xsimd_aligned_allocator.hpp
+++ b/include/xsimd/memory/xsimd_aligned_allocator.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <cstddef>
 #include <stdlib.h>
+#include <cassert>
 
 #include "../config/xsimd_align.hpp"
 


### PR DESCRIPTION
7a4fc55 added uses of the assert macro without including the cassert
header