### PR TITLE
Fix avx512 build error from clang

### DIFF
--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -148,10 +148,10 @@ namespace xsimd {
       else {
         switch(sizeof(T)) {
           case 1: {
-            uint64_t mask_low0 = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x000000FF), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x000000FF), Cmp);
-            uint64_t mask_low1 = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x0000FF00), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x0000FF00), Cmp);
-            uint64_t mask_high0 = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x00FF0000), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x00FF0000), Cmp);
-            uint64_t mask_high1 = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0xFF000000), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0xFF000000), Cmp);
+            uint64_t mask_low0 = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x000000FF)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x000000FF)), Cmp);
+            uint64_t mask_low1 = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x0000FF00)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x0000FF00)), Cmp);
+            uint64_t mask_high0 = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x00FF0000)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x00FF0000)), Cmp);
+            uint64_t mask_high1 = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0xFF000000)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0xFF000000)), Cmp);
             uint64_t mask = 0;
             for(unsigned i = 0; i < 16; ++i) {
               mask |= (mask_low0 & (uint64_t(1) << i)) << (3 * i + 0);
@@ -162,8 +162,8 @@ namespace xsimd {
             return (register_type)mask;
           }
           case 2: {
-            uint16_t mask_low = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x0000FFFF), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x0000FFFF), Cmp);
-            uint16_t mask_high = _mm512_cmp_epu32_mask(batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0xFFFF0000), batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0xFFFF0000), Cmp);
+            uint16_t mask_low = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0x0000FFFF)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0x0000FFFF)), Cmp);
+            uint16_t mask_high = _mm512_cmp_epu32_mask((batch<uint32_t, A>(self.data) & batch<uint32_t, A>(0xFFFF0000)), (batch<uint32_t, A>(other.data)  & batch<uint32_t, A>(0xFFFF0000)), Cmp);
             return static_cast<register_type>(morton(mask_low, mask_high));
           }
           case 4: return (register_type)_mm512_cmp_epu32_mask(self, other, Cmp);

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -130,7 +130,10 @@
 #ifdef __AVX512F__
     // AVX512 instructions are supported starting with gcc 6
     // see https://www.gnu.org/software/gcc/gcc-6/changes.html
-    #if defined(__GNUC__) && __GNUC__ < 6
+    // check clang first, newer clang always defines __GNUC__ = 4
+    #if defined(__clang__) && __clang_major__ >= 6
+        #define XSIMD_WITH_AVX512F 1
+    #elif defined(__GNUC__) && __GNUC__ < 6
         #define XSIMD_WITH_AVX512F 0
     #else
         #define XSIMD_WITH_AVX512F 1


### PR DESCRIPTION
I'm building apache arrow with latest xsimd and met with many errors
when using clang and enabling avx512. This patch fixes the issues.