### PR TITLE
Fix xsimd::transform for complex types.

### DIFF
--- a/include/xsimd/stl/algorithms.hpp
+++ b/include/xsimd/stl/algorithms.hpp
@@ -47,7 +47,7 @@ namespace xsimd
             for (std::size_t i = align_begin; i < align_end; i += simd_size)
             {
                 batch_type batch = batch_type::load_aligned(&first[i]);
-                xsimd::store_aligned(&out_first[i], f(batch));
+                f(batch).store_aligned(&out_first[i]);
             }
 
             for (std::size_t i = align_end; i < size; ++i)
@@ -65,7 +65,7 @@ namespace xsimd
             for (std::size_t i = align_begin; i < align_end; i += simd_size)
             {
                 batch_type batch = batch_type::load_aligned(&first[i]);
-                xsimd::store_unaligned(&out_first[i], f(batch));
+                f(batch).store_unaligned(&out_first[i]);
             }
 
             for (std::size_t i = align_end; i < size; ++i)
@@ -104,7 +104,7 @@ namespace xsimd
     {                                                                  \
         batch_1 = batch_type::A1(&first_1[i]);                         \
         batch_2 = batch_type::A2(&first_2[i]);                         \
-        xsimd::A3(&out_first[i], f(batch_1, batch_2));                 \
+        f(batch_1, batch_2).A3(&out_first[i]);                         \
     }                                                                  \
                                                                        \
     for (std::size_t i = align_end; i < size; ++i)                     \

--- a/test/test_algorithms.cpp
+++ b/test/test_algorithms.cpp
@@ -43,9 +43,9 @@ public:
 };
 
 #if XSIMD_WITH_NEON && !XSIMD_WITH_NEON64
-using algorithms_types = ::testing::Types<float>;
+using algorithms_types = ::testing::Types<float, std::complex<float>>;
 #else
-using algorithms_types = ::testing::Types<float, double>;
+using algorithms_types = ::testing::Types<float, double, std::complex<float>, std::complex<double>>;
 #endif
 
 TYPED_TEST_SUITE(algorithms, algorithms_types);

--- a/test/test_algorithms.cpp
+++ b/test/test_algorithms.cpp
@@ -34,21 +34,30 @@ struct unary_functor
     }
 };
 
-template <class T>
-using test_allocator_type = xsimd::aligned_allocator<T>;
+template <typename T>
+class algorithms : public testing::Test
+{
+public:
+    using vector = std::vector<T>;
+    using aligned_vector = std::vector<T, xsimd::aligned_allocator<T>>;
+};
 
 #if XSIMD_WITH_NEON && !XSIMD_WITH_NEON64
-using test_value_type = float;
+using algorithms_types = ::testing::Types<float>;
 #else
-using test_value_type = double;
+using algorithms_types = ::testing::Types<float, double>;
 #endif
 
-TEST(algorithms, binary_transform)
-{
-    std::vector<test_value_type> expected(93);
+TYPED_TEST_SUITE(algorithms, algorithms_types);
 
-    std::vector<test_value_type> a(93, 123), b(93, 123), c(93);
-    std::vector<test_value_type, test_allocator_type<test_value_type>> aa(93, 123), ba(93, 123), ca(93);
+TYPED_TEST(algorithms, binary_transform)
+{
+    using vector = typename TestFixture::vector;
+    using aligned_vector = typename TestFixture::aligned_vector;
+
+    vector expected(93);
+    vector a(93, 123), b(93, 123), c(93);
+    aligned_vector aa(93, 123), ba(93, 123), ca(93);
 
     std::transform(a.begin(), a.end(), b.begin(), expected.begin(),
                    binary_functor {});
@@ -89,11 +98,14 @@ TEST(algorithms, binary_transform)
     std::fill(ca.begin(), ca.end(), -1); // erase
 }
 
-TEST(algorithms, unary_transform)
+TYPED_TEST(algorithms, unary_transform)
 {
-    std::vector<test_value_type> expected(93);
-    std::vector<test_value_type> a(93, 123), c(93);
-    std::vector<test_value_type, test_allocator_type<test_value_type>> aa(93, 123), ca(93);
+    using vector = typename TestFixture::vector;
+    using aligned_vector = typename TestFixture::aligned_vector;
+
+    vector expected(93);
+    vector a(93, 123), c(93);
+    aligned_vector aa(93, 123), ca(93);
 
     std::transform(a.begin(), a.end(), expected.begin(),
                    unary_functor {});
@@ -118,6 +130,15 @@ TEST(algorithms, unary_transform)
     EXPECT_TRUE(std::equal(expected.begin(), expected.end(), ca.begin()) && expected.size() == ca.size());
     std::fill(ca.begin(), ca.end(), -1); // erase
 }
+
+template <class T>
+using test_allocator_type = xsimd::aligned_allocator<T>;
+
+#if XSIMD_WITH_NEON && !XSIMD_WITH_NEON64
+using test_value_type = float;
+#else
+using test_value_type = double;
+#endif
 
 class xsimd_reduce : public ::testing::Test
 {


### PR DESCRIPTION
This fixes #652. New tests are included.