### PR TITLE
fix fast_cast selection

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_details.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_details.hpp
@@ -136,7 +136,9 @@ namespace xsimd {
 
       template <class A, class From, class To>
       struct conversion_type_impl<A, From, To,
-                void_t<decltype(fast_cast(std::declval<const From&>(), std::declval<const To&>(), std::declval<const A&>()))>>
+                void_t<decltype(fast_cast(std::declval<const batch<From, A>&>(),
+                                          std::declval<const batch<To, A>&>(),
+                                          std::declval<const A&>()))>>
       {
           using type = with_fast_conversion;
       };

--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -2283,19 +2283,6 @@ namespace xsimd
             return vcvtq_f32_s32(x);
         }
 
-        /*************
-         * fast_cast *
-         *************/
-
-        namespace detail
-        {
-            template <class Tin, class Tout, class A>
-            inline batch<Tout, A> fast_cast(batch<Tin, A> const& in, batch<Tout, A> const& out, requires_arch<neon>)
-            {
-                return bitwise_cast(in, out, A{});
-            }
-        }
-
         /*********
          * isnan *
          *********/

--- a/test/test_batch_cast.cpp
+++ b/test/test_batch_cast.cpp
@@ -51,6 +51,10 @@ namespace detail
     {
         return true;
     }
+
+    template <typename Arch, typename From, typename To>
+    using uses_fast_cast = std::is_same<xsimd::kernel::detail::conversion_type<Arch, From, To>,
+                                        xsimd::kernel::detail::with_fast_conversion>;
 }
 
 template <class CP>
@@ -347,5 +351,16 @@ TYPED_TEST(batch_cast_test, cast_sizeshift1)
 TYPED_TEST(batch_cast_test, cast_sizeshift2)
 {
     this->test_cast_sizeshift2();
+}
+#endif
+
+#if XSIMD_WITH_SSE2
+TEST(batch_cast, uses_fast_cast)
+{
+    using A = xsimd::default_arch;
+    static_assert(detail::uses_fast_cast<A, int32_t, float>::value,
+                  "expected int32 to float conversion to use fast_cast");
+    static_assert(detail::uses_fast_cast<A, float, int32_t>::value,
+                  "expected float to int32 conversion to use fast_cast");
 }
 #endif


### PR DESCRIPTION
Fixes #626 

I'm not sure about formatting; it would be helpful to have a clang-format config.

The value of a test for this is a bit questionable since you can't see what implementation will actually use, so feel free to skip that.