### PR TITLE
Fix SSE build failure with MSVC

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -210,6 +210,9 @@
 // Workaround for MSVC compiler
 #ifdef _MSC_VER
 
+// NB: MSVC does not define __SSEn__
+#define XSIMD_WITH_SSE4_2 1
+
 #if XSIMD_WITH_AVX512
 #define XSIMD_WITH_AVX2 1
 #endif


### PR DESCRIPTION
MSVC does not define `__SSEn__` macros. Currently, we have to specify `/arch:AVXn` for an SSE only binary.

Fix https://github.com/xtensor-stack/xsimd/issues/561