### PR TITLE
FMA5 defined with AVX instead of FMA3

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -123,7 +123,7 @@
  */
 #ifdef __FMA__
 
-#if defined(__AVX2__)
+#ifdef __AVX2__
 #define XSIMD_WITH_FMA5 1
 #else
 #define XSIMD_WITH_FMA5 0
@@ -241,13 +241,13 @@
 #if !defined(__clang__) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2))
 #undef XSIMD_WITH_SSE4_2
 #define XSIMD_WITH_SSE4_2 1
-#undef XSIMD_WITH_FMA3
-#define XSIMD_WITH_FMA3 1
 #endif
 
 #if XSIMD_WITH_SSE4_2
 #undef XSIMD_WITH_SSE4_1
 #define XSIMD_WITH_SSE4_1 1
+#undef XSIMD_WITH_FMA3
+#define XSIMD_WITH_FMA3 1
 #endif
 
 #if XSIMD_WITH_SSE4_1

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -241,6 +241,8 @@
 #if !defined(__clang__) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2))
 #undef XSIMD_WITH_SSE4_2
 #define XSIMD_WITH_SSE4_2 1
+#undef XSIMD_WITH_FMA3
+#define XSIMD_WITH_FMA3 1
 #endif
 
 #if XSIMD_WITH_SSE4_2

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -102,11 +102,11 @@
 /**
  * @ingroup xsimd_config_macro
  *
- * Set to 1 if FMA  for SSE is available at compile-time, to 0 otherwise.
+ * Set to 1 if FMA for SSE or AVX is available at compile-time, to 0 otherwise.
  */
 #ifdef __FMA__
 
-#if defined(__SSE__) && !defined(__AVX__)
+#if defined(__SSE__) || defined(__AVX__)
 #define XSIMD_WITH_FMA3 1
 #else
 #define XSIMD_WITH_FMA3 0
@@ -119,11 +119,11 @@
 /**
  * @ingroup xsimd_config_macro
  *
- * Set to 1 if FMA for AVX is available at compile-time, to 0 otherwise.
+ * Set to 1 if FMA for AVX2 is available at compile-time, to 0 otherwise.
  */
 #ifdef __FMA__
 
-#if defined(__AVX__)
+#if defined(__AVX2__)
 #define XSIMD_WITH_FMA5 1
 #else
 #define XSIMD_WITH_FMA5 0

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -102,11 +102,11 @@
 /**
  * @ingroup xsimd_config_macro
  *
- * Set to 1 if FMA for SSE or AVX is available at compile-time, to 0 otherwise.
+ * Set to 1 if FMA for SSE4.2 or AVX is available at compile-time, to 0 otherwise.
  */
 #ifdef __FMA__
 
-#if defined(__SSE__) || defined(__AVX__)
+#if defined(__SSE4_2__) || defined(__AVX__)
 #define XSIMD_WITH_FMA3 1
 #else
 #define XSIMD_WITH_FMA3 0


### PR DESCRIPTION
Updates the configuration checks for FMA-enabled ISA.
It allows the use of FMA3 with SSE4.2 or AVX, and FMA5 with AVX2.