### PR TITLE
Fix dispatch issues

### DIFF
--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -193,7 +193,7 @@ namespace xsimd
             auto walk_archs(arch_list<Arch, ArchNext, Archs...>, Tys&&... args) -> decltype(functor(Arch {}, std::forward<Tys>(args)...))
             {
                 static_assert(Arch::supported(), "dispatching on supported architecture");
-                if (Arch::version() == best_arch)
+                if (Arch::version() <= best_arch)
                     return functor(Arch {}, std::forward<Tys>(args)...);
                 else
                     return walk_archs(arch_list<ArchNext, Archs...> {}, std::forward<Tys>(args)...);

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -184,7 +184,6 @@ namespace xsimd
             template <class Arch, class... Tys>
             auto walk_archs(arch_list<Arch>, Tys&&... args) -> decltype(functor(Arch {}, std::forward<Tys>(args)...))
             {
-                static_assert(Arch::supported(), "dispatching on supported architecture");
                 assert(Arch::available() && "At least one arch must be supported during dispatch");
                 return functor(Arch {}, std::forward<Tys>(args)...);
             }
@@ -192,7 +191,6 @@ namespace xsimd
             template <class Arch, class ArchNext, class... Archs, class... Tys>
             auto walk_archs(arch_list<Arch, ArchNext, Archs...>, Tys&&... args) -> decltype(functor(Arch {}, std::forward<Tys>(args)...))
             {
-                static_assert(Arch::supported(), "dispatching on supported architecture");
                 if (Arch::version() <= best_arch)
                     return functor(Arch {}, std::forward<Tys>(args)...);
                 else

--- a/include/xsimd/config/xsimd_cpuid.hpp
+++ b/include/xsimd/config/xsimd_cpuid.hpp
@@ -131,12 +131,12 @@ namespace xsimd
                 avx = regs[2] >> 28 & 1;
                 best = std::max(best, avx::version() * avx);
 
-                // fma3 = regs[2] >> 12 & 1;
-                // best = std::max(best, XSIMD_X86_FMA3_VERSION * fma3);
+                fma3 = regs[2] >> 12 & 1;
 
                 get_cpuid(regs, 0x7);
                 avx2 = regs[1] >> 5 & 1;
                 best = std::max(best, avx2::version() * avx2);
+                best = std::max(best, fma5::version() * avx2 * fma3);
 
                 avx512f = regs[1] >> 16 & 1;
                 best = std::max(best, avx512f::version() * avx512f);

--- a/include/xsimd/config/xsimd_cpuid.hpp
+++ b/include/xsimd/config/xsimd_cpuid.hpp
@@ -45,6 +45,8 @@ namespace xsimd
             unsigned avx : 1;
             unsigned avx2 : 1;
             unsigned avx512f : 1;
+            unsigned avx512cd : 1;
+            unsigned avx512dq : 1;
             unsigned avx512bw : 1;
             unsigned neon : 1;
             unsigned neon64 : 1;
@@ -141,8 +143,14 @@ namespace xsimd
                 avx512f = regs[1] >> 16 & 1;
                 best = std::max(best, avx512f::version() * avx512f);
 
+                avx512cd = regs[1] >> 28 & 1;
+                best = std::max(best, avx512cd::version() * avx512cd * avx512f);
+
+                avx512dq = regs[1] >> 17 & 1;
+                best = std::max(best, avx512dq::version() * avx512dq * avx512cd * avx512f);
+
                 avx512bw = regs[1] >> 30 & 1;
-                best = std::max(best, avx512bw::version() * avx512bw);
+                best = std::max(best, avx512bw::version() * avx512bw * avx512dq * avx512cd * avx512f);
 
                 // get_cpuid(regs, 0x80000001);
                 // fma4 = regs[2] >> 16 & 1;

--- a/include/xsimd/types/xsimd_register.hpp
+++ b/include/xsimd/types/xsimd_register.hpp
@@ -20,7 +20,10 @@ namespace xsimd
     {
 
         template <class T, class Arch>
-        struct simd_register;
+        struct simd_register
+        {
+            static_assert(Arch::supported(), "usage of simd_register with unsupported architecture");
+        };
 
         template <class T, class A>
         struct has_simd_register : std::false_type

--- a/test/test_arch.cpp
+++ b/test/test_arch.cpp
@@ -70,6 +70,12 @@ struct sum
     }
 };
 
+struct get_arch_version
+{
+    template <class Arch>
+    unsigned operator()(Arch) { return Arch::version(); }
+};
+
 TEST(arch, dispatcher)
 {
     float data[17] = { 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f, 17.f };
@@ -88,6 +94,16 @@ TEST(arch, dispatcher)
         auto dispatched = xsimd::dispatch<sum, xsimd::arch_list<xsimd::avx, xsimd::sse2>>(sum {});
         float res = dispatched(data, 17);
         EXPECT_EQ(ref, res);
+    }
+
+    // check that we pick the most appropriate version
+    {
+        auto dispatched = xsimd::dispatch<get_arch_version,
+                                          xsimd::arch_list<xsimd::sse3, xsimd::sse2>>(get_arch_version {});
+        unsigned expected = xsimd::available_architectures().best >= xsimd::sse3::version()
+            ? xsimd::sse3::version()
+            : xsimd::sse2::version();
+        EXPECT_EQ(expected, dispatched());
     }
 #endif
 }


### PR DESCRIPTION
See #632, #633 and #634.

This doesn't cover the documentation or cmake aspects of #633; i think that's a separate job.

I'm not totally sure about the consequences of "add explicit check for architecture support in batch"; it could make for more mysterious error messages if simd_register is used directly for some reason, but I think it'll be alright.