### PR TITLE
Accelerate gathers

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,14 +26,16 @@ else()
     message(STATUS "Tests build type is ${CMAKE_BUILD_TYPE}")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++14")
-if (NOT CMAKE_CXX_FLAGS MATCHES "-march" AND NOT CMAKE_CXX_FLAGS MATCHES "-arch" AND NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mtune=native")
-endif()
-if(NOT CMAKE_CXX_COMPILER_ID MATCHES Clang) # We are using clang-cl
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+    if (NOT CMAKE_CXX_FLAGS MATCHES "-march" AND NOT CMAKE_CXX_FLAGS MATCHES "-arch" AND NOT CMAKE_OSX_ARCHITECTURES)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mtune=native")
+    endif()
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES Clang) # We are using clang-cl
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+    endif()
 endif()
 
 add_executable(mandelbrot mandelbrot.cpp ${XSIMD_HEADERS})
+set_property(TARGET mandelbrot PROPERTY CXX_STANDARD 14)
 
 add_custom_target(xmandelbrot COMMAND mandelbrot DEPENDS mandelbrot)

--- a/include/xsimd/arch/generic/xsimd_generic_memory.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_memory.hpp
@@ -77,9 +77,9 @@ namespace xsimd
         } // namespace detail
 
         // Gather with runtime indexes and mismatched strides.
