### PR TITLE
Add remaining bitwise_cast permutations

### DIFF
--- a/include/xsimd/types/xsimd_avx512_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx512_conversion.hpp
@@ -242,45 +242,106 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 16,
-                                 double, 8,
-                                 _mm512_castps_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 16,
-                                 int32_t, 16,
-                                 _mm512_castps_si512)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 16,
-                                 int64_t, 8,
-                                 _mm512_castps_si512)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 8,
-                                 float, 16,
-                                 _mm512_castpd_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 8,
-                                 int32_t, 16,
-                                 _mm512_castpd_si512)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 8,
-                                 int64_t, 8,
-                                 _mm512_castpd_si512)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 16,
-                                 float, 16,
-                                 _mm512_castsi512_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 16,
-                                 double, 8,
-                                 _mm512_castsi512_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 8,
-                                 float, 16,
-                                 _mm512_castsi512_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 8,
-                                 double, 8,
-                                 _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 64, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 64, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 64, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 64, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 64, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 64, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 32, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 32, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 32, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 32, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 32, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 32, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 16, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 16, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 16, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 16, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 16, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 16, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 8, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 8, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 8, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, int8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, uint8_t, 64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, int16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, uint16_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, int32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, uint32_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, int64_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 8, uint64_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 8, float, 16, _mm512_castsi512_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 8, double, 8, _mm512_castsi512_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, int8_t, 64, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, uint8_t, 64, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, int16_t, 32, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, uint16_t, 32, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, int32_t, 16, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, uint32_t, 16, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, int64_t, 8, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, uint64_t, 8, _mm512_castps_si512)
+    XSIMD_BITWISE_CAST_IMPLICIT(float, 16, float, 16)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 16, double, 8, _mm512_castps_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, int8_t, 64, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, uint8_t, 64, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, int16_t, 32, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, uint16_t, 32, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, int32_t, 16, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, uint32_t, 16, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, int64_t, 8, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, uint64_t, 8, _mm512_castpd_si512)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 8, float, 16, _mm512_castpd_ps)
+    XSIMD_BITWISE_CAST_IMPLICIT(double, 8, double, 8)
 }
 
 #endif

--- a/include/xsimd/types/xsimd_avx_conversion.hpp
+++ b/include/xsimd/types/xsimd_avx_conversion.hpp
@@ -218,45 +218,106 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
-                                 double, 4,
-                                 _mm256_castps_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
-                                 int32_t, 8,
-                                 _mm256_castps_si256)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 8,
-                                 int64_t, 4,
-                                 _mm256_castps_si256)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
-                                 float, 8,
-                                 _mm256_castpd_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
-                                 int32_t, 8,
-                                 _mm256_castpd_si256)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 4,
-                                 int64_t, 4,
-                                 _mm256_castpd_si256)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8,
-                                 float, 8,
-                                 _mm256_castsi256_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8,
-                                 double, 4,
-                                 _mm256_castsi256_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4,
-                                 float, 8,
-                                 _mm256_castsi256_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4,
-                                 double, 4,
-                                 _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 32, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 32, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 32, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 32, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 32, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 32, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 16, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 16, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 16, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 16, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 16, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 16, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 8, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 8, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 8, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 8, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 8, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 4, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 4, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, int8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, uint8_t, 32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, int16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, uint16_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, int32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, uint32_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, int64_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 4, uint64_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 4, float, 8, _mm256_castsi256_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 4, double, 4, _mm256_castsi256_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, int8_t, 32, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, uint8_t, 32, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, int16_t, 16, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, uint16_t, 16, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, int32_t, 8, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, uint32_t, 8, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, int64_t, 4, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, uint64_t, 4, _mm256_castps_si256)
+    XSIMD_BITWISE_CAST_IMPLICIT(float, 8, float, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 8, double, 4, _mm256_castps_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, int8_t, 32, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, uint8_t, 32, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, int16_t, 16, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, uint16_t, 16, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, int32_t, 8, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, uint32_t, 8, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, int64_t, 4, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, uint64_t, 4, _mm256_castpd_si256)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 4, float, 8, _mm256_castpd_ps)
+    XSIMD_BITWISE_CAST_IMPLICIT(double, 4, double, 4)
 }
 
 #endif

