### PR TITLE
Add real and imaginary complex multiplication

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1780,6 +1780,19 @@ namespace xsimd
                                  self, other);
         }
 
+        // mul_real/imag
+        template <class A, class T>
+        inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        {
+            return (a.real() * b.real()) - (a.imag() * b.imag());
+        }
+
+        template <class A, class T>
+        inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        {
+            return (a.real() * b.imag()) + (a.imag() * b.real());
+        }
+
         // nearbyint
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch<T, A> nearbyint(batch<T, A> const& self, requires_arch<generic>) noexcept

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1251,6 +1251,34 @@ namespace xsimd
     }
 
     /**
+     * @ingroup batch_arithmetic
+     *
+     * Computes the real part product of the complex batches \c a and \c b.
+     * @param a batch involved in the product.
+     * @param b batch involved in the product.
+     * @return the result of the product.
+     */
+    template <class T, class A>
+    inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    {
+        return kernel::mul_real<A>(a, b, A {});
+    }
+
+    /**
+     * @ingroup batch_arithmetic
+     *
+     * Computes the imaginary part product of the complex batches \c a and \c b.
+     * @param a batch involved in the product.
+     * @param b batch involved in the product.
+     * @return the result of the product.
+     */
+    template <class T, class A>
+    inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    {
+        return kernel::mul_imag<A>(a, b, A {});
+    }
+
+    /**
      * @ingroup batch_rounding
      *
      * Rounds the scalars in \c x to integer values (in floating point format), using

--- a/test/test_batch_complex.cpp
+++ b/test/test_batch_complex.cpp
@@ -284,6 +284,24 @@ protected:
             batch_type rres = real_scalar * batch_lhs();
             EXPECT_BATCH_EQ(rres, expected) << print_function_name("real_scalar * batch");
         }
+        // real(batch * batch)
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), expected.begin(),
+                           [](const value_type& l, const value_type& r)
+                           { return std::real(l * r); });
+            batch_type res = mul_real(batch_lhs(), batch_rhs());
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("mul_real");
+        }
+        // imag(batch * batch)
+        {
+            array_type expected;
+            std::transform(lhs.cbegin(), lhs.cend(), rhs.cbegin(), expected.begin(),
+                           [](const value_type& l, const value_type& r)
+                           { return std::imag(l * r); });
+            batch_type res = mul_imag(batch_lhs(), batch_rhs());
+            EXPECT_BATCH_EQ(res, expected) << print_function_name("mul_imag");
+        }
         // batch / batch
         {
             array_type expected;


### PR DESCRIPTION
I often run into cases where I need to multiply two complex batches, but only take the real or imaginary part, e.g.
```cpp
batch<std::complex<float>> a;
batch<std::complex<float>> b;
auto y = real(a * b);
```
In this case, doing the full multiply operation is somewhat wasteful, since half of the operation ends up getting thrown away.

This PR adds `xsimd::mul_real()` and `xsimd::mul_imag()` to compute this result without the wasted computations.