### PR TITLE
Add xsimd::none

### DIFF
--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1938,6 +1938,20 @@ namespace xsimd
     }
 
     /**
+     * @ingroup batch_bool_reducers
+     *
+     * Return true if none of the boolean values in the batch is true,
+     * false otherwise.
+     * @param x the batch to reduce.
+     * @return a boolean scalar.
+     */
+    template <class T, class A>
+    inline bool none(batch_bool<T, A> const& x) noexcept
+    {
+        return !xsimd::any(x);
+    }
+
+    /**
      * @ingroup batch_miscellaneous
      *
      * Dump the content of batch \c x to stream \c o

--- a/test/test_batch_bool.cpp
+++ b/test/test_batch_bool.cpp
@@ -221,6 +221,29 @@ protected:
                 EXPECT_FALSE(all_res) << print_function_name("all (almost_all_true)");
             }
         }
+        // none
+        {
+            auto none_check_false = (batch_lhs() == batch_rhs());
+            bool none_res_false = xsimd::none(none_check_false);
+            EXPECT_FALSE(none_res_false) << print_function_name("none (false)");
+            auto none_check_true = (batch_lhs() != batch_lhs());
+            bool none_res_true = xsimd::none(none_check_true);
+            EXPECT_TRUE(none_res_true) << print_function_name("none (true)");
+
+            for (const auto& vec : bool_g.almost_all_false())
+            {
+                batch_bool_type b = batch_bool_type::load_unaligned(vec.data());
+                bool none_res = xsimd::none(b);
+                EXPECT_FALSE(none_res) << print_function_name("none (almost_all_false)");
+            }
+
+            for (const auto& vec : bool_g.almost_all_true())
+            {
+                batch_bool_type b = batch_bool_type::load_unaligned(vec.data());
+                bool none_res = xsimd::none(b);
+                EXPECT_FALSE(none_res) << print_function_name("none (almost_all_true)");
+            }
+        }
     }
 
     void test_logical_operations() const


### PR DESCRIPTION
👋 

This PR is once again an offshoot of #706. This one adds `xsimd::none`, which completes the trifecta of `any/all/none` boolean checking functions.