### PR TITLE
Minimal testing of xsimd_numerical_constant

### DIFF
--- a/include/xsimd/math/xsimd_numerical_constant.hpp
+++ b/include/xsimd/math/xsimd_numerical_constant.hpp
@@ -91,7 +91,7 @@ namespace xsimd
     XSIMD_DEFINE_CONSTANT_HEX(pio2_3t, 0x248d3132, 0x397b839a252049c1)
     XSIMD_DEFINE_CONSTANT_HEX(pio4, 0x3f490fdb, 0x3fe921fb54442d18)
     XSIMD_DEFINE_CONSTANT_HEX(signmask, 0x80000000, 0x8000000000000000)
-    XSIMD_DEFINE_CONSTANT(smallestposval, 1.1754944e-38f, 2.225073858507201e-308)
+    XSIMD_DEFINE_CONSTANT(smallestposval, std::numeric_limits<float>::min(), std::numeric_limits<double>::min())
     XSIMD_DEFINE_CONSTANT_HEX(sqrt_2pi, 0x40206c99, 0x40040d931ff62704)
     XSIMD_DEFINE_CONSTANT_HEX(sqrteps, 0x39b504f3, 0x3e50000000000000)
     XSIMD_DEFINE_CONSTANT_HEX(tanpio8, 0x3ed413cd, 0x3fda827999fcef31)
@@ -357,7 +357,7 @@ namespace xsimd
     {
         return T(std::numeric_limits<typename T::value_type>::max());
     }
-    
+
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -167,6 +167,7 @@ set(XSIMD_TESTS
     test_hyperbolic.cpp
     test_load_store.cpp
     test_memory.cpp
+    test_numerical_constant.cpp
     test_poly_evaluation.cpp
     test_power.cpp
     test_rounding.cpp

--- a/test/test_numerical_constant.cpp
+++ b/test/test_numerical_constant.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+* Martin Renou                                                             *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <cmath>
+
+#include "test_utils.hpp"
+
+#include "xsimd/math/xsimd_numerical_constant.hpp"
+
+template<typename T>
+struct numerical_constant : public testing::Test
+{
+      using type = T;
+};
+
+using FloatingPointTypes = testing::Types<float, double>;
+TYPED_TEST_SUITE(numerical_constant, FloatingPointTypes);
+
+TYPED_TEST(numerical_constant, constants)
+{
+    using T = typename TestFixture::type;
+    EXPECT_TRUE(std::isinf(xsimd::infinity<T>()) && xsimd::infinity<T>() > 0);
+    EXPECT_EQ(xsimd::invlog_2<T>(), T(1) / std::log(T(2)));
+    EXPECT_EQ(xsimd::invlog10_2<T>(), T(1) / std::log10(T(2)));
+    EXPECT_EQ(xsimd::log_2<T>(), std::log(T(2)));
+    EXPECT_TRUE(std::isinf(xsimd::minusinfinity<T>()) && xsimd::minusinfinity<T>() < 0);
+    EXPECT_EQ(xsimd::minuszero<T>(), -T(0));
+    EXPECT_TRUE(std::isnan(xsimd::nan<T>()));
+    EXPECT_TRUE(xsimd::smallestposval<T>() < std::numeric_limits<T>::epsilon());
+}
+


### PR DESCRIPTION
As a side effect, detect a defect in xsimd::minposval
Fix #474