### PR TITLE
Add gather/scatter functions to xsimd::batch

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_memory.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_memory.hpp
@@ -89,8 +89,8 @@ namespace xsimd
         gather(U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
-            static_assert(batch<T, A>::size <= batch<V, A>::size,
-                          "Not enough indexes for gathering!");
+            static_assert(batch<T, A>::size == batch<V, A>::size,
+                          "Index and destination sizes must match");
             return kernel::detail::gather<T, A, U, V>(
                 src, index,
                 ::xsimd::detail::make_index_sequence<xsimd::batch<T, A>::size>());
@@ -101,8 +101,8 @@ namespace xsimd
         gather(U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
-            static_assert(batch<T, A>::size <= batch<V, A>::size,
-                          "Not enough indexes for gathering!");
+            static_assert(batch<T, A>::size == batch<V, A>::size,
+                          "Index and destination sizes must match");
             const auto dst = kernel::detail::gather<U, A, U, V>(
                 src, index,
                 ::xsimd::detail::make_index_sequence<batch<U, A>::size>());
@@ -203,8 +203,8 @@ namespace xsimd
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
         {
-            static_assert(batch<T, A>::size <= batch<V, A>::size,
-                          "Not enough indexes for scattering!");
+            static_assert(batch<T, A>::size == batch<V, A>::size,
+                          "Source and index sizes must match");
             kernel::detail::scatter<T, A, U, V>(
                 src, dst, index,
                 ::xsimd::detail::make_index_sequence<batch<T, A>::size>());
@@ -216,8 +216,8 @@ namespace xsimd
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
         {
-            static_assert(batch<T, A>::size <= batch<V, A>::size,
-                          "Not enough indexes for scattering!");
+            static_assert(batch<T, A>::size == batch<V, A>::size,
+                          "Source and index sizes must match");
             const auto tmp = batch_cast<U>(src);
             kernel::detail::scatter<U, A, U, V>(
                 tmp, dst, index,

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -312,6 +312,45 @@ namespace xsimd
             }
         }
 
+        // gather
+        template <class A, class T,
+                  typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
+                                          void>::type>
+        inline batch<T, A> gather(T const* src, batch<int32_t, A> const& index,
+                                  kernel::requires_arch<avx2>) noexcept
+        {
+            // scatter for this one is AVX512F+AVX512VL
+            return _mm256_i32gather_epi32(src, index, 1);
+        }
+
+        template <class A, class T,
+                  typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
+                                          void>::type>
+        inline batch<T, A> gather(T const* src, batch<int64_t, A> const& index,
+                                  kernel::requires_arch<avx2>) noexcept
+        {
+            // scatter for this one is AVX512F+AVX512VL
+            return _mm256_i64gather_epi64(src, index, 1);
+        }
+
+        template <class A>
+        inline batch<float, A> gather(float const* src,
+                                      batch<int32_t, A> const& index,
+                                      kernel::requires_arch<avx2>) noexcept
+        {
+            // scatter for this one is AVX512F+AVX512VL
+            return _mm256_i32gather_ps(src, index, 1);
+        }
+
+        template <class A>
+        inline batch<double, A> gather(double const* src,
+                                       batch<int64_t, A> const& index,
+                                       kernel::requires_arch<avx2>) noexcept
+        {
+            // scatter for this one is AVX512F+AVX512VL
+            return _mm256_i64gather_pd(src, index, 1);
+        }
+
         // lt
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -320,7 +320,7 @@ namespace xsimd
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            return _mm256_i32gather_epi32(src, index, 1);
+            return _mm256_i32gather_epi32(src, index, sizeof(T));
         }
 
         template <class A, class T,
@@ -330,7 +330,7 @@ namespace xsimd
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            return _mm256_i64gather_epi64(src, index, 1);
+            return _mm256_i64gather_epi64(src, index, sizeof(T));
         }
 
         template <class A>
@@ -339,7 +339,7 @@ namespace xsimd
                                       kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            return _mm256_i32gather_ps(src, index, 1);
+            return _mm256_i32gather_ps(src, index, sizeof(float));
         }
 
         template <class A>
@@ -348,7 +348,7 @@ namespace xsimd
                                        kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            return _mm256_i64gather_pd(src, index, 1);
+            return _mm256_i64gather_pd(src, index, sizeof(double));
         }
 
         // lt

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -746,7 +746,7 @@ namespace xsimd
         inline batch<T, A> gather(T const* src, batch<int32_t, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i32gather_epi32(index, src, 1);
+            return _mm512_i32gather_epi32(index, src, sizeof(T));
         }
 
         template <class A, class T,
@@ -755,7 +755,7 @@ namespace xsimd
         inline batch<T, A> gather(T const* src, batch<int64_t, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i64gather_epi64(index, src, 1);
+            return _mm512_i64gather_epi64(index, src, sizeof(T));
         }
 
         template <class A>
@@ -763,7 +763,7 @@ namespace xsimd
                                       batch<int, A> const& index,
                                       kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i32gather_ps(index, src, 1);
