### PR TITLE
There's no fallback implementation anymore, don't document it

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux-clang.yml
+++ b/.azure-pipelines/azure-pipelines-linux-clang.yml
@@ -35,7 +35,6 @@ jobs:
       avx512: 0
       i686: 0
       enable_xtl_complex: 0
-      enable_fallback: 0
       force_no_instr_set: 0
 
     timeoutInMinutes: 30

--- a/.azure-pipelines/azure-pipelines-linux-gcc.yml
+++ b/.azure-pipelines/azure-pipelines-linux-gcc.yml
@@ -34,7 +34,6 @@ jobs:
       avx512: 0
       i686: 0
       enable_xtl_complex: 0
-      enable_fallback: 0
       force_no_instr_set: 0
     timeoutInMinutes: 30
     steps:

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -32,9 +32,6 @@ steps:
       if [[ $(enable_xtl_complex) == 1 ]]; then
         CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DENABLE_XTL_COMPLEX=ON";
       fi
-      if [[ $(enable_fallback) == 1 ]]; then
-        CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DENABLE_FALLBACK=ON";
-      fi
       if [[ $(avx) == 1 ]]; then
         CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=sandybridge"
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,17 +87,12 @@ target_include_directories(xsimd INTERFACE
 
 target_compile_features(xsimd INTERFACE cxx_std_11)
 
-OPTION(ENABLE_FALLBACK "build tests/benchmarks with fallback implementation" OFF)
 OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
 OPTION(BUILD_TESTS "xsimd test suite" OFF)
 OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)
-endif()
-
-if(ENABLE_FALLBACK)
-    add_definitions(-DXSIMD_ENABLE_FALLBACK=1)
 endif()
 
 if(ENABLE_XTL_COMPLEX)

--- a/docs/source/api/available_wrappers.rst
+++ b/docs/source/api/available_wrappers.rst
@@ -33,18 +33,6 @@ The :ref:`batch <xsimd-batch-ref>` and :ref:`batch_bool <xsimd-batch-bool-ref>` 
 by default, only full specializations of these templates are available depending on the instruction set macros defined
 according to the instruction sets provided by the compiler.
 
-Fallback implementation
------------------------
-
-You may optionally enable a fallback implementation, which translates batch and batch_bool variants that do not exist in
-hardware into scalar loops. This is done by setting the XSIMD_ENABLE_FALLBACK preprocessor flag before including any xsimd
-header.
-
-This scalar fallback enables you to test the correctness of your computations without having matching hardware available, but
-you should be aware that it is only intended for use in validation scenarios. It has generally speaking not been tuned for
-performance, and its run-time characteristics may vary enormously from one compiler to another. Enabling it in
-performance-conscious production code is therefore strongly discouraged.
-
 XTL complex support
 -------------------
 

--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -20,8 +20,6 @@
 
 #include "pico_bench.hpp"
 
-#define XSIMD_ENABLE_FALLBACK
-
 #include <xsimd/xsimd.hpp>
 
 // helper function to write the rendered image as PPM file

--- a/test/test_arch.cpp
+++ b/test/test_arch.cpp
@@ -178,15 +178,4 @@ TEST(arch, default_load)
     try_loads<type_list>();
 }
 
-#ifdef XSIMD_ENABLE_FALLBACK
-// FIXME: this should be named scalar
-TEST(arch, scalar)
-{
-    float data[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
-    float ref = std::accumulate(std::begin(data), std::end(data), 0);
-
-    float res = sum {}(xsimd::arch::scalar {}, data, 17);
-    EXPECT_EQ(ref, res);
-}
-#endif
 #endif


### PR DESCRIPTION
Remove all obsolete reference to XSIMD_ENABLE_FALLBACK

Related to #756