### PR TITLE
Adding some complex batch operations

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -962,6 +962,21 @@ namespace xsimd
             return { rem1 - 2. * re * si * si, re * isin };
         }
 
+        // polar
+        template <class A, class T>
+        inline batch<std::complex<T>, A> polar(const batch<T, A>& r, const batch<T, A>& theta, requires_arch<generic>) noexcept
+        {
+            auto sincosTheta = sincos(theta);
+            return { r * sincosTheta.second, r * sincosTheta.first };
+        }
+
+        template <class A, class T>
+        inline batch<std::complex<T>, A> polar(const batch<T, A>& theta, requires_arch<generic>) noexcept
+        {
+            auto sincosTheta = sincos(theta);
+            return { sincosTheta.second, sincosTheta.first };
+        }
+
         // fdim
         template <class A, class T>
         inline batch<T, A> fdim(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -977,6 +977,19 @@ namespace xsimd
             return { sincosTheta.second, sincosTheta.first };
         }
 
+        // mul_real/complex
+        template <class A, class T>
+        inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        {
+            return (a.real() * b.real()) - (a.imag() * b.imag());
+        }
+
+        template <class A, class T>
+        inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        {
+            return (a.real() * b.imag()) + (a.imag() * b.real());
+        }
+
         // fdim
         template <class A, class T>
         inline batch<T, A> fdim(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1251,6 +1251,34 @@ namespace xsimd
     }
 
     /**
+     * @ingroup batch_arithmetic
+     *
+     * Computes the real part product of the complex batches \c a and \c b.
+     * @param a batch involved in the product.
+     * @param b batch involved in the product.
+     * @return the result of the product.
+     */
+    template <class T, class A>
+    inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    {
+        return kernel::mul_real<A>(a, b, A {});
+    }
+
+    /**
+     * @ingroup batch_arithmetic
+     *
+     * Computes the imaginary part product of the complex batches \c a and \c b.
+     * @param a batch involved in the product.
+     * @param b batch involved in the product.
+     * @return the result of the product.
+     */
+    template <class T, class A>
+    inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    {
+        return kernel::mul_imag<A>(a, b, A {});
+    }
+
+    /**
      * @ingroup batch_rounding
      *
      * Rounds the scalars in \c x to integer values (in floating point format), using

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1335,6 +1335,33 @@ namespace xsimd
     }
 
     /**
+     * @ingroup batch_math
+     *
+     * Returns a complex batch with magnitude \c r and phase angle \c theta.
+     * @param r The magnitude of the desired complex result.
+     * @param theta The phase angle of the desired complex result.
+     * @return \c r exp(i * \c theta).
+     */
+    template <class T, class A>
+    inline complex_batch_type_t<batch<T, A>> polar(batch<T, A> const& r, batch<T, A> const& theta) noexcept
+    {
+        return kernel::polar<A>(r, theta, A {});
+    }
+
+    /**
+     * @ingroup batch_math
+     *
+     * Returns a complex batch with phase angle \c theta.
+     * @param theta The phase angle of the desired complex result.
+     * @return exp(i * \c theta).
+     */
+    template <class T, class A>
+    inline complex_batch_type_t<batch<T, A>> polar(batch<T, A> const& theta) noexcept
+    {
+        return kernel::polar<A>(theta, A {});
+    }
+
+    /**
      * @ingroup batch_arithmetic
      *
      * No-op on \c x.

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1356,8 +1356,8 @@ namespace xsimd
      * @param y batch of floating point values.
      * @return \c x raised to the power \c y.
      */
-    template <class T, class A>
-    inline batch<T, A> pow(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    template <class T1, class T2, class A>
+    inline simd_return_type<T1, T2, A> pow(batch<T1, A> const& x, batch<T2, A> const& y) noexcept
     {
         return kernel::pow<A>(x, y, A {});
     }

--- a/test/test_batch_complex.cpp
+++ b/test/test_batch_complex.cpp
@@ -530,6 +530,29 @@ protected:
         }
     }
 
+    void test_polar() const
+    {
+        // polar w/ magnitude/phase
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), rhs.begin(), expected.begin(),
+                           [](const value_type& v_lhs, const value_type& v_rhs)
+                           { return std::polar(std::real(v_lhs), std::real(v_rhs)); });
+            batch_type res = polar(real(batch_lhs()), real(batch_rhs()));
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("polar(mag/phase)");
+        }
+
+        // polar w/ just phase
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), expected.begin(),
+                           [](const value_type& v)
+                           { return std::exp(value_type(0, 1) * std::real(v)); });
+            batch_type res = polar(real(batch_lhs()));
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("polar(phase)");
+        }
+    }
+
     void test_horizontal_operations() const
     {
         // hadd
@@ -662,6 +685,11 @@ TYPED_TEST(batch_complex_test, conj_norm_proj)
 TYPED_TEST(batch_complex_test, conj_norm_proj_real)
 {
     this->test_conj_norm_proj_real();
+}
+
+TYPED_TEST(batch_complex_test, polar)
+{
+    this->test_polar();
 }
 
 TYPED_TEST(batch_complex_test, horizontal_operations)

--- a/test/test_batch_complex.cpp
+++ b/test/test_batch_complex.cpp
@@ -284,6 +284,24 @@ protected:
             batch_type rres = real_scalar * batch_lhs();
             EXPECT_BATCH_EQ(rres, expected) << print_function_name("real_scalar * batch");
         }
