### PR TITLE
Fix x86-only build on MSVC

### DIFF
--- a/include/xsimd/arch/xsimd_sse4_1.hpp
+++ b/include/xsimd/arch/xsimd_sse4_1.hpp
@@ -113,7 +113,7 @@ namespace xsimd
                 return _mm_insert_epi8(self, val, I);
             case 4:
                 return _mm_insert_epi32(self, val, I);
-#if !defined(_MSC_VER) || _MSC_VER > 1900
+#if !defined(_MSC_VER) || _MSC_VER > 1900 && defined(_M_X64)
             case 8:
                 return _mm_insert_epi64(self, val, I);
 #endif


### PR DESCRIPTION
👋 

I found a very specific case CI didn't cover: if the MSVC version is new enough (2019/22) and it compiles with `/arch:SSE2`, hence targeting up to SSE4.2, it will attempt to use `_mm_insert_epi64`. But according to [the docs](https://docs.microsoft.com/en-us/cpp/intrinsics/x86-intrinsics-list?view=msvc-170), this particular intrinsic isn't available on x86 platforms.

This PR makes sure we don't try to use this intrinsic on these particular builds.