### PR TITLE
Add mixed-complex implementations of xsimd::pow()

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1967,20 +1967,7 @@ namespace xsimd
         template <class A, class T>
         inline batch<std::complex<T>, A> pow(const batch<T, A>& a, const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
-            // same as the complex/complex implementation above, except that we can skip calling arg()!
-            using cplx_batch = batch<std::complex<T>, A>;
-            using real_batch = typename cplx_batch::real_batch;
-            real_batch absa = abs(a);
-            real_batch arga = select(a >= constants::zero<real_batch>(), constants::zero<real_batch>(), constants::pi<real_batch>()); // since a is real, we know arg must be either 0 or pi
-            real_batch x = z.real();
-            real_batch y = z.imag();
-            real_batch r = pow(absa, x);
-            real_batch theta = x * arga;
-            real_batch ze(0);
-            auto cond = (y == ze);
-            r = select(cond, r, r * exp(-y * arga));
-            theta = select(cond, theta, theta + y * log(absa));
-            return select(absa == ze, cplx_batch(ze), cplx_batch(r * cos(theta), r * sin(theta)));
+            return pow(batch<std::complex<T>, A> { a, batch<T, A> {} }, z);
         }
 
         // reciprocal

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1959,6 +1959,7 @@ namespace xsimd
             auto absa = abs(a);
             auto arga = arg(a);
             auto r = pow(absa, z);
+            
             auto theta = z * arga;
             auto sincosTheta = xsimd::sincos(theta);
             return { r * sincosTheta.second, r * sincosTheta.first };

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1356,8 +1356,8 @@ namespace xsimd
      * @param y batch of floating point values.
      * @return \c x raised to the power \c y.
      */
-    template <class T, class A>
-    inline batch<T, A> pow(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    template <class T1, class T2, class A>
+    inline simd_return_type<T1, T2, A> pow(batch<T1, A> const& x, batch<T2, A> const& y) noexcept
     {
         return kernel::pow<A>(x, y, A {});
     }


### PR DESCRIPTION
Adding a specialization of `xsimd::pow()` for cases where only one of the two arguments is complex.