-        template <typename A, typename T, typename U, typename V>
-        inline typename ::xsimd::sizes_mismatch_t<T, U, batch<T, A>>
-        gather(U const* src, batch<V, A> const& index,
+        template <typename T, typename A, typename U, typename V>
+        inline detail::sizes_mismatch_t<T, U, batch<T, A>>
+        gather(batch<T, A> const&, U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
             static_assert(batch<T, A>::size == batch<V, A>::size,
@@ -89,9 +89,9 @@ namespace xsimd
         }
 
         // Gather with runtime indexes and matching strides.
-        template <typename A, typename T, typename U, typename V>
-        inline typename ::xsimd::sizes_match_t<T, U, batch<T, A>>
-        gather(U const* src, batch<V, A> const& index,
+        template <typename T, typename A, typename U, typename V>
+        inline detail::sizes_match_t<T, U, batch<T, A>>
+        gather(batch<T, A> const&, U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
             static_assert(batch<T, A>::size == batch<V, A>::size,
@@ -241,7 +241,7 @@ namespace xsimd
         } // namespace detail
 
         template <typename A, typename T, typename U, typename V>
-        inline typename ::xsimd::sizes_mismatch_t<T, U, void>
+        inline detail::sizes_mismatch_t<T, U, void>
         scatter(batch<T, A> const& src, U* dst,
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
@@ -253,7 +253,7 @@ namespace xsimd
         }
 
         template <typename A, typename T, typename U, typename V>
-        inline typename ::xsimd::sizes_match_t<T, U, void>
+        inline detail::sizes_match_t<T, U, void>
         scatter(batch<T, A> const& src, U* dst,
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -36,9 +36,27 @@ namespace xsimd
                 low = _mm256_castsi256_si128(val);
                 high = _mm256_extractf128_si256(val, 1);
             }
+            inline void split_avx(__m256 val, __m128& low, __m128& high) noexcept
+            {
+                low = _mm256_castps256_ps128(val);
+                high = _mm256_extractf128_ps(val, 1);
+            }
+            inline void split_avx(__m256d val, __m128d& low, __m128d& high) noexcept
+            {
+                low = _mm256_castpd256_pd128(val);
+                high = _mm256_extractf128_pd(val, 1);
+            }
             inline __m256i merge_sse(__m128i low, __m128i high) noexcept
             {
                 return _mm256_insertf128_si256(_mm256_castsi128_si256(low), high, 1);
+            }
+            inline __m256 merge_sse(__m128 low, __m128 high) noexcept
+            {
+                return _mm256_insertf128_ps(_mm256_castps128_ps256(low), high, 1);
+            }
+            inline __m256d merge_sse(__m128d low, __m128d high) noexcept
+            {
+                return _mm256_insertf128_pd(_mm256_castpd128_pd256(low), high, 1);
             }
             template <class F>
             inline __m256i fwd_to_sse(F f, __m256i self) noexcept

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -318,7 +318,7 @@ namespace xsimd
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            return _mm256_i32gather_epi32(reinterpret_cast<const int32_t*>(src), index, sizeof(T));
+            return _mm256_i32gather_epi32(reinterpret_cast<const int*>(src), index, sizeof(T));
         }
 
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
@@ -326,7 +326,6 @@ namespace xsimd
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
-            // Note: GCC for some reason defines this with long long int
             return _mm256_i64gather_epi64(reinterpret_cast<const long long int*>(src), index, sizeof(T));
         }
 

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -313,39 +313,36 @@ namespace xsimd
         }
 
         // gather
-        template <class A, class T,
-                  typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
-                                          void>::type>
-        inline batch<T, A> gather(T const* src, batch<int32_t, A> const& index,
+        template <class T, class A, class U, detail::enable_sized_integral_t<T, 4> = 0, detail::enable_sized_integral_t<U, 4> = 0>
+        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i32gather_epi32(src, index, sizeof(T));
         }
 
-        template <class A, class T,
-                  typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
-                                          void>::type>
-        inline batch<T, A> gather(T const* src, batch<int64_t, A> const& index,
+        template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
+        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i64gather_epi64(src, index, sizeof(T));
         }
 
-        template <class A>
-        inline batch<float, A> gather(float const* src,
-                                      batch<int32_t, A> const& index,
+        template <class A, class U,
+                  detail::enable_sized_integral_t<U, 4> = 0>
+        inline batch<float, A> gather(batch<float, A> const&, float const* src,
+                                      batch<U, A> const& index,
                                       kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i32gather_ps(src, index, sizeof(float));
         }
 
-        template <class A>
-        inline batch<double, A> gather(double const* src,
-                                       batch<int64_t, A> const& index,
-                                       kernel::requires_arch<avx2>) noexcept
+        template <class A, class U, detail::enable_sized_integral_t<U, 8> = 0>
+        inline batch<double, A> gather(batch<double, A> const&, double const* src,
+                                       batch<U, A> const& index,
+                                       requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i64gather_pd(src, index, sizeof(double));

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -740,35 +740,31 @@ namespace xsimd
         }
 
         // gather
-        template <class A, class T,
-                  typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
-                                          void>::type>
-        inline batch<T, A> gather(T const* src, batch<int32_t, A> const& index,
+        template <class T, class A, class U, detail::enable_sized_integral_t<T, 4> = 0, detail::enable_sized_integral_t<U, 4> = 0>
+        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i32gather_epi32(index, src, sizeof(T));
         }
 
-        template <class A, class T,
-                  typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
-                                          void>::type>
-        inline batch<T, A> gather(T const* src, batch<int64_t, A> const& index,
+        template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
+        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i64gather_epi64(index, src, sizeof(T));
         }
 
-        template <class A>
-        inline batch<float, A> gather(float const* src,
-                                      batch<int, A> const& index,
+        template <class A, class U, detail::enable_sized_integral_t<U, 4> = 0>
+        inline batch<float, A> gather(batch<float, A> const&, float const* src,
+                                      batch<U, A> const& index,
                                       kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i32gather_ps(index, src, sizeof(float));
         }
 
-        template <class A>
+        template <class A, class U, detail::enable_sized_integral_t<U, 8> = 0>
         inline batch<double, A>
-        gather(double const* src, batch<int64_t, A> const& index,
+        gather(batch<double, A> const&, double const* src, batch<U, A> const& index,
                kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i64gather_pd(index, src, sizeof(double));

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -744,14 +744,14 @@ namespace xsimd
         inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i32gather_epi32(index, reinterpret_cast<const int32_t*>(src), sizeof(T));
+            return _mm512_i32gather_epi32(index, static_cast<const void*>(src), sizeof(T));
         }
 
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
         inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
                                   kernel::requires_arch<avx512f>) noexcept
         {
-            return _mm512_i64gather_epi64(index, reinterpret_cast<const long long int*>(src), sizeof(T));
+            return _mm512_i64gather_epi64(index, static_cast<const void*>(src), sizeof(T));
         }
 
         template <class A, class U, detail::enable_sized_integral_t<U, 4> = 0>

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -567,7 +567,7 @@ namespace xsimd
     inline batch<T, A> batch<T, A>::gather(U const* src, batch<V, A> const& index) noexcept
     {
         static_assert(std::is_convertible<T, U>::value, "Can't convert from src to this batch's type!");
-        return kernel::gather<A, T>(src, index, A {});
+        return kernel::gather(batch {}, src, index, A {});
     }
 
     /**

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -221,6 +221,16 @@ namespace xsimd
 
             template <class T, size_t S>
             using enable_max_sized_integral_t = typename std::enable_if<std::is_integral<T>::value && sizeof(T) <= S, int>::type;
+
+            /********************************
+             * Matching & mismatching sizes *
+             ********************************/
+
+            template <class T, class U, class B = int>
+            using sizes_match_t = typename std::enable_if<sizeof(T) == sizeof(U), B>::type;
+
+            template <class T, class U, class B = int>
+            using sizes_mismatch_t = typename std::enable_if<sizeof(T) != sizeof(U), B>::type;
         } // namespace detail
     } // namespace kernel
 
@@ -512,16 +522,6 @@ namespace xsimd
 
     template <class B>
     using complex_batch_type_t = typename complex_batch_type<B>::type;
-
-    /********************************
-     * Matching & mismatching sizes *
-     ********************************/
-
-    template <class T, class U, class B>
-    using sizes_match_t = typename std::enable_if<sizeof(T) == sizeof(U), B>::type;
-
-    template <class T, class U, class B>
-    using sizes_mismatch_t = typename std::enable_if<sizeof(T) != sizeof(U), B>::type;
 }
 
 #endif

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -231,6 +231,9 @@ namespace xsimd
 
             template <class T, class U, class B = int>
             using sizes_mismatch_t = typename std::enable_if<sizeof(T) != sizeof(U), B>::type;
+
+            template <class T, class U, class B = int>
+            using stride_match_t = typename std::enable_if<!std::is_same<T, U>::value && sizeof(T) == sizeof(U), B>::type;
         } // namespace detail
     } // namespace kernel
 

--- a/test/test_error_gamma.cpp
+++ b/test/test_error_gamma.cpp
@@ -127,7 +127,8 @@ protected:
             size_t diff = detail::get_nb_diff(res, expected);
             EXPECT_EQ(diff, 0) << print_function_name("lgamma");
         }
-#if not(XSIMD_WITH_AVX and not XSIMD_WITH_AVX2)
+#if !(XSIMD_WITH_AVX && !XSIMD_WITH_AVX2)
+
         // tgamma (negative input)
         {
             std::transform(gamma_neg_input.cbegin(), gamma_neg_input.cend(), expected.begin(),


### PR DESCRIPTION
:wave: 

I finished the xsimd port of our app, and I discovered that Vc accelerates narrowing gathers of particular types. xsimd doesn't have these primitives, so I looked at the assembly and ported them here.

This PR also removes dead code that got introduced by mistake in #730 .

(Setting as draft because I'd like to check if I can add choices in SSE-land, as well as widening options.)