### PR TITLE
improve code generated for AVX2 signed integer comparisons

### DIFF
--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -569,44 +569,6 @@ namespace xsimd
             return _mm256_floor_pd(self);
         }
 
-        // ge
-        template <class A>
-        inline batch_bool<float, A> ge(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>)
-        {
-            return _mm256_cmp_ps(self, other, _CMP_GE_OQ);
-        }
-        template <class A>
-        inline batch_bool<double, A> ge(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>)
-        {
-            return _mm256_cmp_pd(self, other, _CMP_GE_OQ);
-        }
-        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>)
-        {
-            return detail::fwd_to_sse([](__m128i s, __m128i o)
-                                      { return ge(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
-                                      self, other);
-        }
-
-        // gt
-        template <class A>
-        inline batch_bool<float, A> gt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>)
-        {
-            return _mm256_cmp_ps(self, other, _CMP_GT_OQ);
-        }
-        template <class A>
-        inline batch_bool<double, A> gt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>)
-        {
-            return _mm256_cmp_pd(self, other, _CMP_GT_OQ);
-        }
-        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>)
-        {
-            return detail::fwd_to_sse([](__m128i s, __m128i o)
-                                      { return gt(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
-                                      self, other);
-        }
-
         // hadd
         template <class A>
         inline float hadd(batch<float, A> const& rhs, requires_arch<avx>)

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -262,29 +262,29 @@ namespace xsimd
             }
         }
 
-        // gt
+        // lt
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>)
+        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>)
         {
             if (std::is_signed<T>::value)
             {
                 switch (sizeof(T))
                 {
                 case 1:
-                    return _mm256_cmpgt_epi8(self, other);
+                    return _mm256_cmpgt_epi8(other, self);
                 case 2:
-                    return _mm256_cmpgt_epi16(self, other);
+                    return _mm256_cmpgt_epi16(other, self);
                 case 4:
-                    return _mm256_cmpgt_epi32(self, other);
+                    return _mm256_cmpgt_epi32(other, self);
                 case 8:
-                    return _mm256_cmpgt_epi64(self, other);
+                    return _mm256_cmpgt_epi64(other, self);
                 default:
-                    return gt(self, other, avx {});
+                    return lt(self, other, avx {});
                 }
             }
             else
             {
-                return gt(self, other, avx {});
+                return lt(self, other, avx {});
             }
         }
 


### PR DESCRIPTION
Previously, AVX2 `gt` was implemented, but `lt` fell back to the AVX `lt`, which is implemented with SSE2 instructions.

generic_logical has the following mappings:

 - `gt` -> `lt`
 - `ge` -> `le`
 - `le` -> `lt || eq`

so it seems best to just implement `eq`, `lt`, and `le` if it's available.

I've had a brief look at the SSE and NEON comparison code and they don't seem to be affected by this.

It's tempting to go through and delete all the `gt` and `ge` implementations as they don't seem to add anything, but I feel like I might be missing something.

Here's an example showing the issue: https://gcc.godbolt.org/z/Gd3K9WfTG