--- a/include/xsimd/types/xsimd_base.hpp
+++ b/include/xsimd/types/xsimd_base.hpp
@@ -396,19 +396,47 @@ namespace xsimd
             }                                                                  \
         };
 
+    #define XSIMD_BITWISE_CAST_IMPLICIT(T_IN, N_IN, T_OUT, N_OUT)              \
+        template <>                                                            \
+        struct bitwise_cast_impl<batch<T_IN, N_IN>, batch<T_OUT, N_OUT>>       \
+        {                                                                      \
+            static inline batch<T_OUT, N_OUT> run(const batch<T_IN, N_IN>& x)  \
+            {                                                                  \
+                return batch<T_OUT, N_OUT>(x);                                 \
+            }                                                                  \
+        };
+
 
     // Backwards-compatible interface to bitwise_cast_impl
     template <class B, std::size_t N = simd_batch_traits<B>::size>
-    B bitwise_cast(const batch<float, N>& x);
+    B bitwise_cast(const batch<int8_t, N>& x);
 
     template <class B, std::size_t N = simd_batch_traits<B>::size>
-    B bitwise_cast(const batch<double, N>& x);
+    B bitwise_cast(const batch<uint8_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<int16_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<uint16_t, N>& x);
 
     template <class B, std::size_t N = simd_batch_traits<B>::size>
     B bitwise_cast(const batch<int32_t, N>& x);
 
     template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<uint32_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
     B bitwise_cast(const batch<int64_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<uint64_t, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<float, N>& x);
+
+    template <class B, std::size_t N = simd_batch_traits<B>::size>
+    B bitwise_cast(const batch<double, N>& x);
 
     template <class T, std::size_t N>
     batch<T, N> bitwise_cast(const batch_bool<T, N>& src);
@@ -2034,15 +2062,27 @@ namespace xsimd
      *****************************************/
 
     template <class B, std::size_t N>
-    inline B bitwise_cast(const batch<float, N>& x)
+    inline B bitwise_cast(const batch<int8_t, N>& x)
     {
-        return bitwise_cast_impl<batch<float, N>, B>::run(x);
+        return bitwise_cast_impl<batch<int8_t, N>, B>::run(x);
     }
 
     template <class B, std::size_t N>
-    inline B bitwise_cast(const batch<double, N>& x)
+    inline B bitwise_cast(const batch<uint8_t, N>& x)
     {
-        return bitwise_cast_impl<batch<double, N>, B>::run(x);
+        return bitwise_cast_impl<batch<uint8_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<int16_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<int16_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<uint16_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<uint16_t, N>, B>::run(x);
     }
 
     template <class B, std::size_t N>
@@ -2052,9 +2092,33 @@ namespace xsimd
     }
 
     template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<uint32_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<uint32_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
     inline B bitwise_cast(const batch<int64_t, N>& x)
     {
         return bitwise_cast_impl<batch<int64_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<uint64_t, N>& x)
+    {
+        return bitwise_cast_impl<batch<uint64_t, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<float, N>& x)
+    {
+        return bitwise_cast_impl<batch<float, N>, B>::run(x);
+    }
+
+    template <class B, std::size_t N>
+    inline B bitwise_cast(const batch<double, N>& x)
+    {
+        return bitwise_cast_impl<batch<double, N>, B>::run(x);
     }
 
     template <class T, std::size_t N>

--- a/include/xsimd/types/xsimd_neon_conversion.hpp
+++ b/include/xsimd/types/xsimd_neon_conversion.hpp
@@ -136,23 +136,23 @@ namespace xsimd
      * batch cast functions implementation *
      *****************************************/
 