+            return _mm512_i32gather_ps(index, src, sizeof(float));
         }
 
         template <class A>
@@ -771,7 +771,7 @@ namespace xsimd
         gather(double const* src, batch<int64_t, A> const& index,
                kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i64gather_pd(index, src, 1);
+            return _mm512_i64gather_pd(index, src, sizeof(double));
         }
 
         // ge
@@ -1266,7 +1266,7 @@ namespace xsimd
                             batch<int32_t, A> const& index,
                             kernel::requires_arch<avx512f>) noexcept
         {
-            _mm512_i32scatter_epi32(dst, index, src, 1);
+            _mm512_i32scatter_epi32(dst, index, src, sizeof(T));
         }
 
         template <class T, class A,
@@ -1276,7 +1276,7 @@ namespace xsimd
                             batch<int64_t, A> const& index,
                             kernel::requires_arch<avx512f>) noexcept
         {
-            _mm512_i64scatter_epi64(dst, index, src, 1);
+            _mm512_i64scatter_epi64(dst, index, src, sizeof(T));
         }
 
         template <class A>
@@ -1284,7 +1284,7 @@ namespace xsimd
                             batch<int32_t, A> const& index,
                             kernel::requires_arch<avx512f>) noexcept
         {
-            _mm512_i32scatter_ps(dst, index, src, 1);
+            _mm512_i32scatter_ps(dst, index, src, sizeof(float));
         }
 
         template <class A>
@@ -1292,7 +1292,7 @@ namespace xsimd
                             batch<int64_t, A> const& index,
                             kernel::requires_arch<avx512f>) noexcept
         {
-            _mm512_i64scatter_pd(dst, index, src, 1);
+            _mm512_i64scatter_pd(dst, index, src, sizeof(double));
         }
 
         // select

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -739,6 +739,41 @@ namespace xsimd
             return select(self, batch<T, A>(1), batch<T, A>(0));
         }
 
+        // gather
+        template <class A, class T,
+                  typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
+                                          void>::type>
+        inline batch<T, A> gather(T const* src, batch<int32_t, A> const& index,
+                                  kernel::requires_arch<avx512f>) noexcept
+        {
+            return _mm512_i32gather_epi32(index, src, 1);
+        }
+
+        template <class A, class T,
+                  typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
+                                          void>::type>
+        inline batch<T, A> gather(T const* src, batch<int64_t, A> const& index,
+                                  kernel::requires_arch<avx512f>) noexcept
+        {
+            return _mm512_i64gather_epi64(index, src, 1);
+        }
+
+        template <class A>
+        inline batch<float, A> gather(float const* src,
+                                      batch<int, A> const& index,
+                                      kernel::requires_arch<avx512f>) noexcept
+        {
+            return _mm512_i32gather_ps(index, src, 1);
+        }
+
+        template <class A>
+        inline batch<double, A>
+        gather(double const* src, batch<int64_t, A> const& index,
+               kernel::requires_arch<avx512f>) noexcept
+        {
+            return _mm512_i64gather_pd(index, src, 1);
+        }
+
         // ge
         template <class A>
         inline batch_bool<float, A> ge(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
@@ -1221,6 +1256,43 @@ namespace xsimd
                 const auto mindiff = min(diffmax, other);
                 return self + mindiff;
             }
