### PR TITLE
Add NEON64 hadd for single-precision floats

### DIFF
--- a/include/xsimd/arch/xsimd_neon64.hpp
+++ b/include/xsimd/arch/xsimd_neon64.hpp
@@ -711,6 +711,12 @@ namespace xsimd
         }
 
         template <class A>
+        inline float hadd(batch<float, A> const& arg, requires_arch<neon64>) noexcept
+        {
+            return vaddvq_f32(arg);
+        }
+
+        template <class A>
         inline double hadd(batch<double, A> const& arg, requires_arch<neon64>) noexcept
         {
             return vaddvq_f64(arg);


### PR DESCRIPTION
I noticed this was missing. On clang at least this still produces two calls to FADDP, but without an extract instruction present in the Neon32 implementation