### PR TITLE
added XSIMD_VERSION_* defines back to config

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -1,6 +1,9 @@
 #ifndef XSIMD_CONFIG_HPP
 #define XSIMD_CONFIG_HPP
 
+#define XSIMD_VERSION_MAJOR 8
+#define XSIMD_VERSION_MINOR 0
+#define XSIMD_VERSION_PATCH 0
 
 /**
  * high level free functions


### PR DESCRIPTION
the config file is missing `XSIMD_VERSION_*`  which are still needed in the CMakeLists.
Not sure if 8.0.0 is the correct version of master