+        }
+
+        // scatter
+        template <class A, class T,
+                  typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
+                                          void>::type>
+        inline void scatter(batch<T, A> const& src, T* dst,
+                            batch<int32_t, A> const& index,
+                            kernel::requires_arch<avx512f>) noexcept
+        {
+            _mm512_i32scatter_epi32(dst, index, src, 1);
+        }
+
+        template <class T, class A,
+                  typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
+                                          void>::type>
+        inline void scatter(batch<T, A> const& src, T* dst,
+                            batch<int64_t, A> const& index,
+                            kernel::requires_arch<avx512f>) noexcept
+        {
+            _mm512_i64scatter_epi64(dst, index, src, 1);
+        }
+
+        template <class A>
+        inline void scatter(batch<float, A> const& src, float* dst,
+                            batch<int32_t, A> const& index,
+                            kernel::requires_arch<avx512f>) noexcept
+        {
+            _mm512_i32scatter_ps(dst, index, src, 1);
+        }
+
+        template <class A>
+        inline void scatter(batch<double, A> const& src, double* dst,
+                            batch<int64_t, A> const& index,
+                            kernel::requires_arch<avx512f>) noexcept
+        {
+            _mm512_i64scatter_pd(dst, index, src, 1);
         }
 
         // select

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -560,11 +560,10 @@ namespace xsimd
     }
 
     /**
-     * Scatter elements from the batch \c src at addresses starting at \c dst
+     * Scatter elements from this batch into addresses starting at \c dst
      * and offset by each element in \c index.
      * If \c T is not of the same size as \c U, a \c static_cast is performed
      * at element scatter time.
-     * @param src Batch of elements to scatter.
      * @param dst Destination address
      * @param index Indexes in which to store the elements to.
      */

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -544,7 +544,9 @@ namespace xsimd
 
     /**
      * Create a new batch gathering elements starting at address \c src and
-     * offset by each element in \c index. The scale is always 1.
+     * offset by each element in \c index.
+     * If \c T is not of the same size as \c U, a \c static_cast is performed
+     * at element gather time.
      * @param src Starting address.
      * @param index Indexes of the elements to gather.
      * @return a batch containing the gathered elements.
@@ -558,7 +560,9 @@ namespace xsimd
 
     /**
      * Scatter elements from the batch \c src at addresses starting at \c dst
-     * and offset by each element in \c index. The scale is always 1.
+     * and offset by each element in \c index.
+     * If \c T is not of the same size as \c U, a \c static_cast is performed
+     * at element scatter time.
      * @param src Batch of elements to scatter.
      * @param dst Destination address
      * @param index Indexes in which to store the elements to.

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -71,6 +71,11 @@ namespace xsimd
         template <class U>
         static XSIMD_NO_DISCARD batch load(U const* mem, unaligned_mode) noexcept;
 
+        template <class U, class V>
+        static XSIMD_NO_DISCARD batch gather(U const* src, batch<V, arch_type> const& index) noexcept;
+        template <class U, class V>
+        void scatter(U* dst, batch<V, arch_type> const& index) const noexcept;
+
         T get(std::size_t i) const noexcept;
 
         // comparison operators
@@ -535,6 +540,34 @@ namespace xsimd
     inline batch<T, A> batch<T, A>::load(U const* mem, unaligned_mode) noexcept
     {
         return load_unaligned(mem);
+    }
+
+    /**
+     * Create a new batch gathering elements starting at address \c src and
+     * offset by each element in \c index. The scale is always 1.
+     * @param src Starting address.
+     * @param index Indexes of the elements to gather.
+     * @return a batch containing the gathered elements.
+     */
+    template <class T, class A>
+    template <typename U, typename V>
+    inline batch<T, A> batch<T, A>::gather(U const* src, batch<V, A> const& index) noexcept
+    {
+        return kernel::gather<A, T>(src, index, A {});
+    }
+
+    /**
+     * Scatter elements from the batch \c src at addresses starting at \c dst
+     * and offset by each element in \c index. The scale is always 1.
+     * @param src Batch of elements to scatter.
+     * @param dst Destination address
+     * @param index Indexes in which to store the elements to.
+     */
+    template <class T, class A>
+    template <class U, class V>
+    inline void batch<T, A>::scatter(U* dst, batch<V, A> const& index) const noexcept
+    {
+        kernel::scatter<A>(*this, dst, index, A {});
     }
 
     template <class T, class A>

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -555,6 +555,7 @@ namespace xsimd
     template <typename U, typename V>
     inline batch<T, A> batch<T, A>::gather(U const* src, batch<V, A> const& index) noexcept
     {
+        static_assert(std::is_convertible<T, U>::value, "Can't convert from src to this batch's type!");
         return kernel::gather<A, T>(src, index, A {});
     }
 
@@ -571,6 +572,7 @@ namespace xsimd
     template <class U, class V>
     inline void batch<T, A>::scatter(U* dst, batch<V, A> const& index) const noexcept
     {
+        static_assert(std::is_convertible<T, U>::value, "Can't convert from this batch's type to dst!");
         kernel::scatter<A>(*this, dst, index, A {});
     }
 

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -277,6 +277,18 @@ namespace xsimd
         template <typename... Ts>
         using int_sequence_for = make_int_sequence<(int)sizeof...(Ts)>;
 
+        // Type-casted index sequence.
+        template <class P, size_t... Is>
+        inline P indexes_from(index_sequence<Is...>) noexcept
+        {
+            return { static_cast<typename P::value_type>(Is)... };
+        }
+
+        template <class P>
+        inline P make_sequence_as_batch() noexcept
+        {
+            return indexes_from<P>(make_index_sequence<P::size>());
+        }
     }
 
     /***********************************


### PR DESCRIPTION
Hi!

This PR is to propose adding five new functions to xsimd. I've used these in the (still WIP) port from Vc to xsimd, which you can see [here](https://invent.kde.org/graphics/krita/-/merge_requests/1404).

These functions are *(crossing out already upstreamed ones, check the mentions)*:

- ~~`xsimd::reciprocal`: calculates the approximate reciprocal of the SIMD register.~~
- ~~`xsimd::none`: a typo-free way to say `!xsimd::any` more clearly.~~
- `xsimd::gather` and `xsimd::scatter`: for <AVX512F, templates gathering using the new `xsimd::insert` function. (It will also take advantage of #691 when it's fixed)
- ~~`xsimd::round_to_even`: uses intrinsics to achieve fast rounding to even *integers*.~~

~~These do not include tests yet, as I'd like first to gather some feedback, especially regarding the approach I've followed and potential performance issues.~~ I've added the relevant test cases.

Thanks in advance for all your comments!

Fixes #106 
