### PR TITLE
Add Shuffle-nbit(32bit/64bit) integers in a across lanes

### DIFF
--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -335,7 +335,21 @@ namespace xsimd {
       }
     }
 
-
+    // Shuffle_nbit
+    namespace detail
+    {
+      template <class T, size_t S>
+      using enable_nbit_sized_t = typename std::enable_if<std::is_integral<T>::value &&
+                                                          sizeof(T) == S, int>::type;
+    }
+    template<class A, class T, detail::enable_nbit_sized_t<T, 4> = 0>
+    batch<T, A> shuffle_nbit(batch<T, A>& s_mask, batch<T, A>& self, requires_arch<avx2>) {
+      return _mm256_permutevar8x32_epi32(self, s_mask);
+    }
+    template<class A, class T, class=typename std::enable_if<std::is_integral<T>::value, void>::type>
+    batch<float, A> shuffle_nbit(batch<T, A>& s_mask, batch<float, A>& self, requires_arch<avx2>) {
+      return _mm256_permutevar8x32_ps(self, s_mask);
+    }
 
   }
 

--- a/include/xsimd/arch/xsimd_avx512bw.hpp
+++ b/include/xsimd/arch/xsimd_avx512bw.hpp
@@ -256,6 +256,19 @@ namespace xsimd {
       }
     }
 
+    // Shuffle_nbit
+    namespace detail
+    {
+      template <class T, size_t S>
+      using enable_nbit_sized_t = typename std::enable_if<std::is_integral<T>::value &&
+                                                          sizeof(T) == S, int>::type;
+    }
+    // Shuffle 16-bit integers by shuffle mask
+    template<class A, class T, detail::enable_nbit_sized_t<T, 2> = 0>
+    batch<T, A> shuffle_nbit(batch<T, A>& s_mask, batch<T, A>& self, requires_arch<avx512bw>) {
+      return _mm512_permutexvar_epi16(s_mask, self);
+    }
+
   }
 
 }

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -1234,6 +1234,29 @@ namespace xsimd {
       return _mm512_permutexvar_pd(s_mask, self);
     }
 
+    // Shuffle nx128-bit
+    namespace detail {
+      template<class T, class A>
+      batch<T, A> shuffle_nx128bit_avx512(batch<T, A>& self, batch<T, A>&, std::size_t, ::xsimd::detail::index_sequence<>) {
+        return self;
+      }
+
+      template<class T, class A, std::size_t I, std::size_t... Is>
+      batch<T, A> shuffle_nx128bit_avx512(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, ::xsimd::detail::index_sequence<I, Is...>) {
+        if(i == I) {
+          return _mm512_shuffle_i32x4(self, other, I);
+        }
+        else
+          return shuffle_nx128bit_avx512(self, other, i, ::xsimd::detail::index_sequence<Is...>());
+      }
+    }
+    template<class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+    batch<T, A> shuffle_nx128bit(batch<T, A>& self, batch<T, A>& other, std::size_t i, requires_arch<avx512f>) {
+      constexpr std::size_t size = std::numeric_limits<unsigned char>::max();
+      assert(0<= i && i< size && "index in bounds");
+      return detail::shuffle_nx128bit_avx512(self, other, i, ::xsimd::detail::make_index_sequence<size>());
+    }
+
   }
 
 }

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -1208,6 +1208,32 @@ namespace xsimd {
       return _mm512_unpacklo_pd(self, other);
     }
 
+    // Shuffle_nbit
+    namespace detail
+    {
+      template <class T, size_t S>
+      using enable_nbit_sized_t = typename std::enable_if<std::is_integral<T>::value &&
+                                                          sizeof(T) == S, int>::type;
+    }
+    // 32-bit
+    template<class A, class T, detail::enable_nbit_sized_t<T, 4> = 0>
+    batch<T, A> shuffle_nbit(batch<T, A>& s_mask, batch<T, A>& self, requires_arch<avx512f>) {
+      return _mm512_permutexvar_epi32(s_mask, self);
+    }
+    template<class A, class T, class=typename std::enable_if<std::is_integral<T>::value, void>::type>
+    batch<float, A> shuffle_nbit(batch<T, A>& s_mask, batch<float, A>& self, requires_arch<avx512f>) {
+      return _mm512_permutexvar_ps(s_mask, self);
+    }
+    // 64-bit
+    template<class A, class T, detail::enable_nbit_sized_t<T, 8> = 0>
+    batch<T, A> shuffle_nbit(batch<T, A>& s_mask, batch<T, A>& self, requires_arch<avx512f>) {
+      return _mm512_permutexvar_epi64(s_mask, self);
+    }
+    template<class A, class T, class=typename std::enable_if<std::is_integral<T>::value, void>::type>
+    batch<double, A> shuffle_nbit(batch<T, A>& s_mask, batch<double, A>& self, requires_arch<avx512f>) {
+      return _mm512_permutexvar_pd(s_mask, self);
+    }
+
   }
 
 }

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1528,6 +1528,7 @@ batch<as_integer_t<T>, A> to_int(batch<T, A> const& x) {
   return kernel::to_int<A>(x, A{});
 }
 
+#if XSIMD_WITH_AVX2 || XSIMD_WITH_AVX512
 /**
  * Shuffle 16/32/64 bit integers in \c y
  * across lanes using the corresponding index in idx: \c x
@@ -1540,6 +1541,7 @@ template <class T, class A>
 batch<T, A> shuffle_nbit(batch<T, A>& x, batch<T, A>& y) {
   return kernel::shuffle_nbit<A>(x, y, A{});
 }
+#endif
 
 /**
  * @ingroup batch_rounding

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1529,6 +1529,19 @@ batch<as_integer_t<T>, A> to_int(batch<T, A> const& x) {
 }
 
 /**
+ * Shuffle 16/32/64 bit integers in \c y
+ * across lanes using the corresponding index in idx: \c x
+ * and store the results in dst.
+ * @param x index mask
+ * @param y batch of target values.
+ * @return.
+ */
+template <class T, class A>
+batch<T, A> shuffle_nbit(batch<T, A>& x, batch<T, A>& y) {
+  return kernel::shuffle_nbit<A>(x, y, A{});
+}
+
+/**
  * @ingroup batch_rounding
  *
  * Computes the batch of nearest integer values not greater in magnitude

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1541,6 +1541,18 @@ template <class T, class A>
 batch<T, A> shuffle_nbit(batch<T, A>& x, batch<T, A>& y) {
   return kernel::shuffle_nbit<A>(x, y, A{});
 }
+
+/**
+ * Shuffle 128 bit selected by i
+ * from \c x and \c y
+ * and store the results in dst.
+ * @return.
+ */
+
+template <class T, class A>
+batch<T, A> shuffle_nx128bit(batch<T, A>& x, batch<T, A>& y, std::size_t i) {
+  return kernel::shuffle_nx128bit<A>(x, y, i, A{});
+}
 #endif
 
 /**


### PR DESCRIPTION
Add Shuffle-nbit(32bit/64bit) integers in a across lanes using the corresponding 256/512bit mask and store the results in dst.
It's just for 256/512bit(Avx2/Avx512), not for 128bit(neon/sse).

