### PR TITLE
Implement permute conversion for Apache Arrow simd reference

### DIFF
--- a/include/xsimd/types/xsimd_avx512_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx512_conversion.hpp
@@ -281,6 +281,32 @@ namespace xsimd
     XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 8,
                                  double, 8,
                                  _mm512_castsi512_pd)
+
+    /****************************
+     * permute 512bit functions *
+     ****************************/
+#if defined(XSIMD_AVX512BW_AVAILABLE)
+    batch<uint8_t, 64> permute512_16_convert(const batch<uint8_t, 64>& p_mask, const batch<uint8_t, 64>& lhs);
+
+    inline batch<uint8_t, 64> permute512_16_convert(const batch<uint8_t, 64>& p_mask, const batch<uint8_t, 64>& lhs)
+    {
+        return _mm512_permutexvar_epi16(p_mask, lhs);
+    }
+#endif
+
+    batch<uint8_t, 64> permute512_32_convert(const batch<uint8_t, 64>& p_mask, const batch<uint8_t, 64>& lhs);
+    batch<uint8_t, 64> permute512_32x4_convert(const batch<uint8_t, 64>& lhs,
+                                               const batch<uint8_t, 64>& rhs, const int idx);
+    inline batch<uint8_t, 64> permute512_32_convert(const batch<uint8_t, 64>& p_mask, const batch<uint8_t, 64>& lhs)
+    {
+        return _mm512_permutexvar_epi32(p_mask, lhs);
+    }
+
+    inline batch<uint8_t, 64> permute512_32x4_convert(const batch<uint8_t, 64>& lhs, const batch<uint8_t, 64>& rhs,
+                                                      const int idx)
+    {
+        return _mm512_shuffle_i32x4(lhs, rhs, idx);
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_avx_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx_conversion.hpp
@@ -257,6 +257,26 @@ namespace xsimd
     XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4,
                                  double, 4,
                                  _mm256_castsi256_pd)
+
+    /****************************
+     * permute 256bit functions *
+     ****************************/
+#if XSIMD_X86_INSTR_SET >= XSIMD_X86_AVX2_VERSION
+    batch<uint8_t, 32> permute256_8x32_convert(const batch<uint8_t, 32>& x, const batch<uint8_t, 32>& p_mask);
+    batch<uint8_t, 32> permute256_2x128_convert(const batch<uint8_t, 32>& lhs,
+                                                const batch<uint8_t, 32>& rhs, const int idx);
+
+    inline batch<uint8_t, 32> permute256_8x32_convert(const batch<uint8_t, 32>& x, const batch<uint8_t, 32>& p_mask)
+    {
+        return _mm256_permutevar8x32_epi32(x, p_mask);
+    }
+
+    inline batch<uint8_t, 32> permute256_2x128_convert(const batch<uint8_t, 32>& lhs, const batch<uint8_t, 32>& rhs,
+                                                       const int idx)
+    {
+        return _mm256_permute2x128_si256(lhs, rhs, idx);
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
permute 2x128, 8x32 for 256bit/512bit.
The PR is the simple wrap of  `permute ` used by Arrow.
