### PR TITLE
Add extra namespace in Basic Usage example

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -21,8 +21,8 @@ Here is an example that computes the mean of two sets of 4 double floating point
 
     int main(int argc, char* argv[])
     {
-        xs::avx::batch<double> a(1.5, 2.5, 3.5, 4.5);
-        xs::avx::batch<double> b(2.5, 3.5, 4.5, 5.5);
+        xs::arch::avx::batch<double> a(1.5, 2.5, 3.5, 4.5);
+        xs::arch::avx::batch<double> b(2.5, 3.5, 4.5, 5.5);
         auto mean = (a + b) / 2;
         std::cout << mean << std::endl;
         return 0;


### PR DESCRIPTION
Thanks for the great library!

Add the `arch` namespace needed to get access to `avx::batch`.

It looks like the README uses `batch<double, 4>`. If that's preferred I can update the PR to do that instead.