### PR TITLE
Slight optimization to gather/scatter + related fixes

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_memory.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_memory.hpp
@@ -58,12 +58,6 @@ namespace xsimd
         // gather
         namespace detail
         {
-            template <class T, class U, class B>
-            using sizes_match_t = typename std::enable_if<sizeof(T) == sizeof(U), B>::type;
-
-            template <class T, class U, class B>
-            using sizes_mismatch_t = typename std::enable_if<sizeof(T) != sizeof(U), B>::type;
-
             template <typename T, typename A, typename U, typename V, size_t I>
             inline batch<T, A> gather(U const* src, batch<V, A> const& index,
                                       ::xsimd::detail::index_sequence<I>) noexcept

--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -229,23 +229,8 @@ namespace xsimd
              **************************************/
 
             template <class T>
-            using enable_integral_t = typename std::enable_if<std::is_integral<T>::value, int>::type;
-
-            template <class T>
             using enable_neon_type_t = typename std::enable_if<std::is_integral<T>::value || std::is_same<T, float>::value,
                                                                int>::type;
-
-            template <class T, size_t S>
-            using enable_sized_signed_t = typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value && sizeof(T) == S, int>::type;
-
-            template <class T, size_t S>
-            using enable_sized_unsigned_t = typename std::enable_if<std::is_integral<T>::value && !std::is_signed<T>::value && sizeof(T) == S, int>::type;
-
-            template <class T, size_t S>
-            using enable_sized_integral_t = typename std::enable_if<std::is_integral<T>::value && sizeof(T) == S, int>::type;
-
-            template <class T, size_t S>
-            using enable_sized_t = typename std::enable_if<sizeof(T) == S, int>::type;
 
             template <class T>
             using exclude_int64_neon_t

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -589,9 +589,7 @@ namespace xsimd
     template <class T, class A>
     inline T batch<T, A>::get(std::size_t i) const noexcept
     {
-        alignas(A::alignment()) T buffer[size];
-        store_aligned(&buffer[0]);
-        return buffer[i];
+        return kernel::get(*this, i, A {});
     }
 
     /******************************
@@ -845,9 +843,7 @@ namespace xsimd
     template <class T, class A>
     inline bool batch_bool<T, A>::get(std::size_t i) const noexcept
     {
-        alignas(A::alignment()) bool buffer[size];
-        store_aligned(&buffer[0]);
-        return buffer[i];
+        return kernel::get(*this, i, A {});
     }
 
     /***********************************
@@ -1078,9 +1074,7 @@ namespace xsimd
     template <class T, class A>
     inline auto batch<std::complex<T>, A>::get(std::size_t i) const noexcept -> value_type
     {
-        alignas(A::alignment()) value_type buffer[size];
-        store_aligned(&buffer[0]);
-        return buffer[i];
+        return kernel::get(*this, i, A {});
     }
 
     /**************************************

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -196,6 +196,34 @@ namespace xsimd
         return res;
     }
 
+    namespace kernel
+    {
+        namespace detail
+        {
+            /**************************************
+             * enabling / disabling metafunctions *
+             **************************************/
+
+            template <class T>
+            using enable_integral_t = typename std::enable_if<std::is_integral<T>::value, int>::type;
+
+            template <class T, size_t S>
+            using enable_sized_signed_t = typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value && sizeof(T) == S, int>::type;
+
+            template <class T, size_t S>
+            using enable_sized_unsigned_t = typename std::enable_if<std::is_integral<T>::value && !std::is_signed<T>::value && sizeof(T) == S, int>::type;
+
+            template <class T, size_t S>
+            using enable_sized_integral_t = typename std::enable_if<std::is_integral<T>::value && sizeof(T) == S, int>::type;
+
+            template <class T, size_t S>
+            using enable_sized_t = typename std::enable_if<sizeof(T) == S, int>::type;
+
+            template <class T, size_t S>
+            using enable_max_sized_integral_t = typename std::enable_if<std::is_integral<T>::value && sizeof(T) <= S, int>::type;
+        } // namespace detail
+    } // namespace kernel
+
     /*****************************************
      * Backport of index_sequence from c++14 *
      *****************************************/
@@ -484,6 +512,16 @@ namespace xsimd
 
     template <class B>
     using complex_batch_type_t = typename complex_batch_type<B>::type;
+
+    /********************************
+     * Matching & mismatching sizes *
+     ********************************/
+
+    template <class T, class U, class B>
+    using sizes_match_t = typename std::enable_if<sizeof(T) == sizeof(U), B>::type;
+
+    template <class T, class U, class B>
+    using sizes_mismatch_t = typename std::enable_if<sizeof(T) != sizeof(U), B>::type;
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,7 +109,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
     set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES Clang AND WIN32) # We are using clang-cl
+if(CMAKE_CXX_COMPILER_ID MATCHES Clang AND MSVC AND WIN32) # We are using clang-cl
     add_compile_options(/EHsc /bigobj)
     set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
 endif()


### PR DESCRIPTION
:wave: 

This introduces small fixes and quality-of-life optimizations I made as part of my debugging.

- Made the tests buildable on MSYS Clang
- Arm's type size SFINAE have been factored out for better availability
- Changed the internals of gather/scatter to take a single index in the template (the current element).

The last change includes a small refactor to move the `get` implementation inside `generic_memory`, thus making it style-wise more compliant and mistake-proof.