### PR TITLE
Prevent building invalid batch due to implicit conversion

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_logical.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_logical.hpp
@@ -84,12 +84,12 @@ namespace xsimd
         template <class A>
         inline batch_bool<float, A> isfinite(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
-            return (self - self) == 0;
+            return (self - self) == 0.f;
         }
         template <class A>
         inline batch_bool<double, A> isfinite(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
-            return (self - self) == 0;
+            return (self - self) == 0.;
         }
 
         // isnan

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -217,6 +217,9 @@ namespace xsimd
         batch_bool(register_type reg) noexcept;
         batch_bool(std::initializer_list<bool> data) noexcept;
 
+        template <class Tp>
+        batch_bool(Tp const*) = delete;
+
         // memory operators
         void store_aligned(bool* mem) const noexcept;
         void store_unaligned(bool* mem) const noexcept;

--- a/test/test_basic_math.cpp
+++ b/test/test_basic_math.cpp
@@ -21,13 +21,13 @@ namespace detail
     {
         static void test_isfinite()
         {
-            T input(1.);
+            T input(1);
             EXPECT_TRUE(xsimd::all(xsimd::isfinite(input))) << print_function_name("isfinite");
         }
 
         static void test_isinf()
         {
-            T input(1.);
+            T input(1);
             EXPECT_FALSE(xsimd::any(xsimd::isinf(input))) << print_function_name("isfinite");
         }
     };


### PR DESCRIPTION
It is tempting to build a batch from a memory address, but that's not supported,
load_aligned or load_unaligned provide that feature instead.

As C++ conversion rule would still accept that constructor as T* is convertible
to bool which is convertible to T, mark these constructors explicitly deleted.

Fix #602