### PR TITLE
Made it so that clang also warns on unused results.

### DIFF
--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -12,7 +12,7 @@
 #ifndef XSIMD_HPP
 #define XSIMD_HPP
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined (__clang__)
 #define XSIMD_NO_DISCARD __attribute__((warn_unused_result))
 #else
 #define XSIMD_NO_DISCARD

--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -12,7 +12,7 @@
 #ifndef XSIMD_HPP
 #define XSIMD_HPP
 
-#if defined(__GNUC__) || defined (__clang__)
+#if defined(__GNUC__) || defined(__clang__)
 #define XSIMD_NO_DISCARD __attribute__((warn_unused_result))
 #else
 #define XSIMD_NO_DISCARD


### PR DESCRIPTION
The proper way to check if the compiler is Clang or not, is to [check if `__clang__` is defined](https://stackoverflow.com/a/2658480/12591388). I updated the preprocessor directives around `XSIMD_NO_DISCARD` to check for `__clang__` as well.