### PR TITLE
Implement uint8 casting functions

### DIFF
--- a/include/xsimd/types/xsimd_avx512_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx512_conversion.hpp
@@ -31,6 +31,13 @@ namespace xsimd
     batch<float, 16> to_float(const batch<int32_t, 16>& x);
     batch<double, 8> to_float(const batch<int64_t, 8>& x);
 
+    batch<uint16_t, 32> u8_to_u16(const batch<uint8_t, 64>& x);
+    batch<uint8_t, 64> u16_to_u8(const batch<uint16_t, 32>& x);
+    batch<uint32_t, 16> u8_to_u32(const batch<uint8_t, 64>& x);
+    batch<uint8_t, 64> u32_to_u8(const batch<uint32_t, 16>& x);
+    batch<uint64_t, 8> u8_to_u64(const batch<uint8_t, 64>& x);
+    batch<uint8_t, 64> u64_to_u8(const batch<uint64_t, 8>& x);
+
     /**************************
      * boolean cast functions *
      **************************/
@@ -178,6 +185,34 @@ namespace xsimd
     XSIMD_BATCH_CAST_INTRINSIC(double, int64_t, 8, _mm512_cvttpd_epi64)
     XSIMD_BATCH_CAST_INTRINSIC(double, uint64_t, 8, _mm512_cvttpd_epu64)
 #endif
+
+    inline batch<uint16_t, 32> u8_to_u16(const batch<uint8_t, 64>& x)
+    {
+        return static_cast<batch<uint16_t, 32>>(x);
+    }
+    inline batch<uint8_t, 64> u16_to_u8(const batch<uint16_t, 32>& x)
+    {
+        return static_cast<batch<uint8_t, 64>>(x);
+    }
+
+    inline batch<uint32_t, 16> u8_to_u32(const batch<uint8_t, 64>& x)
+    {
+        return static_cast<batch<uint32_t, 16>>(x);
+    }
+    inline batch<uint8_t, 64> u32_to_u8(const batch<uint32_t, 16>& x)
+    {
+        return static_cast<batch<uint8_t, 64>>(x);
+    }
+
+    inline batch<uint64_t, 8> u8_to_u64(const batch<uint8_t, 64>& x)
+    {
+        return static_cast<batch<uint64_t, 8>>(x);
+    }
+
+    inline batch<uint8_t, 64> u64_to_u8(const batch<uint64_t, 8>& x)
+    {
+        return static_cast<batch<uint8_t, 64>>(x);
+    }
 
     /**************************
      * boolean cast functions *

--- a/include/xsimd/types/xsimd_avx_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx_conversion.hpp
@@ -31,6 +31,13 @@ namespace xsimd
     batch<float, 8> to_float(const batch<int32_t, 8>& x);
     batch<double, 4> to_float(const batch<int64_t, 4>& x);
 
+    batch<uint16_t, 16> u8_to_u16(const batch<uint8_t, 32>& x);
+    batch<uint8_t, 32> u16_to_u8(const batch<uint16_t, 16>& x);
+    batch<uint32_t, 8> u8_to_u32(const batch<uint8_t, 32>& x);
+    batch<uint8_t, 32> u32_to_u8(const batch<uint32_t, 8>& x);
+    batch<uint64_t, 4> u8_to_u64(const batch<uint8_t, 32>& x);
+    batch<uint8_t, 32> u64_to_u8(const batch<uint64_t, 4>& x);
+
     /**************************
      * boolean cast functions *
      **************************/
@@ -76,6 +83,34 @@ namespace xsimd
                                 static_cast<double>(x[2]),
                                 static_cast<double>(x[3]));
 #endif
