### PR TITLE
Fix Arm64 Clang build issues when enabling '-DBUILD_TESTS'

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
         message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
         message(STATUS "CMAKE_CXX_LINK_EXECUTABLE: ${CMAKE_CXX_LINK_EXECUTABLE}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-parameter -Wextra -Wreorder -std=c++11")
-    elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^ppc64")
+    elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^ppc64"  OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fPIC -mcpu=${TARGET_ARCH} -mtune=${TARGET_ARCH} -Wunused-parameter -Wextra -Wreorder -std=c++11")
     elseif(NOT WIN32)
         if(NOT CMAKE_CXX_FLAGS MATCHES "-march")


### PR DESCRIPTION
Failed to `cmake `with clang-10/11/12 when enabling '-DBUILD_TESTS' on Arm64:

```
Run Build Command(s):/usr/bin/make cmTC_0043d/fast && /usr/bin/make -f CMakeFiles/cmTC_0043d.dir/build.make CMakeFiles/cmTC_0043d.dir/build
make[1]: Entering directory '/home/builder/xsimd/build/CMakeFiles/CMakeTmp'
Building CXX object CMakeFiles/cmTC_0043d.dir/src.cxx.o
/usr/bin/clang++-10    -march=native -DHAS_CPP11_FLAG   -std=c++11 -o CMakeFiles/cmTC_0043d.dir/src.cxx.o -c /home/builder/xsimd/build/CMakeFiles/CMakeTmp/src.cxx
clang: error: the clang compiler does not support '-march=native'
make[1]: *** [CMakeFiles/cmTC_0043d.dir/build.make:66: CMakeFiles/cmTC_0043d.dir/src.cxx.o] Error 1
make[1]: Leaving directory '/home/builder/xsimd/build/CMakeFiles/CMakeTmp'
make: *** [Makefile:121: cmTC_0043d/fast] Error 2
```