### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ namespace xs = xsimd;
 
 int main(int argc, char* argv[])
 {
-    xs::batch<double, xs::avx2> a(1.5, 2.5, 3.5, 4.5);
-    xs::batch<double, xs::avx2> b(2.5, 3.5, 4.5, 5.5);
+    xs::batch<double, xs::avx2> a = {1.5, 2.5, 3.5, 4.5};
+    xs::batch<double, xs::avx2> b = {2.5, 3.5, 4.5, 5.5};
     auto mean = (a + b) / 2;
     std::cout << mean << std::endl;
     return 0;


### PR DESCRIPTION
Fix the example for the explicit use of an instruction set extension in ```README.md``` as discussed in #766 