+    }
+
+    inline batch<uint16_t, 16> u8_to_u16(const batch<uint8_t, 32>& x)
+    {
+        return static_cast<batch<uint16_t, 16>>(x);
+    }
+    inline batch<uint8_t, 32> u16_to_u8(const batch<uint16_t, 16>& x)
+    {
+        return static_cast<batch<uint8_t, 32>>(x);
+    }
+
+    inline batch<uint32_t, 8> u8_to_u32(const batch<uint8_t, 32>& x)
+    {
+        return static_cast<batch<uint32_t, 8>>(x);
+    }
+    inline batch<uint8_t, 32> u32_to_u8(const batch<uint32_t, 8>& x)
+    {
+        return static_cast<batch<uint8_t, 32>>(x);
+    }
+
+    inline batch<uint64_t, 4> u8_to_u64(const batch<uint8_t, 32>& x)
+    {
+        return static_cast<batch<uint64_t, 4>>(x);
+    }
+
+    inline batch<uint8_t, 32> u64_to_u8(const batch<uint64_t, 4>& x)
+    {
+        return static_cast<batch<uint8_t, 32>>(x);
     }
 
     /*****************************************

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -1199,6 +1199,24 @@ namespace xsimd
     /*****************************************
      * bitwise cast functions implementation *
      *****************************************/
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint16_t, out_N> u8_to_u16(const batch<uint8_t, in_N>& x);
+
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint8_t, out_N> u16_to_u8(const batch<uint16_t, in_N>& x);
+
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint32_t, out_N> u8_to_u32(const batch<uint8_t, in_N>& x);
+
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint8_t, out_N> u32_to_u8(const batch<uint32_t, in_N>& x);
+
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint64_t, out_N> u8_to_u64(const batch<uint8_t, in_N>& x);
+
+    template <std::size_t in_N, std::size_t out_N>
+    batch<uint8_t, out_N> u64_to_u8(const batch<uint64_t, in_N>& x);
+
 
     template <class T_in, class T_out, std::size_t N_in>
     struct bitwise_cast_impl<batch<T_in, N_in>,
@@ -1221,6 +1239,46 @@ namespace xsimd
             return batch<T_out, N_out>(caster.out);
         }
     };
+
+    /***********************************************
+     * static_cast conversion by bitwise_cast_impl *
+     ***********************************************/
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint16_t, out_N> u8_to_u16(const batch<uint8_t, in_N>& x)
+    {
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint16_t, out_N>>::run(x);
+    }
+
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint8_t, out_N> u16_to_u8(const batch<uint16_t, in_N>& x)
+    {
+        return bitwise_cast_impl<batch<uint16_t, in_N>, batch<uint8_t, out_N>>::run(x);
+    }
+
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint32_t, out_N> u8_to_u32(const batch<uint8_t, in_N>& x)
+    {
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint32_t, out_N>>::run(x);
+    }
+
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint8_t, out_N> u32_to_u8(const batch<uint32_t, in_N>& x)
+    {
+        return bitwise_cast_impl<batch<uint32_t, in_N>, batch<uint8_t, out_N>>::run(x);
+    }
+
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint64_t, out_N> u8_to_u64(const batch<uint8_t, in_N>& x)
+    {
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint64_t, out_N>>::run(x);
+    }
+
+    template <std::size_t in_N, std::size_t out_N>
+    inline batch<uint8_t, out_N> u64_to_u8(const batch<uint64_t, in_N>& x)
+    {
+       return bitwise_cast_impl<batch<uint64_t, in_N>, batch<uint8_t, out_N>>::run(x);
+    }
+
 }
 
 #endif

