### PR TITLE
Fix extract_pair implementation on SSSE3

### DIFF
--- a/include/xsimd/arch/xsimd_ssse3.hpp
+++ b/include/xsimd/arch/xsimd_ssse3.hpp
@@ -24,20 +24,21 @@ namespace xsimd {
     namespace detail {
 
       template<class T, class A>
-      batch<T, A> extract_pair(batch<T, A> const&, batch<T, A> const& other, std::size_t, ::xsimd::detail::index_sequence<0>) {
+      batch<T, A> extract_pair(batch<T, A> const&, batch<T, A> const& other, std::size_t, ::xsimd::detail::index_sequence<>) {
         return other;
       }
 
-      template<class T, class A, size_t I, std::size_t... Is>
+      template<class T, class A, std::size_t I, std::size_t... Is>
       batch<T, A> extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, ::xsimd::detail::index_sequence<I, Is...>) {
-        if(i == I)
+        if(i == I) {
           return _mm_alignr_epi8(self, other, sizeof(T) * I);
+        }
         else
           return extract_pair(self, other, i, ::xsimd::detail::index_sequence<Is...>());
       }
     }
 
-    template<class A, class T, typename std::enable_if<std::is_integral<T>::value, void>::type>
+    template<class A, class T, class _ = typename std::enable_if<std::is_integral<T>::value, void>::type>
     batch<T, A> extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, requires_arch<ssse3>) {
       constexpr std::size_t size = batch<T, A>::size;
       assert(0<= i && i< size && "index in bounds");

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -94,7 +94,7 @@ namespace xsimd {
   } // namespace detail
 
   struct unsupported {};
-  using all_x86_architectures = arch_list<avx512bw, avx512dq, avx512cd, avx512f, fma5, avx2, /*fma3, xop, fma4,*/ avx, sse4_2, sse4_1, /*sse4a, ssse3,*/ sse3, sse2>;
+  using all_x86_architectures = arch_list<avx512bw, avx512dq, avx512cd, avx512f, fma5, avx2, /*fma3, xop, fma4,*/ avx, sse4_2, sse4_1, /*sse4a,*/ ssse3, sse3, sse2>;
   using all_arm_architectures = arch_list<neon64, neon>;
   using all_architectures = typename detail::join<all_arm_architectures, all_x86_architectures>::type;
 


### PR DESCRIPTION
Missing default template argument and invalid recursion...

Fix #557