### PR TITLE
Fix nearbyint_as_int test on Arm

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_details.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_details.hpp
@@ -122,6 +122,23 @@ namespace xsimd
                 }
                 return batch<T, A>::load_aligned(self_buffer);
             }
+
+            template <class U, class F, class A, class T>
+            inline batch<U, A> apply_transform(F&& func, batch<T, A> const& self) noexcept
+            {
+                static_assert(batch<T, A>::size == batch<U, A>::size,
+                              "Source and destination sizes must match");
+                constexpr std::size_t src_size = batch<T, A>::size;
+                constexpr std::size_t dest_size = batch<U, A>::size;
+                alignas(A::alignment()) T self_buffer[src_size];
+                alignas(A::alignment()) U other_buffer[dest_size];
+                self.store_aligned(&self_buffer[0]);
+                for (std::size_t i = 0; i < src_size; ++i)
+                {
+                    other_buffer[i] = func(self_buffer[i]);
+                }
+                return batch<U, A>::load_aligned(other_buffer);
+            }
         }
 
         namespace detail

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1827,11 +1827,24 @@ namespace xsimd
         }
 
         // nearbyint_as_int
-        template <class T, class A, class = typename std::enable_if<std::is_floating_point<T>::value, void>::type>
-        inline batch<as_integer_t<T>, A>
-        nearbyint_as_int(batch<T, A> const& x, requires_arch<generic>) noexcept
+        template <class A>
+        inline batch<as_integer_t<float>, A>
+        nearbyint_as_int(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
-            return to_int(round(x));
+            using U = as_integer_t<float>;
+            return kernel::detail::apply_transform<U>([](float x) noexcept -> U
+                                                      { return std::lroundf(x); },
+                                                      self);
+        }
+
+        template <class A>
+        inline batch<as_integer_t<double>, A>
+        nearbyint_as_int(batch<double, A> const& self, requires_arch<generic>) noexcept
+        {
+            using U = as_integer_t<double>;
+            return kernel::detail::apply_transform<U>([](double x) noexcept -> U
+                                                      { return std::llround(x); },
+                                                      self);
         }
 
         // nextafter

--- a/include/xsimd/arch/xsimd_avx512dq.hpp
+++ b/include/xsimd/arch/xsimd_avx512dq.hpp
@@ -81,7 +81,7 @@ namespace xsimd
         inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& self,
                                                   requires_arch<avx512dq>) noexcept
         {
-            return _mm512_cvtps_epi64(self);
+            return _mm512_cvtpd_epi64(self);
         }
 
         // convert

--- a/include/xsimd/arch/xsimd_neon64.hpp
+++ b/include/xsimd/arch/xsimd_neon64.hpp
@@ -599,12 +599,14 @@ namespace xsimd
             return vcvtnq_s32_f32(self);
         }
 
+#if !defined(__GNUC__)
         template <class A>
         inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& self,
                                                   requires_arch<neon64>) noexcept
         {
             return vcvtnq_s64_f64(self);
         }
+#endif
 
         /**************
          * reciprocal *

--- a/test/test_rounding.cpp
+++ b/test/test_rounding.cpp
@@ -141,13 +141,12 @@ protected:
             EXPECT_EQ(diff, 0) << print_function_name("nearbyint");
         }
         // nearbyint_as_int
-#if !XSIMD_WITH_NEON && !XSIMD_WITH_NEON64
         {
             std::array<int_value_type, nb_input> expected;
             std::array<int_value_type, nb_input> res;
             std::transform(input.cbegin(), input.cend(), expected.begin(),
                            [](const value_type& v)
-                           { return static_cast<int_value_type>(std::round(v)); });
+                           { return detail::nearbyint_as_int(v); });
             batch_type in;
             int_batch_type out;
             for (size_t i = 0; i < nb_batches; i += size)
@@ -158,12 +157,11 @@ protected:
             }
             for (size_t i = nb_batches; i < nb_input; ++i)
             {
-                res[i] = static_cast<int_value_type>(std::round(input[i]));
+                res[i] = detail::nearbyint_as_int(input[i]);
             }
             size_t diff = detail::get_nb_diff(res, expected);
             EXPECT_EQ(diff, 0) << print_function_name("nearbyint_as_int");
         }
-#endif
         // rint
         {
             std::transform(input.cbegin(), input.cend(), expected.begin(),

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -577,6 +577,16 @@ namespace detail
     {
         b.store_unaligned(dst.data() + i);
     }
+
+    inline xsimd::as_integer_t<float> nearbyint_as_int(float a)
+    {
+        return std::lroundf(a);
+    }
+
+    inline xsimd::as_integer_t<double> nearbyint_as_int(double a)
+    {
+        return std::llround(a);
+    }
 }
 
 #define EXPECT_BATCH_EQ(b1, b2) EXPECT_PRED_FORMAT2(::detail::expect_batch_near, b1, b2)


### PR DESCRIPTION
This PR fixes the semantics of nearbyint_as_int on Arm. I made a typo in the AVX512DQ version too.

You'll notice that I added a guard around the NEON64 version; I've seen online that the codegen of GCC simply doesn't return the expected results, but Clang's does.

This PR depends on #726, which is why you'll see extraneous commits. They'll be gone once that one is merged.

See #721