+        // real(batch * batch)
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), expected.begin(),
+                           [](const value_type& l, const value_type& r)
+                           { return std::real(l * r); });
+            batch_type res = mul_real(batch_lhs(), batch_rhs());
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("mul_real");
+        }
+        // imag(batch * batch)
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), expected.begin(),
+                           [](const value_type& l, const value_type& r)
+                           { return std::imag(l * r); });
+            batch_type res = mul_imag(batch_lhs(), batch_rhs());
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("mul_imag");
+        }
         // batch / batch
         {
             array_type expected;

--- a/test/test_complex_power.cpp
+++ b/test/test_complex_power.cpp
@@ -31,7 +31,9 @@ protected:
     vector_type lhs_pn;
     vector_type lhs_np;
     vector_type lhs_pp;
+    real_vector_type lhs_real;
     vector_type rhs;
+    real_vector_type rhs_real;
     vector_type expected;
     vector_type res;
 
@@ -42,7 +44,9 @@ protected:
         lhs_pn.resize(nb_input);
         lhs_np.resize(nb_input);
         lhs_pp.resize(nb_input);
+        lhs_real.resize(nb_input);
         rhs.resize(nb_input);
+        rhs_real.resize(nb_input);
         for (size_t i = 0; i < nb_input; ++i)
         {
             real_value_type real = (real_value_type(i) / 4 + real_value_type(1.2) * std::sqrt(real_value_type(i + 0.25))) / 100;
@@ -53,6 +57,9 @@ protected:
             lhs_pp[i] = value_type(real, imag);
             rhs[i] = value_type(real_value_type(10.2) / (i + 2) + real_value_type(0.25),
                                 real_value_type(9.1) / (i + 3) + real_value_type(0.45));
+
+            lhs_real[i] = (i % 2 == 0 ? 1 : -1) * real;
+            rhs_real[i] = (i % 3 == 0 ? 1 : -1) * rhs[i].real();
         }
         expected.resize(nb_input);
         res.resize(nb_input);
@@ -163,6 +170,42 @@ protected:
         EXPECT_EQ(diff, 0) << print_function_name("sqrt_pp");
     }
 
+    void test_pow_real_complex()
+    {
+        std::transform(lhs_real.cbegin(), lhs_real.cend(), rhs.cbegin(), expected.begin(),
+                       [](const real_value_type& l, const value_type& r)
+                       { using std::pow; return pow(l, r); });
+        batch_type rhs_in, out;
+        real_batch_type lhs_in;
+        for (size_t i = 0; i < nb_input; i += size)
+        {
+            detail::load_batch(lhs_in, lhs_real, i);
+            detail::load_batch(rhs_in, rhs, i);
+            out = pow(lhs_in, rhs_in);
+            detail::store_batch(out, res, i);
+        }
+        size_t diff = detail::get_nb_diff(res, expected);
+        EXPECT_EQ(diff, 0) << print_function_name("pow (real/complex)");
+    }
+
+    void test_pow_complex_real()
+    {
+        std::transform(lhs_np.cbegin(), lhs_np.cend(), rhs_real.cbegin(), expected.begin(),
+                       [](const real_value_type& l, const value_type& r)
+                       { using std::pow; return pow(l, r); });
+        batch_type lhs_in, out;
+        real_batch_type rhs_in;
+        for (size_t i = 0; i < nb_input; i += size)
+        {
+            detail::load_batch(lhs_in, lhs_np, i);
+            detail::load_batch(rhs_in, rhs_real, i);
+            out = pow(lhs_in, rhs_in);
+            detail::store_batch(out, res, i);
+        }
+        size_t diff = detail::get_nb_diff(res, expected);
+        EXPECT_EQ(diff, 0) << print_function_name("pow (complex/real)");
+    }
+
 private:
     void test_pow_impl()
     {
@@ -216,6 +259,16 @@ TYPED_TEST(complex_power_test, arg)
 TYPED_TEST(complex_power_test, pow)
 {
     this->test_pow();
+}
+
+TYPED_TEST(complex_power_test, pow_real_complex)
+{
+    this->test_pow_real_complex();
+}
+
+TYPED_TEST(complex_power_test, pow_complex_real)
+{
+    this->test_pow_real_complex();
 }
 
 TYPED_TEST(complex_power_test, sqrt_nn)


### PR DESCRIPTION
I had a few complex operations based on the `xsimd` implementations and thought they might make useful additions to the library. If not, that's totally fine as well!

The operations are:
- `xsimd::pow` for the case where only one of the arguments is complex
- `xsimd::polar` (basically the same as `std::polar`)
- `xsimd::mul_real` as a faster way of doing `(complex_batch_1 * complex_batch_2).real();`, and corresponding `xsimd::mul_imag`