### PR TITLE
Fix msvc build warnings

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -211,34 +211,42 @@
 #ifdef _MSC_VER
 
 #if XSIMD_WITH_AVX512
+#undef XSIMD_WITH_AVX2
 #define XSIMD_WITH_AVX2 1
 #endif
 
 #if XSIMD_WITH_AVX2
+#undef XSIMD_WITH_AVX
 #define XSIMD_WITH_AVX 1
 #endif
 
 #if XSIMD_WITH_AVX
+#undef XSIMD_WITH_SSE4_2
 #define XSIMD_WITH_SSE4_2 1
 #endif
 
 #if !defined(__clang__) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2))
+#undef XSIMD_WITH_SSE4_2
 #define XSIMD_WITH_SSE4_2 1
 #endif
 
 #if XSIMD_WITH_SSE4_2
+#undef XSIMD_WITH_SSE4_1
 #define XSIMD_WITH_SSE4_1 1
 #endif
 
 #if XSIMD_WITH_SSE4_1
+#undef XSIMD_WITH_SSSE3
 #define XSIMD_WITH_SSSE3 1
 #endif
 
 #if XSIMD_WITH_SSSE3
+#undef XSIMD_WITH_SSE3
 #define XSIMD_WITH_SSE3 1
 #endif
 
 #if XSIMD_WITH_SSE3
+#undef XSIMD_WITH_SSE2
 #define XSIMD_WITH_SSE2 1
 #endif
 

--- a/test/test_select.cpp
+++ b/test/test_select.cpp
@@ -57,7 +57,7 @@ class select_test : public testing::Test
             detail::store_batch(out, res, i);
         }
         size_t diff = detail::get_nb_diff(res, expected);
-        EXPECT_EQ(diff, 0) << print_function_name("pow");
+        EXPECT_EQ(diff, 0) << print_function_name("select_dynamic");
     }
     struct pattern
     {
@@ -83,7 +83,7 @@ class select_test : public testing::Test
             detail::store_batch(out, res, i);
         }
         size_t diff = detail::get_nb_diff(res, expected);
-        EXPECT_EQ(diff, 0) << print_function_name("pow");
+        EXPECT_EQ(diff, 0) << print_function_name("select_static");
     }
 };
 


### PR DESCRIPTION
There are some msvc build warnings in current xsimd code. It may block
adoption of xsimd by some projects (e.g., apache arrow) if they treat
compiler warnings as errors. As xsimd is header only, it's not easy to
build xsimd separately to ignore the warnings.