--- a/include/xsimd/types/xsimd_fallback.hpp
+++ b/include/xsimd/types/xsimd_fallback.hpp
@@ -1199,23 +1199,23 @@ namespace xsimd
     /*****************************************
      * bitwise cast functions implementation *
      *****************************************/
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint16_t, out_N> u8_to_u16(const batch<uint8_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint16_t, sizeof(uint8_t)*in_N/sizeof(uint16_t)> u8_to_u16(const batch<uint8_t, in_N>& x);
 
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint8_t, out_N> u16_to_u8(const batch<uint16_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint8_t, sizeof(uint16_t)*in_N/sizeof(uint8_t)> u16_to_u8(const batch<uint16_t, in_N>& x);
 
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint32_t, out_N> u8_to_u32(const batch<uint8_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint32_t, sizeof(uint8_t)*in_N/sizeof(uint32_t)> u8_to_u32(const batch<uint8_t, in_N>& x);
 
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint8_t, out_N> u32_to_u8(const batch<uint32_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint8_t, sizeof(uint32_t)*in_N/sizeof(uint8_t)> u32_to_u8(const batch<uint32_t, in_N>& x);
 
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint64_t, out_N> u8_to_u64(const batch<uint8_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint64_t, sizeof(uint8_t)*in_N/sizeof(uint64_t)> u8_to_u64(const batch<uint8_t, in_N>& x);
 
-    template <std::size_t in_N, std::size_t out_N>
-    batch<uint8_t, out_N> u64_to_u8(const batch<uint64_t, in_N>& x);
+    template <std::size_t in_N>
+    batch<uint8_t, sizeof(uint64_t)*in_N/sizeof(uint8_t)> u64_to_u8(const batch<uint64_t, in_N>& x);
 
 
     template <class T_in, class T_out, std::size_t N_in>
@@ -1243,40 +1243,40 @@ namespace xsimd
     /***********************************************
      * static_cast conversion by bitwise_cast_impl *
      ***********************************************/
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint16_t, out_N> u8_to_u16(const batch<uint8_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint16_t, sizeof(uint8_t)*in_N/sizeof(uint16_t)> u8_to_u16(const batch<uint8_t, in_N>& x)
     {
-        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint16_t, out_N>>::run(x);
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint16_t, sizeof(uint8_t)*in_N/sizeof(uint16_t)>>::run(x);
     }
 
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint8_t, out_N> u16_to_u8(const batch<uint16_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint8_t, sizeof(uint16_t)*in_N/sizeof(uint8_t)> u16_to_u8(const batch<uint16_t, in_N>& x)
     {
-        return bitwise_cast_impl<batch<uint16_t, in_N>, batch<uint8_t, out_N>>::run(x);
+        return bitwise_cast_impl<batch<uint16_t, in_N>, batch<uint8_t, sizeof(uint16_t)*in_N/sizeof(uint8_t)>>::run(x);
     }
 
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint32_t, out_N> u8_to_u32(const batch<uint8_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint32_t, sizeof(uint8_t)*in_N/sizeof(uint32_t)> u8_to_u32(const batch<uint8_t, in_N>& x)
     {
-        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint32_t, out_N>>::run(x);
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint32_t, sizeof(uint8_t)*in_N/sizeof(uint32_t)>>::run(x);
     }
 
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint8_t, out_N> u32_to_u8(const batch<uint32_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint8_t, sizeof(uint32_t)*in_N/sizeof(uint8_t)> u32_to_u8(const batch<uint32_t, in_N>& x)
     {
-        return bitwise_cast_impl<batch<uint32_t, in_N>, batch<uint8_t, out_N>>::run(x);
+        return bitwise_cast_impl<batch<uint32_t, in_N>, batch<uint8_t, sizeof(uint32_t)*in_N/sizeof(uint8_t)>>::run(x);
     }
 
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint64_t, out_N> u8_to_u64(const batch<uint8_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint64_t, sizeof(uint8_t)*in_N/sizeof(uint64_t)> u8_to_u64(const batch<uint8_t, in_N>& x)
     {
-        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint64_t, out_N>>::run(x);
+        return bitwise_cast_impl<batch<uint8_t, in_N>, batch<uint64_t, sizeof(uint8_t)*in_N/sizeof(uint64_t)>>::run(x);
     }
 
-    template <std::size_t in_N, std::size_t out_N>
-    inline batch<uint8_t, out_N> u64_to_u8(const batch<uint64_t, in_N>& x)
+    template <std::size_t in_N>
+    inline batch<uint8_t, sizeof(uint64_t)*in_N/sizeof(uint8_t)> u64_to_u8(const batch<uint64_t, in_N>& x)
     {
-       return bitwise_cast_impl<batch<uint64_t, in_N>, batch<uint8_t, out_N>>::run(x);
+       return bitwise_cast_impl<batch<uint64_t, in_N>, batch<uint8_t, sizeof(uint64_t)*in_N/sizeof(uint8_t)>>::run(x);
     }
 
 }

--- a/include/xsimd/types/xsimd_neon_conversion.hpp
+++ b/include/xsimd/types/xsimd_neon_conversion.hpp
@@ -35,6 +35,13 @@ namespace xsimd
     batch<int32_t, 4> to_int(const batch<float, 4>& x);
     batch<float, 4> to_float(const batch<int32_t, 4>& x);
 
+    batch<uint16_t, 8> u8_to_u16(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u16_to_u8(const batch<uint16_t, 8>& x);
+    batch<uint32_t, 4> u8_to_u32(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u32_to_u8(const batch<uint32_t, 4>& x);
+    batch<uint64_t, 2> u8_to_u64(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u64_to_u8(const batch<uint64_t, 2>& x);
+
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
     batch<int64_t, 2> to_int(const batch<double, 2>& x);
     batch<double, 2> to_float(const batch<int64_t, 2>& x);
@@ -81,6 +88,36 @@ namespace xsimd
     inline batch<float, 4> to_float(const batch<int32_t, 4>& x)
     {
         return vcvtq_f32_s32(x);
+    }
+
+    inline batch<uint16_t, 8> u8_to_u16(const batch<uint8_t, 16>& x)
+    {
+        return vreinterpretq_u16_u8(x);
+    }
+
+    inline batch<uint8_t, 16> u16_to_u8(const batch<uint16_t, 8>& x)
+    {
+        return vreinterpretq_u8_u16(x);
+    }
+
+    inline batch<uint32_t, 4> u8_to_u32(const batch<uint8_t, 16>& x)
+    {
+        return vreinterpretq_u32_u8(x);
+    }
+
+    inline batch<uint8_t, 16> u32_to_u8(const batch<uint32_t, 4>& x)
+    {
+        return vreinterpretq_u8_u32(x);
+    }
+
+    inline batch<uint64_t, 2> u8_to_u64(const batch<uint8_t, 16>& x)
+    {
+        return vreinterpretq_u64_u8(x);
+    }
+
+    inline batch<uint8_t, 16> u64_to_u8(const batch<uint64_t, 2>& x)
+    {
+        return vreinterpretq_u8_u64(x);
     }
 
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION

--- a/include/xsimd/types/xsimd_sse_conversion.hpp
+++ b/include/xsimd/types/xsimd_sse_conversion.hpp
@@ -31,6 +31,13 @@ namespace xsimd
     batch<float, 4> to_float(const batch<int32_t, 4>& x);
     batch<double, 2> to_float(const batch<int64_t, 2>& x);
 
+    batch<uint16_t, 8> u8_to_u16(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u16_to_u8(const batch<uint16_t, 8>& x);
+    batch<uint32_t, 4> u8_to_u32(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u32_to_u8(const batch<uint32_t, 4>& x);
+    batch<uint64_t, 2> u8_to_u64(const batch<uint8_t, 16>& x);
+    batch<uint8_t, 16> u64_to_u8(const batch<uint64_t, 2>& x);
+
     /**************************
      * boolean cast functions *
      **************************/
@@ -70,6 +77,36 @@ namespace xsimd
 #else
         return batch<double, 2>(static_cast<double>(x[0]), static_cast<double>(x[1]));
 #endif
+    }
+
+    inline batch<uint16_t, 8> u8_to_u16(const batch<uint8_t, 16>& x)
+    {
+        return static_cast<batch<uint16_t, 8>>(x);
+    }
+
+    inline batch<uint8_t, 16> u16_to_u8(const batch<uint16_t, 8>& x)
+    {
+        return static_cast<batch<uint8_t, 16>>(x);
+    }
+
+    inline batch<uint32_t, 4> u8_to_u32(const batch<uint8_t, 16>& x)
+    {
+        return static_cast<batch<uint32_t, 4>>(x);
+    }
+
+    inline batch<uint8_t, 16> u32_to_u8(const batch<uint32_t, 4>& x)
+    {
+        return static_cast<batch<uint8_t, 16>>(x);
+    }
+
+    inline batch<uint64_t, 2> u8_to_u64(const batch<uint8_t, 16>& x)
+    {
+        return static_cast<batch<uint64_t, 2>>(x);
+    }
+
+    inline batch<uint8_t, 16> u64_to_u8(const batch<uint64_t, 2>& x)
+    {
+        return static_cast<batch<uint8_t, 16>>(x);
     }
 
     /*****************************************

--- a/test/test_conversion.cpp
+++ b/test/test_conversion.cpp
@@ -23,10 +23,17 @@ protected:
     using float_batch = xsimd::batch<float, N * 2>;
     using double_batch = xsimd::batch<double, N>;
 
+    using uint8_batch = xsimd::batch<uint8_t, N * 8>;
+    using uint16_batch = xsimd::batch<uint16_t, N * 4>;
+    using uint32_batch = xsimd::batch<uint32_t, N * 2>;
+    using uint64_batch = xsimd::batch<uint64_t, N>;
+
     using int32_vector = std::vector<int32_t, xsimd::aligned_allocator<int32_t, A>>;
     using int64_vector = std::vector<int64_t, xsimd::aligned_allocator<int64_t, A>>;
     using float_vector = std::vector<float, xsimd::aligned_allocator<float, A>>;
     using double_vector = std::vector<double, xsimd::aligned_allocator<double, A>>;
+
+    using uint8_vector = std::vector<uint8_t, xsimd::aligned_allocator<uint8_t, A>>;
 
     /*int32_batch i32pos;
     int32_batch i32neg;
@@ -46,10 +53,13 @@ protected:
     double_vector i64posres;
     double_vector i64negres;
 
+    uint8_vector ui8res;
+
     conversion_test()
         : fposres(2 * N, 7), fnegres(2 * N, -6), dposres(N, 5), dnegres(N, -1),
           i32posres(2 * N, float(2)), i32negres(2 * N, float(-3)),
-          i64posres(N, double(2)), i64negres(N, double(-3))
+          i64posres(N, double(2)), i64negres(N, double(-3)),
+          ui8res(8 * N, 4)
     {
     }
 
@@ -116,6 +126,30 @@ protected:
             EXPECT_VECTOR_EQ(i64vres, i64negres) << print_function_name("to_float(negative int64)");
         }
     }
+
+    void test_u8_casting()
+    {
+        uint8_batch ui8tmp(4);
+        uint8_vector ui8vres(uint8_batch::size);
+        {
+            uint16_batch ui16casting = u8_to_u16(ui8tmp);
+            uint8_batch ui8casting = u16_to_u8(ui16casting);
+            ui8casting.store_aligned(ui8vres.data());
+            EXPECT_VECTOR_EQ(ui8vres, ui8res) << print_function_name("u8_to_16");
+        }
+        {
+            uint32_batch ui32casting = u8_to_u32(ui8tmp);
+            uint8_batch ui8casting = u32_to_u8(ui32casting);
+            ui8casting.store_aligned(ui8vres.data());
+            EXPECT_VECTOR_EQ(ui8vres, ui8res) << print_function_name("u8_to_32");
+        }
+        {
+            uint64_batch ui64casting = u8_to_u64(ui8tmp);
+            uint8_batch ui8casting = u64_to_u8(ui64casting);
+            ui8casting.store_aligned(ui8vres.data());
+            EXPECT_VECTOR_EQ(ui8vres, ui8res) << print_function_name("u8_to_64");
+        }
+    }
 };
 
 TYPED_TEST_SUITE(conversion_test, conversion_types, conversion_test_names);
@@ -138,4 +172,9 @@ TYPED_TEST(conversion_test, to_float)
 TYPED_TEST(conversion_test, to_double)
 {
     this->test_to_double();
+}
+
+TYPED_TEST(conversion_test, u8_casting)
+{
+    this->test_u8_casting();
 }


### PR DESCRIPTION
Background( in #475 ): 

- In Arrow use cases scenario (xsimd as the 3rd party simd library),  we'd like to cast xsimd::batch<uint8_t, 16> to xsimd::batch<uint32_t, 4> for operating some fixed size of shared data buffer. 
For this fixed size of shared data buffer, data usually are regarded as `unsigned`. So the PR is just for u8,u16, u32 and u64.

- In x86,  the simd data structures are  `__m128i` / `__m256i `/ `__m512i`.
It's correct to leverage the `static_cast` to  cast `uint8 * N_u8` to `uint16 * N_u16` , `uint32 * N_u32` `and uint64 * N_u64`, but it failed in Arm64.

- In xsimd, [XSIMD_BITWISE_CAST_INTRINSIC](https://github.com/xtensor-stack/xsimd/blob/master/include/xsimd/types/xsimd_base.hpp#L389) (`#define XSIMD_BITWISE_CAST_INTRINSIC(T_IN, N_IN, T_OUT, N_OUT, INTRINSIC)`) is used for the similar casting fucntion. 
But the parameter `INTRINSIC` depends on architecture. 

The PR is to add data casting functions.
Leverage vreinterpretq in Arm64 neon.
Directly leverage `static_cast` in x86.



