### PR TITLE
Add xsimd::nearbyint_as_int

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_details.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_details.hpp
@@ -77,6 +77,8 @@ namespace xsimd
     template <class T, class A>
     inline batch<T, A> nearbyint(batch<T, A> const& self) noexcept;
     template <class T, class A>
+    inline batch<as_integer_t<T>, A> nearbyint_as_int(const batch<T, A>& x) noexcept;
+    template <class T, class A>
     inline batch<T, A> select(batch_bool<T, A> const&, batch<T, A> const&, batch<T, A> const&) noexcept;
     template <class T, class A>
     inline batch<std::complex<T>, A> select(batch_bool<T, A> const&, batch<std::complex<T>, A> const&, batch<std::complex<T>, A> const&) noexcept;

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1819,6 +1819,21 @@ namespace xsimd
             return detail::nearbyintf(self);
         }
 
+        // nearbyint_as_int
+        template <class T, class A, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        inline batch<T, A> nearbyint_as_int(batch<T, A> const& self, requires_arch<generic>) noexcept
+        {
+            return self;
+        }
+
+        // nearbyint_as_int
+        template <class T, class A, class = typename std::enable_if<std::is_floating_point<T>::value, void>::type>
+        inline batch<as_integer_t<T>, A>
+        nearbyint_as_int(batch<T, A> const& x, requires_arch<generic>) noexcept
+        {
+            return to_int(round(x));
+        }
+
         // nextafter
         namespace detail
         {

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -881,6 +881,14 @@ namespace xsimd
             return _mm256_round_pd(self, _MM_FROUND_TO_NEAREST_INT);
         }
 
+        // nearbyint_as_int
+        template <class A>
+        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
+                                                  requires_arch<avx>) noexcept
+        {
+            return _mm256_cvtps_epi32(self);
+        }
+
         // neg
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch<T, A> neg(batch<T, A> const& self, requires_arch<avx>) noexcept

--- a/include/xsimd/arch/xsimd_avx512dq.hpp
+++ b/include/xsimd/arch/xsimd_avx512dq.hpp
@@ -76,6 +76,14 @@ namespace xsimd
             return _mm512_xor_pd(self, other);
         }
 
+        // nearbyint_as_int
+        template <class A>
+        inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& self,
+                                                  requires_arch<avx512dq>) noexcept
+        {
+            return _mm512_cvtps_epi64(self);
+        }
+
         // convert
         namespace detail
         {

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -1126,6 +1126,14 @@ namespace xsimd
             return _mm512_roundscale_round_pd(self, _MM_FROUND_TO_NEAREST_INT, _MM_FROUND_CUR_DIRECTION);
         }
 
+        // nearbyint_as_int
+        template <class A>
+        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
+                                                  requires_arch<avx512f>) noexcept
+        {
+            return _mm512_cvtps_epi32(self);
+        }
+
         // neg
         template <class A, class T>
         inline batch<T, A> neg(batch<T, A> const& self, requires_arch<avx512f>) noexcept

--- a/include/xsimd/arch/xsimd_neon64.hpp
+++ b/include/xsimd/arch/xsimd_neon64.hpp
@@ -592,6 +592,20 @@ namespace xsimd
             return vabsq_f64(rhs);
         }
 
+        template <class A>
+        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
+                                                  requires_arch<neon64>) noexcept
+        {
+            return vcvtnq_s32_f32(self);
+        }
+
+        template <class A>
+        inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& self,
+                                                  requires_arch<neon64>) noexcept
+        {
+            return vcvtnq_s64_f64(self);
+        }
+
         /**************
          * reciprocal *
          **************/

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -934,6 +934,14 @@ namespace xsimd
             return _mm_mul_pd(self, other);
         }
 
+        // nearbyint_as_int
+        template <class A>
+        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
+                                                  requires_arch<sse2>) noexcept
+        {
+            return _mm_cvtps_epi32(self);
+        }
+
         // neg
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch<T, A> neg(batch<T, A> const& self, requires_arch<sse2>) noexcept

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1255,13 +1255,28 @@ namespace xsimd
      *
      * Rounds the scalars in \c x to integer values (in floating point format), using
      * the current rounding mode.
-     * @param x batch of flaoting point values.
+     * @param x batch of floating point values.
      * @return the batch of nearest integer values.
      */
     template <class T, class A>
     inline batch<T, A> nearbyint(batch<T, A> const& x) noexcept
     {
         return kernel::nearbyint<A>(x, A {});
+    }
+
+    /**
+     * @ingroup batch_rounding
+     *
+     * Rounds the scalars in \c x to integer values (in integer format) using
+     * the current rounding mode.
+     * @param x batch of floating point values.
+     * @return the batch of nearest integer values.
+     */
+    template <class T, class A>
+    inline batch<as_integer_t<T>, A>
+    nearbyint_as_int(batch<T, A> const& x) noexcept
+    {
+        return kernel::nearbyint_as_int(x, A {});
     }
 
     /**


### PR DESCRIPTION
:wave:

Again re #706, this is the rounding function that returns integers instead of floating-point numbers. I've renamed it appropriately, since there's already a `nearbyint` function that works similarly.

Rationale for this function: https://godbolt.org/z/q4rc6dvW3

Fixes #623