### PR TITLE
add alignment helper to arch_list

### DIFF
--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -61,6 +61,18 @@ namespace xsimd
         {
         };
 
+        template <typename T>
+        constexpr T max_of(T value)
+        {
+            return value;
+        }
+
+        template <typename T, typename... Ts>
+        constexpr T max_of(T head0, T head1, Ts... tail)
+        {
+            return max_of((head0 > head1 ? head0 : head1), tail...);
+        }
+
     } // namespace detail
 
     // An arch_list is a list of architectures, sorted by version number.
@@ -88,6 +100,12 @@ namespace xsimd
         static void for_each(F&& f)
         {
             (void)std::initializer_list<bool> { (f(Archs {}), true)... };
+        }
+
+        static constexpr std::size_t alignment()
+        {
+            // all alignments are a power of two
+            return detail::max_of(Archs::alignment()..., static_cast<size_t>(0));
         }
     };
 

--- a/include/xsimd/types/xsimd_generic_arch.hpp
+++ b/include/xsimd/types/xsimd_generic_arch.hpp
@@ -23,6 +23,7 @@ namespace xsimd
     {
         static constexpr bool supported() { return true; }
         static constexpr bool available() { return true; }
+        static constexpr std::size_t alignment() { return 0; }
         static constexpr bool requires_alignment() { return false; }
 
     protected:

--- a/test/test_arch.cpp
+++ b/test/test_arch.cpp
@@ -53,6 +53,18 @@ TEST(arch, available)
     EXPECT_TRUE(xsimd::default_arch::available());
 }
 
+TEST(arch, arch_list_alignment)
+{
+    static_assert(xsimd::arch_list<xsimd::generic>::alignment() == 0,
+                  "generic");
+    static_assert(xsimd::arch_list<xsimd::sse2>::alignment()
+                      == xsimd::sse2::alignment(),
+                  "one architecture");
+    static_assert(xsimd::arch_list<xsimd::avx512f, xsimd::sse2>::alignment()
+                      == xsimd::avx512f::alignment(),
+                  "two architectures");
+}
+
 struct sum
 {
     template <class Arch, class T>


### PR DESCRIPTION
This is a follow-on from #635; this is useful when using per-architecture compilation and dynamic dispatch, as the required alignment when allocating data can be greater than the alignment of the default architecture.
