### PR TITLE
Fixed a TODO.

### DIFF
--- a/include/xsimd/types/xsimd_register.hpp
+++ b/include/xsimd/types/xsimd_register.hpp
@@ -73,10 +73,9 @@ namespace xsimd
 
     namespace kernel
     {
-        // TODO: rename this, as it might conflict with C++20 keyword.
-        // We should use add_const and add_reference to build A const&
         template <class A>
-        using requires_arch = A const&;
+        // makes requires_arch equal to A const&, using type_traits functions
+        using requires_arch = typename std::add_lvalue_reference<typename std::add_const<A>::type>::type;
         template <class T>
         struct convert
         {


### PR DESCRIPTION
I fixed the TODO, which said that using [`std::add_const`](https://en.cppreference.com/w/cpp/types/add_cv) and [`std::add_lvalue_reference`](https://en.cppreference.com/w/cpp/types/add_reference) is the preferred of building the `requires_arch` predicate.

I also removed the comment about the possible clash with the C++20 [`requires` keyword](https://en.cppreference.com/w/cpp/keyword/requires), as it is not a concern: The keyword is `requires`, so it does not clash with `requires_arch`.