### PR TITLE
Fix NEON64 bitwidth to 128

### DIFF
--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -297,8 +297,8 @@ namespace xsimd
             static bool available() { return detail::available().neon64; }
 
             template<class T>
-            using batch = xsimd::batch<T, 512 / ( 8 * sizeof(T))>;
-            static constexpr size_t alignment = 32;
+            using batch = xsimd::batch<T, 128 / ( 8 * sizeof(T))>;
+            static constexpr size_t alignment = 16;
         };
 
         struct scalar


### PR DESCRIPTION
Failed to build on Arm64 (Arm64 gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0).
The data bitwidth of Arm64 Neon extension should be set to 128.
```
/home/yuqi/xsimd/test/test_arch.cpp:53:11: error: ‘batch acc’ has incomplete type
   53 |     batch acc(static_cast<T>(0));
      |           ^~~
/home/yuqi/xsimd/test/test_arch.cpp:54:29: error: incomplete type ‘batch’ {aka ‘xsimd::batch<unsigned int, 16>’} used in nested name specifier
   54 |     const unsigned n = size / batch::size * batch::size;
      |                        ~~~~~^~~~~~~~~~~~~
/home/yuqi/xsimd/test/test_arch.cpp:54:43: error: incomplete type ‘batch’ {aka ‘xsimd::batch<unsigned int, 16>’} used in nested name specifier
   54 |     const unsigned n = size / batch::size * batch::size;
      |                        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/home/yuqi/xsimd/test/test_arch.cpp:55:35: error: incomplete type ‘batch’ {aka ‘xsimd::batch<unsigned int, 16>’} used in nested name specifier
   55 |     for(unsigned i = 0; i != n; i += batch::size)
      |                                 ~~^~~~~~~~~~~~~~
/home/yuqi/xsimd/test/test_arch.cpp:56:16: error: invalid use of incomplete type ‘using batch = xsimd::arch::batch<unsigned int, xsimd::arch::neon64>’ {aka ‘class xsimd::batch<unsigned int, 16>’}
   56 |         acc += batch(data + i);
```

