### PR TITLE
Enables support for FMA when AVX2 is detected on Windows

### DIFF
--- a/include/xsimd/arch/xsimd_fma3.hpp
+++ b/include/xsimd/arch/xsimd_fma3.hpp
@@ -12,7 +12,7 @@
 #ifndef XSIMD_FMA3_HPP
 #define XSIMD_FMA3_HPP
 
-#include "../types/xsimd_sse_register.hpp"
+#include "../types/xsimd_fma3_register.hpp"
 
 namespace xsimd
 {

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -229,6 +229,8 @@
 #if XSIMD_WITH_AVX2
 #undef XSIMD_WITH_AVX
 #define XSIMD_WITH_AVX 1
+#undef XSIMD_WITH_FMA5
+#define XSIMD_WITH_FMA5 1
 #endif
 
 #if XSIMD_WITH_AVX


### PR DESCRIPTION
Fixes #630 