### PR TITLE
insert: allow intrinsics to be used for Windows

### DIFF
--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -690,7 +690,7 @@ namespace xsimd
         {
             switch (sizeof(T))
             {
-#ifndef _WIN32
+#if !defined(_MSC_VER) || _MSC_VER > 1900
             case 1:
                 return _mm256_insert_epi8(self, val, I);
             case 2:

--- a/include/xsimd/arch/xsimd_sse4_1.hpp
+++ b/include/xsimd/arch/xsimd_sse4_1.hpp
@@ -113,7 +113,7 @@ namespace xsimd
                 return _mm_insert_epi8(self, val, I);
             case 4:
                 return _mm_insert_epi32(self, val, I);
-#ifndef _WIN32
+#if !defined(_MSC_VER) || _MSC_VER > 1900
             case 8:
                 return _mm_insert_epi64(self, val, I);
 #endif


### PR DESCRIPTION
This PR adjusts the check that was added in #690 to:

- account for MSVC only (_WIN32 also implies MSYS compilers, such as GCC and Clang)
- block usage of the intrinsics only on MSVS 2015 and earlier, which lack the definition.