### PR TITLE
Fix usage of unincluded std::array in avx512bw

### DIFF
--- a/include/xsimd/arch/xsimd_avx512bw.hpp
+++ b/include/xsimd/arch/xsimd_avx512bw.hpp
@@ -12,6 +12,7 @@
 #ifndef XSIMD_AVX512BW_HPP
 #define XSIMD_AVX512BW_HPP
 
+#include <array>
 #include <type_traits>
 
 #include "../types/xsimd_avx512bw_register.hpp"


### PR DESCRIPTION
:wave:

This PR is to fix an oversight in #724, in recent enough Clang versions `#include <array>` isn't implied by `type_traits`.

I tested this with MSYS Clang 14.0.3 on the CLANG32 and CLANG64 ABIs.