### PR TITLE
Fix SSE2 not being detected correctly on MSVC for 32-bit targets

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -245,7 +245,7 @@
 #define XSIMD_WITH_SSE3 1
 #endif
 
-#if XSIMD_WITH_SSE3
+#if XSIMD_WITH_SSE3 || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
 #undef XSIMD_WITH_SSE2
 #define XSIMD_WITH_SSE2 1
 #endif


### PR DESCRIPTION
MSVC annoyingly does not define `__SSE2__` at all, instead relying on the fact that:
- SSE2 is supported unconditionally for x86-64 targets (which you already handle)
- SSE2 is opt-in for x86-32 targets and is detected by checking [`_M_IX86_FP >= 2`](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160`)

This PR adds the requisite checks to handle the 32-bit target scenario on MSVC.