-    XSIMD_BATCH_CAST_INTRINSIC(int8_t, uint8_t, 16, vreinterpretq_u8_s8);
-    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, int8_t, 16, vreinterpretq_s8_u8);
-    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint16_t, 8, vreinterpretq_u16_s16);
-    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int16_t, 8, vreinterpretq_s16_u16);
-    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint32_t, 4, vreinterpretq_u32_s32);
-    XSIMD_BATCH_CAST_INTRINSIC(int32_t, float, 4, vcvtq_f32_s32);
-    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int32_t, 4, vreinterpretq_s32_u32);
-    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, float, 4, vcvtq_f32_u32);
-    XSIMD_BATCH_CAST_INTRINSIC(float, int32_t, 4, vcvtq_s32_f32);
-    XSIMD_BATCH_CAST_INTRINSIC(float, uint32_t, 4, vcvtq_u32_f32);
+    XSIMD_BATCH_CAST_INTRINSIC(int8_t, uint8_t, 16, vreinterpretq_u8_s8)
+    XSIMD_BATCH_CAST_INTRINSIC(uint8_t, int8_t, 16, vreinterpretq_s8_u8)
+    XSIMD_BATCH_CAST_INTRINSIC(int16_t, uint16_t, 8, vreinterpretq_u16_s16)
+    XSIMD_BATCH_CAST_INTRINSIC(uint16_t, int16_t, 8, vreinterpretq_s16_u16)
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, uint32_t, 4, vreinterpretq_u32_s32)
+    XSIMD_BATCH_CAST_INTRINSIC(int32_t, float, 4, vcvtq_f32_s32)
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, int32_t, 4, vreinterpretq_s32_u32)
+    XSIMD_BATCH_CAST_INTRINSIC(uint32_t, float, 4, vcvtq_f32_u32)
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, uint64_t, 2, vreinterpretq_u64_s64)
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, int64_t, 2, vreinterpretq_s64_u64)
+    XSIMD_BATCH_CAST_INTRINSIC(float, int32_t, 4, vcvtq_s32_f32)
+    XSIMD_BATCH_CAST_INTRINSIC(float, uint32_t, 4, vcvtq_u32_f32)
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
-    XSIMD_BATCH_CAST_INTRINSIC(int64_t, uint64_t, 2, vreinterpretq_u64_s64);
-    XSIMD_BATCH_CAST_INTRINSIC(int64_t, double, 2, vcvtq_f64_s64);
-    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, int64_t, 2, vreinterpretq_s64_u64);
-    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, double, 2, vcvtq_f64_u64);
-    XSIMD_BATCH_CAST_INTRINSIC(double, int64_t, 2, vcvtq_s64_f64);
-    XSIMD_BATCH_CAST_INTRINSIC(double, uint64_t, 2, vcvtq_u64_f64);
+    XSIMD_BATCH_CAST_INTRINSIC(int64_t, double, 2, vcvtq_f64_s64)
+    XSIMD_BATCH_CAST_INTRINSIC(uint64_t, double, 2, vcvtq_f64_u64)
+    XSIMD_BATCH_CAST_INTRINSIC(double, int64_t, 2, vcvtq_s64_f64)
+    XSIMD_BATCH_CAST_INTRINSIC(double, uint64_t, 2, vcvtq_u64_f64)
 #endif
 
     /**************************
@@ -185,46 +185,107 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 int32_t, 4,
-                                 vreinterpretq_s32_f32)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 int64_t, 2,
-                                 vreinterpretq_s64_f32)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
-                                 float, 4,
-                                 vreinterpretq_f32_s32)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
-                                 float, 4,
-                                 vreinterpretq_f32_s64)
-
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, int8_t, 16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, uint8_t, 16, vreinterpretq_u8_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, int16_t, 8, vreinterpretq_s16_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, uint16_t, 8, vreinterpretq_u16_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, int32_t, 4, vreinterpretq_s32_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, uint32_t, 4, vreinterpretq_u32_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, int64_t, 2, vreinterpretq_s64_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, uint64_t, 2, vreinterpretq_u64_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, float, 4, vreinterpretq_f32_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, int8_t, 16, vreinterpretq_s8_u8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, uint8_t, 16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, int16_t, 8, vreinterpretq_s16_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, uint16_t, 8, vreinterpretq_u16_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, int32_t, 4, vreinterpretq_s32_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, uint32_t, 4, vreinterpretq_u32_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, int64_t, 2, vreinterpretq_s64_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, uint64_t, 2, vreinterpretq_u64_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, float, 4, vreinterpretq_f32_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, int8_t, 16, vreinterpretq_s8_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, uint8_t, 16, vreinterpretq_u8_s16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, int16_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, uint16_t, 8, vreinterpretq_u16_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, int32_t, 4, vreinterpretq_s32_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, uint32_t, 4, vreinterpretq_u32_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, int64_t, 2, vreinterpretq_s64_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, uint64_t, 2, vreinterpretq_u64_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, float, 4, vreinterpretq_f32_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, int8_t, 16, vreinterpretq_s8_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, uint8_t, 16, vreinterpretq_u8_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, int16_t, 8, vreinterpretq_s16_u16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, uint16_t, 8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, int32_t, 4, vreinterpretq_s32_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, uint32_t, 4, vreinterpretq_u32_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, int64_t, 2, vreinterpretq_s64_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, uint64_t, 2, vreinterpretq_u64_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, float, 4, vreinterpretq_f32_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, int8_t, 16, vreinterpretq_s8_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, uint8_t, 16, vreinterpretq_u8_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, int16_t, 8, vreinterpretq_s16_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, uint16_t, 8, vreinterpretq_u16_s32)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, int32_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, uint32_t, 4, vreinterpretq_u32_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, int64_t, 2, vreinterpretq_s64_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, uint64_t, 2, vreinterpretq_u64_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, float, 4, vreinterpretq_f32_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, int8_t, 16, vreinterpretq_s8_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, uint8_t, 16, vreinterpretq_u8_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, int16_t, 8, vreinterpretq_s16_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, uint16_t, 8, vreinterpretq_u16_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, int32_t, 4, vreinterpretq_s32_u32)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, uint32_t, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, int64_t, 2, vreinterpretq_s64_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, uint64_t, 2, vreinterpretq_u64_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, float, 4, vreinterpretq_f32_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, int8_t, 16, vreinterpretq_s8_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, uint8_t, 16, vreinterpretq_u8_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, int16_t, 8, vreinterpretq_s16_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, uint16_t, 8, vreinterpretq_u16_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, int32_t, 4, vreinterpretq_s32_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, uint32_t, 4, vreinterpretq_u32_s64)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, int64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, uint64_t, 2, vreinterpretq_u64_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, float, 4, vreinterpretq_f32_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, int8_t, 16, vreinterpretq_s8_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, uint8_t, 16, vreinterpretq_u8_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, int16_t, 8, vreinterpretq_s16_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, uint16_t, 8, vreinterpretq_u16_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, int32_t, 4, vreinterpretq_s32_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, uint32_t, 4, vreinterpretq_u32_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, int64_t, 2, vreinterpretq_s64_u64)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, float, 4, vreinterpretq_f32_u64)
+    XSIMD_BITWISE_CAST_IMPLICIT(float, 4, float, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int8_t, 16, vreinterpretq_s8_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint8_t, 16, vreinterpretq_u8_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int16_t, 8, vreinterpretq_s16_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint16_t, 8, vreinterpretq_u16_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int32_t, 4, vreinterpretq_s32_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint32_t, 4, vreinterpretq_u32_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int64_t, 2, vreinterpretq_s64_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint64_t, 2, vreinterpretq_u64_f32)
 #if XSIMD_ARM_INSTR_SET >= XSIMD_ARM8_64_NEON_VERSION
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 float, 4,
-                                 vreinterpretq_f32_f64)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 int32_t, 4,
-                                 vreinterpretq_s32_f64)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 int64_t, 2,
-                                 vreinterpretq_s64_f64)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
-                                 double, 2,
-                                 vreinterpretq_f64_s32)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
-                                 double, 2,
-                                 vreinterpretq_f64_s64)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 double, 2,
-                                 vreinterpretq_f64_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, double, 2, vreinterpretq_f64_s8)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, double, 2, vreinterpretq_f64_u8)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, double, 2, vreinterpretq_f64_s16)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, double, 2, vreinterpretq_f64_u16)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, double, 2, vreinterpretq_f64_s32)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, double, 2, vreinterpretq_f64_u32)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, double, 2, vreinterpretq_f64_s64)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, double, 2, vreinterpretq_f64_u64)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, double, 2, vreinterpretq_f64_f32)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int8_t, 16, vreinterpretq_s8_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint8_t, 16, vreinterpretq_u8_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int16_t, 8, vreinterpretq_s16_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint16_t, 8, vreinterpretq_u16_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int32_t, 4, vreinterpretq_s32_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint32_t, 4, vreinterpretq_u32_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int64_t, 2, vreinterpretq_s64_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint64_t, 2, vreinterpretq_u64_f64)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, float, 4, vreinterpretq_f32_f64)
+    XSIMD_BITWISE_CAST_IMPLICIT(double, 2, double, 2)
 #endif
 
 }

--- a/include/xsimd/types/xsimd_sse_conversion.hpp
+++ b/include/xsimd/types/xsimd_sse_conversion.hpp
@@ -174,45 +174,106 @@ namespace xsimd
      * bitwise cast functions implementation *
      *****************************************/
 
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 double, 2,
-                                 _mm_castps_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 int32_t, 4,
-                                 _mm_castps_si128)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(float, 4,
-                                 int64_t, 2,
-                                 _mm_castps_si128)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 float, 4,
-                                 _mm_castpd_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 int32_t, 4,
-                                 _mm_castpd_si128)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(double, 2,
-                                 int64_t, 2,
-                                 _mm_castpd_si128)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
-                                 float, 4,
-                                 _mm_castsi128_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4,
-                                 double, 2,
-                                 _mm_castsi128_pd)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
-                                 float, 4,
-                                 _mm_castsi128_ps)
-
-    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2,
-                                 double, 2,
-                                 _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(int8_t, 16, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int8_t, 16, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint8_t, 16, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint8_t, 16, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(int16_t, 8, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int16_t, 8, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint16_t, 8, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint16_t, 8, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(int32_t, 4, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int32_t, 4, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint32_t, 4, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint32_t, 4, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(int64_t, 2, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(int64_t, 2, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, int8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, uint8_t, 16)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, int16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, uint16_t, 8)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, int32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, uint32_t, 4)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, int64_t, 2)
+    XSIMD_BITWISE_CAST_IMPLICIT(uint64_t, 2, uint64_t, 2)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, float, 4, _mm_castsi128_ps)
+    XSIMD_BITWISE_CAST_INTRINSIC(uint64_t, 2, double, 2, _mm_castsi128_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int8_t, 16, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint8_t, 16, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int16_t, 8, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint16_t, 8, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int32_t, 4, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint32_t, 4, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, int64_t, 2, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, uint64_t, 2, _mm_castps_si128)
+    XSIMD_BITWISE_CAST_IMPLICIT(float, 4, float, 4)
+    XSIMD_BITWISE_CAST_INTRINSIC(float, 4, double, 2, _mm_castps_pd)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int8_t, 16, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint8_t, 16, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int16_t, 8, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint16_t, 8, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int32_t, 4, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint32_t, 4, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, int64_t, 2, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, uint64_t, 2, _mm_castpd_si128)
+    XSIMD_BITWISE_CAST_INTRINSIC(double, 2, float, 4, _mm_castpd_ps)
+    XSIMD_BITWISE_CAST_IMPLICIT(double, 2, double, 2)
 }
 
 #endif

