### PR TITLE
Only use _mm256_unpacklo_epi<N> on AVX2

### DIFF
--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1146,6 +1146,37 @@ namespace xsimd
         {
             switch (sizeof(T))
             {
+            case 1:
+            case 2:
+            {
+                // extract low word
+                __m128i self_lo = _mm256_extractf128_si256(self, 0);
+                __m128i self_hi = _mm256_extractf128_si256(self, 1);
+                // extract high word
+                __m128i other_lo = _mm256_extractf128_si256(other, 0);
+                __m128i other_hi = _mm256_extractf128_si256(other, 1);
+
+                // interleave
+                __m128i res_lo, res_hi;
+                if (sizeof(T) == 1)
+                {
+                    res_lo = _mm_unpackhi_epi8(self_lo, other_lo);
+                    res_hi = _mm_unpackhi_epi8(self_hi, other_hi);
+                }
+                else
+                {
+                    res_lo = _mm_unpackhi_epi16(self_lo, other_lo);
+                    res_hi = _mm_unpackhi_epi16(self_hi, other_hi);
+                }
+
+                // fuse
+                return _mm256_castps_si256(
+                    _mm256_insertf128_ps(
+                        _mm256_castsi256_ps(_mm256_castsi128_si256(res_lo)),
+                        _mm_castsi128_ps(res_hi),
+                        1));
+            }
+
             case 4:
                 return _mm256_castps_si256(_mm256_unpackhi_ps(_mm256_castsi256_ps(self), _mm256_castsi256_ps(other)));
             case 8:
@@ -1172,6 +1203,36 @@ namespace xsimd
         {
             switch (sizeof(T))
             {
+            case 1:
+            case 2:
+            {
+                // extract low word
+                __m128i self_lo = _mm256_extractf128_si256(self, 0);
+                __m128i self_hi = _mm256_extractf128_si256(self, 1);
+                // extract high word
+                __m128i other_lo = _mm256_extractf128_si256(other, 0);
+                __m128i other_hi = _mm256_extractf128_si256(other, 1);
+
+                // interleave
+                __m128i res_lo, res_hi;
+                if (sizeof(T) == 1)
+                {
+                    res_lo = _mm_unpacklo_epi8(self_lo, other_lo);
+                    res_hi = _mm_unpacklo_epi8(self_hi, other_hi);
+                }
+                else
+                {
+                    res_lo = _mm_unpacklo_epi16(self_lo, other_lo);
+                    res_hi = _mm_unpacklo_epi16(self_hi, other_hi);
+                }
+
+                // fuse
+                return _mm256_castps_si256(
+                    _mm256_insertf128_ps(
+                        _mm256_castsi256_ps(_mm256_castsi128_si256(res_lo)),
+                        _mm_castsi128_ps(res_hi),
+                        1));
+            }
             case 4:
                 return _mm256_castps_si256(_mm256_unpacklo_ps(_mm256_castsi256_ps(self), _mm256_castsi256_ps(other)));
             case 8:
@@ -1192,9 +1253,7 @@ namespace xsimd
         {
             return _mm256_unpacklo_pd(self, other);
         }
-
     }
-
 }
 
 #endif

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1146,14 +1146,10 @@ namespace xsimd
         {
             switch (sizeof(T))
             {
-            case 1:
-                return _mm256_unpackhi_epi8(self, other);
-            case 2:
-                return _mm256_unpackhi_epi16(self, other);
             case 4:
-                return _mm256_unpackhi_epi32(self, other);
+                return _mm256_castps_si256(_mm256_unpackhi_ps(_mm256_castsi256_ps(self), _mm256_castsi256_ps(other)));
             case 8:
-                return _mm256_unpackhi_epi64(self, other);
+                return _mm256_castpd_si256(_mm256_unpackhi_pd(_mm256_castsi256_pd(self), _mm256_castsi256_pd(other)));
             default:
                 assert(false && "unsupported arch/op combination");
                 return {};
@@ -1176,19 +1172,16 @@ namespace xsimd
         {
             switch (sizeof(T))
             {
-            case 1:
-                return _mm256_unpacklo_epi8(self, other);
-            case 2:
-                return _mm256_unpacklo_epi16(self, other);
             case 4:
-                return _mm256_unpacklo_epi32(self, other);
+                return _mm256_castps_si256(_mm256_unpacklo_ps(_mm256_castsi256_ps(self), _mm256_castsi256_ps(other)));
             case 8:
-                return _mm256_unpacklo_epi64(self, other);
+                return _mm256_castpd_si256(_mm256_unpacklo_pd(_mm256_castsi256_pd(self), _mm256_castsi256_pd(other)));
             default:
                 assert(false && "unsupported arch/op combination");
                 return {};
             }
         }
+
         template <class A>
         inline batch<float, A> zip_lo(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
         {

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -596,6 +596,46 @@ namespace xsimd
                 return sub(self, other, avx {});
             }
         }
+
+        // zip_hi
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        inline batch<T, A> zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        {
+            switch (sizeof(T))
+            {
+            case 1:
+                return _mm256_unpackhi_epi8(self, other);
+            case 2:
+                return _mm256_unpackhi_epi16(self, other);
+            case 4:
+                return _mm256_unpackhi_epi32(self, other);
+            case 8:
+                return _mm256_unpackhi_epi64(self, other);
+            default:
+                assert(false && "unsupported arch/op combination");
+                return {};
+            }
+        }
+
+        // zip_lo
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        inline batch<T, A> zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        {
+            switch (sizeof(T))
+            {
+            case 1:
+                return _mm256_unpacklo_epi8(self, other);
+            case 2:
+                return _mm256_unpacklo_epi16(self, other);
+            case 4:
+                return _mm256_unpacklo_epi32(self, other);
+            case 8:
+                return _mm256_unpacklo_epi64(self, other);
+            default:
+                assert(false && "unsupported arch/op combination");
+                return {};
+            }
+        }
     }
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,7 +170,7 @@ set(XSIMD_TESTS
     test_power.cpp
     test_rounding.cpp
     test_select.cpp
-    test_shuffle_128.cpp
+    test_shuffle.cpp
     test_traits.cpp
     test_trigonometric.cpp
     test_utils.hpp


### PR DESCRIPTION
As a workaround, rely on cast from float to support epi32 and epi64 on AVX.

Should fix #668