### PR TITLE
Adding missing header "memory"

### DIFF
--- a/include/xsimd/memory/xsimd_aligned_allocator.hpp
+++ b/include/xsimd/memory/xsimd_aligned_allocator.hpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <cassert>
+#include <memory>
 
 namespace xsimd
 {


### PR DESCRIPTION
Build apache arrow on fedora-33 with clang-11 failed with below xsimd error:

xsimd_ep/src/xsimd_ep-install/include/xsimd/types/../memory/xsimd_aligned_allocator.hpp:345:15:
error: no member named 'allocator' in namespace 'std'; did you mean 'alloca'?
              std::allocator<T>
              ^~~~~