--- a/test/test_bitwise_cast.cpp
+++ b/test/test_bitwise_cast.cpp
@@ -13,200 +13,109 @@
 template <class CP>
 class bitwise_cast_test : public testing::Test
 {
-protected:
-
     static constexpr size_t N = CP::size;
     static constexpr size_t A = CP::alignment;
 
-    using int32_batch = xsimd::batch<int32_t, N * 2>;
-    using int64_batch = xsimd::batch<int64_t, N>;
-    using float_batch = xsimd::batch<float, N * 2>;
-    using double_batch = xsimd::batch<double, N>;
+    template <class T>
+    using batch_size = std::integral_constant<size_t, N * (sizeof(uint64_t) / sizeof(T))>;
+    
+    template <class T>
+    using test_batch = xsimd::batch<T, batch_size<T>::value>;
 
-    using int32_vector = std::vector<int32_t, xsimd::aligned_allocator<int32_t, A>>;
-    using int64_vector = std::vector<int64_t, xsimd::aligned_allocator<int64_t, A>>;
-    using float_vector = std::vector<float, xsimd::aligned_allocator<float, A>>;
-    using double_vector = std::vector<double, xsimd::aligned_allocator<double, A>>;
+    template <class T>
+    using test_vector = std::vector<T, xsimd::aligned_allocator<T, A>>;
 
-    int32_vector ftoi32_res;
-    int32_vector dtoi32_res;
-    int64_vector ftoi64_res;
-    int64_vector dtoi64_res;
-    float_vector i32tof_res;
-    float_vector i64tof_res;
-    float_vector dtof_res;
-    double_vector i32tod_res;
-    double_vector i64tod_res;
-    double_vector ftod_res;
-
-    bitwise_cast_test()
-        : ftoi32_res(2 * N), dtoi32_res(2 * N), ftoi64_res(N), dtoi64_res(N),
-          i32tof_res(2 * N), i64tof_res(2 * N), dtof_res(2 * N),
-          i32tod_res(N), i64tod_res(N), ftod_res(N)
+    template <class T>
+    test_vector<T> make_vector(const test_batch<T>& b)
     {
-        {
-            int32_batch input = i32_input();
-            bitcast b;
-            b.i32[0] = input[0];
-            b.i32[1] = input[1];
-            std::fill(i32tof_res.begin(), i32tof_res.end(), b.f[0]);
-            std::fill(i32tod_res.begin(), i32tod_res.end(), b.d);
-        }
-        {
-            int64_batch input = i64_input();
-            bitcast b;
-            b.i64 = input[0];
-            std::fill(i64tod_res.begin(), i64tod_res.end(), b.d);
-            for (size_t i = 0; i < N; ++i)
-            {
-                i64tof_res[2 * i] = b.f[0];
-                i64tof_res[2 * i + 1] = b.f[1];
-            }
-        }
-        {
-            float_batch input = f_input();
-            bitcast b;
-            b.f[0] = input[0];
-            b.f[1] = input[1];
-            std::fill(ftoi32_res.begin(), ftoi32_res.end(), b.i32[0]);
-            std::fill(ftoi64_res.begin(), ftoi64_res.end(), b.i64);
-            std::fill(ftod_res.begin(), ftod_res.end(), b.d);
-        }
-        {
-            double_batch input = d_input();
-            bitcast b;
-            b.d = input[0];
-            //std::fill(dtoi32_res.begin(), dtoi32_res.end(), b.i32[0]);
-            std::fill(dtoi64_res.begin(), dtoi64_res.end(), b.i64);
-            for (size_t i = 0; i < N; ++i)
-            {
-                dtoi32_res[2 * i] = b.i32[0];
-                dtoi32_res[2 * i + 1] = b.i32[1];
-                dtof_res[2 * i] = b.f[0];
-                dtof_res[2 * i + 1] = b.f[1];
-            }
-        }
+        test_vector<T> v(test_batch<T>::size);
+        b.store_aligned(v.data());
+        return v;
     }
 
-    void test_to_int32()
+    template<typename FromT, typename ToT>
+    void test_from_to(const char* from_name, const char* to_name)
     {
-        int32_vector i32vres(int32_batch::size);
-        {
-            int32_batch i32bres = xsimd::bitwise_cast<int32_batch>(f_input());
-            i32bres.store_aligned(i32vres.data());
-            EXPECT_VECTOR_EQ(i32vres, ftoi32_res) << print_function_name("to_int32(float)");
-        }
-        {
-            int32_batch i32bres = xsimd::bitwise_cast<int32_batch>(d_input());
-            i32bres.store_aligned(i32vres.data());
-            EXPECT_VECTOR_EQ(i32vres, dtoi32_res) << print_function_name("to_int32(double)");
-        }
+        using from_batch = test_batch<FromT>;
+        using to_batch = test_batch<ToT>;
+
+        auto input = from_batch(FromT(123));
+
+        auto vector_input = make_vector(input);
+        test_vector<ToT> reference_vector_output(to_batch::size);
+        std::memcpy(reference_vector_output.data(), vector_input.data(), to_batch::size * sizeof(ToT));
+        
+        auto batch_cast_output = xsimd::bitwise_cast<to_batch>(input);
+        auto batch_cast_vector_output = make_vector(batch_cast_output);
+
+        EXPECT_VECTOR_EQ(batch_cast_vector_output, reference_vector_output) << print_function_name(std::string{} + from_name + " => " + to_name);
     }
 
-    void test_to_int64()
+protected:
+    template<typename ToT>
+    void test_to(const char* to_name)
     {
-        int64_vector i64vres(int64_batch::size);
-        {
-            int64_batch i64bres = xsimd::bitwise_cast<int64_batch>(f_input());
-            i64bres.store_aligned(i64vres.data());
-            EXPECT_VECTOR_EQ(i64vres, ftoi64_res) << print_function_name("to_int64(float)");
-        }
-        {
-            int64_batch i64bres = xsimd::bitwise_cast<int64_batch>(d_input());
-            i64bres.store_aligned(i64vres.data());
-            EXPECT_VECTOR_EQ(i64vres, dtoi64_res) << print_function_name("to_int64(double)");
-        }
+        test_from_to<int8_t, ToT>("int8_t", to_name);
+        test_from_to<uint8_t, ToT>("uint8_t", to_name);
+        test_from_to<int16_t, ToT>("int16_t", to_name);
+        test_from_to<uint16_t, ToT>("uint16_t", to_name);
+        test_from_to<int32_t, ToT>("int32_t", to_name);
+        test_from_to<uint32_t, ToT>("uint32_t", to_name);
+        test_from_to<int64_t, ToT>("int64_t", to_name);
+        test_from_to<uint64_t, ToT>("uint64_t", to_name);
+        test_from_to<float, ToT>("float", to_name);
+        test_from_to<double, ToT>("double", to_name);
     }
-
-    void test_to_float()
-    {
-        float_vector fvres(float_batch::size);
-        {
-            float_batch fbres = xsimd::bitwise_cast<float_batch>(i32_input());
-            fbres.store_aligned(fvres.data());
-            EXPECT_VECTOR_EQ(fvres, i32tof_res) << print_function_name("to_float(int32_t)");
-        }
-        {
-            float_batch fbres = xsimd::bitwise_cast<float_batch>(i64_input());
-            fbres.store_aligned(fvres.data());
-            EXPECT_VECTOR_EQ(fvres, i64tof_res) << print_function_name("to_float(int64_t)");
-        }
-        {
-            float_batch fbres = xsimd::bitwise_cast<float_batch>(d_input());
-            fbres.store_aligned(fvres.data());
-            EXPECT_VECTOR_EQ(fvres, dtof_res) << print_function_name("to_float(double)");
-        }
-    }
-
-    void test_to_double()
-    {
-        double_vector dvres(double_batch::size);
-        {
-            double_batch dbres = xsimd::bitwise_cast<double_batch>(i32_input());
-            dbres.store_aligned(dvres.data());
-            EXPECT_VECTOR_EQ(dvres, i32tod_res) << print_function_name("to_double(int32_t)");
-        }
-        {
-            double_batch dbres = xsimd::bitwise_cast<double_batch>(i64_input());
-            dbres.store_aligned(dvres.data());
-            EXPECT_VECTOR_EQ(dvres, i64tod_res) << print_function_name("to_double(int64_t)");
-        }
-        {
-            double_batch dbres = xsimd::bitwise_cast<double_batch>(f_input());
-            dbres.store_aligned(dvres.data());
-            EXPECT_VECTOR_EQ(dvres, ftod_res) << print_function_name("to_double(float)");
-        }
-    }
-
-private:
-
-    int32_batch i32_input() const
-    {
-        return int32_batch(2);
-    }
-
-    int64_batch i64_input() const
-    {
-        return int64_batch(2);
-    }
-
-    float_batch f_input() const
-    {
-        return float_batch(3.);
-    }
-
-    double_batch d_input() const
-    {
-        return double_batch(2.5e17);
-    }
-
-    union bitcast
-    {
-        float f[2];
-        int32_t i32[2];
-        int64_t i64;
-        double d;
-    };
 };
 
 TYPED_TEST_SUITE(bitwise_cast_test, conversion_types, conversion_test_names);
 
+TYPED_TEST(bitwise_cast_test, to_int8)
+{
+    this->template test_to<int8_t>("int8_t");
+}
+
+TYPED_TEST(bitwise_cast_test, to_uint8)
+{
+    this->template test_to<uint8_t>("uint8_t");
+}
+
+TYPED_TEST(bitwise_cast_test, to_int16)
+{
+    this->template test_to<int16_t>("int16_t");
+}
+
+TYPED_TEST(bitwise_cast_test, to_uint16)
+{
+    this->template test_to<uint16_t>("uint16_t");
+}
+
 TYPED_TEST(bitwise_cast_test, to_int32)
 {
-    this->test_to_int32();
+    this->template test_to<int32_t>("int32_t");
+}
+
+TYPED_TEST(bitwise_cast_test, to_uint32)
+{
+    this->template test_to<uint32_t>("uint32_t");
 }
 
 TYPED_TEST(bitwise_cast_test, to_int64)
 {
-    this->test_to_int64();
+    this->template test_to<int64_t>("int64_t");
+}
+
+TYPED_TEST(bitwise_cast_test, to_uint64)
+{
+    this->template test_to<uint64_t>("uint64_t");
 }
 
 TYPED_TEST(bitwise_cast_test, to_float)
 {
-    this->test_to_float();
+    this->template test_to<float>("float");
 }
 
 TYPED_TEST(bitwise_cast_test, to_double)
 {
-    this->test_to_double();
+    this->template test_to<double>("double");
 }


### PR DESCRIPTION
The existing bitwise_cast implementation only had support for casting
between floats, doubles, int32s and int64s. This change adds support
for casting to/from int8s and int16s as well as all the unsigned ints.

I chose to add explicit instantiations for all the different
permutations as opposed to using partial template specialisation or
SFINAE as I wanted to keep the implementation simple despite that
resulting in a very verbose implementation.