### PR TITLE
Exploration of calling convention, pass by ref/value and forced inline on MSVC

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,5 +4,9 @@ AlignAfterOpenBracket: Align
 AlignConsecutiveDeclarations: 'false'
 BreakBeforeBraces: Allman
 NamespaceIndentation: All
-
+AttributeMacros:
+  - XSIMD_CALLCONV
+  - XSIMD_CREF
+  - XSIMD_FORCEINLINE
+  - XSIMD_NODISCARD
 ...

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -425,60 +425,60 @@ namespace xsimd
         out << "============================" << std::endl;
     }
 
-#define DEFINE_OP_FUNCTOR_2OP(OP, NAME)                                              \
-    struct NAME##_fn                                                                 \
+#define DEFINE_OP_FUNCTOR_2OP(OP, NAME)                                                                     \
+    struct NAME##_fn                                                                                        \
+    {                                                                                                       \
+        template <class T>                                                                                  \
+        inline T XSIMD_CALLCONV operator()(T XSIMD_CREF lhs, T XSIMD_CREF rhs) const { return lhs OP rhs; } \
+        inline std::string name() const { return #NAME; }                                                   \
+    }
+
+#define DEFINE_FUNCTOR_1OP(FN)                                   \
+    struct FN##_fn                                               \
+    {                                                            \
+        template <class T>                                       \
+        inline T XSIMD_CALLCONV operator()(T XSIMD_CREF x) const \
+        {                                                        \
+            using xsimd::FN;                                     \
+            return FN(x);                                        \
+        }                                                        \
+        inline std::string name() const { return #FN; }          \
+    }
+
+#define DEFINE_FUNCTOR_1OP_TEMPLATE(FN, N, ...)                  \
+    struct FN##_##N##_fn                                         \
+    {                                                            \
+        template <class T>                                       \
+        inline T XSIMD_CALLCONV operator()(T XSIMD_CREF x) const \
+        {                                                        \
+            using xsimd::FN;                                     \
+            return FN<T, __VA_ARGS__>(x);                        \
+        }                                                        \
+        inline std::string name() const { return #FN " " #N; }   \
+    }
+
+#define DEFINE_FUNCTOR_2OP(FN)                                                       \
+    struct FN##_fn                                                                   \
     {                                                                                \
         template <class T>                                                           \
-        inline T operator()(const T& lhs, const T& rhs) const { return lhs OP rhs; } \
-        inline std::string name() const { return #NAME; }                            \
+        inline T XSIMD_CALLCONV operator()(T XSIMD_CREF lhs, T XSIMD_CREF rhs) const \
+        {                                                                            \
+            using xsimd::FN;                                                         \
+            return FN(lhs, rhs);                                                     \
+        }                                                                            \
+        inline std::string name() const { return #FN; }                              \
     }
 
-#define DEFINE_FUNCTOR_1OP(FN)                          \
-    struct FN##_fn                                      \
-    {                                                   \
-        template <class T>                              \
-        inline T operator()(const T& x) const           \
-        {                                               \
-            using xsimd::FN;                            \
-            return FN(x);                               \
-        }                                               \
-        inline std::string name() const { return #FN; } \
-    }
-
-#define DEFINE_FUNCTOR_1OP_TEMPLATE(FN, N, ...)                \
-    struct FN##_##N##_fn                                       \
-    {                                                          \
-        template <class T>                                     \
-        inline T operator()(const T& x) const                  \
-        {                                                      \
-            using xsimd::FN;                                   \
-            return FN<T, __VA_ARGS__>(x);                      \
-        }                                                      \
-        inline std::string name() const { return #FN " " #N; } \
-    }
-
-#define DEFINE_FUNCTOR_2OP(FN)                                \
-    struct FN##_fn                                            \
-    {                                                         \
-        template <class T>                                    \
-        inline T operator()(const T& lhs, const T& rhs) const \
-        {                                                     \
-            using xsimd::FN;                                  \
-            return FN(lhs, rhs);                              \
-        }                                                     \
-        inline std::string name() const { return #FN; }       \
-    }
-
-#define DEFINE_FUNCTOR_3OP(FN)                                              \
-    struct FN##_fn                                                          \
-    {                                                                       \
-        template <class T>                                                  \
-        inline T operator()(const T& op0, const T& op1, const T& op2) const \
-        {                                                                   \
-            using xsimd::FN;                                                \
-            return FN(op0, op1, op2);                                       \
-        }                                                                   \
-        inline std::string name() const { return #FN; }                     \
+#define DEFINE_FUNCTOR_3OP(FN)                                                                         \
+    struct FN##_fn                                                                                     \
+    {                                                                                                  \
+        template <class T>                                                                             \
+        inline T XSIMD_CALLCONV operator()(T XSIMD_CREF op0, T XSIMD_CREF op1, T XSIMD_CREF op2) const \
+        {                                                                                              \
+            using xsimd::FN;                                                                           \
+            return FN(op0, op1, op2);                                                                  \
+        }                                                                                              \
+        inline std::string name() const { return #FN; }                                                \
     }
 
     DEFINE_OP_FUNCTOR_2OP(+, add);

--- a/cpp.hint
+++ b/cpp.hint
@@ -1,0 +1,4 @@
+#define XSIMD_CALLCONV
+#define XSIMD_CREF          const&
+#define XSIMD_FORCEINLINE   inline
+#define XSIMD_NODISCARD     [[nodiscard]]

--- a/include/xsimd/arch/generic/xsimd_generic_arithmetic.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_arithmetic.hpp
@@ -27,7 +27,7 @@ namespace xsimd
 
         // bitwise_lshift
         template <class A, class T, class /*=typename std::enable_if<std::is_integral<T>::value, void>::type*/>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept
                                  { return x << y; },
@@ -36,7 +36,7 @@ namespace xsimd
 
         // bitwise_rshift
         template <class A, class T, class /*=typename std::enable_if<std::is_integral<T>::value, void>::type*/>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept
                                  { return x >> y; },
@@ -45,7 +45,7 @@ namespace xsimd
 
         // div
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> div(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV div(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept -> T
                                  { return x / y; },
@@ -54,13 +54,13 @@ namespace xsimd
 
         // fma
         template <class A, class T>
-        inline batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
         {
             return x * y + z;
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> fma(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV fma(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             auto res_r = fms(x.real(), y.real(), fms(x.imag(), y.imag(), z.real()));
             auto res_i = fma(x.real(), y.imag(), fma(x.imag(), y.real(), z.imag()));
@@ -69,13 +69,13 @@ namespace xsimd
 
         // fms
         template <class A, class T>
-        inline batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
         {
             return x * y - z;
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> fms(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV fms(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             auto res_r = fms(x.real(), y.real(), fma(x.imag(), y.imag(), z.real()));
             auto res_i = fma(x.real(), y.imag(), fms(x.imag(), y.real(), z.imag()));
@@ -84,13 +84,13 @@ namespace xsimd
 
         // fnma
         template <class A, class T>
-        inline batch<T, A> fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
         {
             return -x * y + z;
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> fnma(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV fnma(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             auto res_r = -fms(x.real(), y.real(), fma(x.imag(), y.imag(), z.real()));
             auto res_i = -fma(x.real(), y.imag(), fms(x.imag(), y.real(), z.imag()));
@@ -99,13 +99,13 @@ namespace xsimd
 
         // fnms
         template <class A, class T>
-        inline batch<T, A> fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<generic>) noexcept
         {
             return -x * y - z;
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> fnms(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV fnms(batch<std::complex<T>, A> const& x, batch<std::complex<T>, A> const& y, batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             auto res_r = -fms(x.real(), y.real(), fms(x.imag(), y.imag(), z.real()));
             auto res_i = -fma(x.real(), y.imag(), fma(x.imag(), y.real(), z.imag()));
@@ -114,7 +114,7 @@ namespace xsimd
 
         // mul
         template <class A, class T, class /*=typename std::enable_if<std::is_integral<T>::value, void>::type*/>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept -> T
                                  { return x * y; },

--- a/include/xsimd/arch/generic/xsimd_generic_complex.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_complex.hpp
@@ -26,54 +26,54 @@ namespace xsimd
 
         // real
         template <class A, class T>
-        inline batch<T, A> real(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV real(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return self;
         }
 
         template <class A, class T>
-        inline batch<T, A> real(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV real(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             return self.real();
         }
 
         // imag
         template <class A, class T>
-        inline batch<T, A> imag(batch<T, A> const& /*self*/, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV imag(batch<T, A> const& /*self*/, requires_arch<generic>) noexcept
         {
             return batch<T, A>(T(0));
         }
 
         template <class A, class T>
-        inline batch<T, A> imag(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV imag(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             return self.imag();
         }
 
         // arg
         template <class A, class T>
-        inline real_batch_type_t<batch<T, A>> arg(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV arg(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return atan2(imag(self), real(self));
         }
 
         // conj
         template <class A, class T>
-        inline complex_batch_type_t<batch<T, A>> conj(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline complex_batch_type_t<batch<T, A>> XSIMD_CALLCONV conj(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return { real(self), -imag(self) };
         }
 
         // norm
         template <class A, class T>
-        inline real_batch_type_t<batch<T, A>> norm(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV norm(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return { fma(real(self), real(self), imag(self) * imag(self)) };
         }
 
         // proj
         template <class A, class T>
-        inline complex_batch_type_t<batch<T, A>> proj(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline complex_batch_type_t<batch<T, A>> XSIMD_CALLCONV proj(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = complex_batch_type_t<batch<T, A>>;
             using real_batch = typename batch_type::real_batch;
@@ -86,7 +86,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> isnan(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV isnan(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             return batch_bool<T, A>(isnan(self.real()) || isnan(self.imag()));
         }

--- a/include/xsimd/arch/generic/xsimd_generic_details.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_details.hpp
@@ -14,6 +14,7 @@
 
 #include <complex>
 
+#include "../../config/xsimd_config.hpp"
 #include "../../math/xsimd_rem_pio2.hpp"
 #include "../../types/xsimd_generic_arch.hpp"
 #include "../../types/xsimd_utils.hpp"
@@ -23,85 +24,85 @@ namespace xsimd
 {
     // Forward declaration. Should we put them in a separate file?
     template <class T, class A>
-    inline batch<T, A> abs(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> abs(batch<std::complex<T>, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV abs(batch<std::complex<T>, A> const& self) noexcept;
     template <class T, class A>
-    inline bool any(batch_bool<T, A> const& self) noexcept;
+    inline bool XSIMD_CALLCONV any(batch_bool<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> atan2(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV atan2(batch<T, A> const& self, batch<T, A> const& other) noexcept;
     template <class T, class A>
-    inline batch<T, A> bitofsign(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV bitofsign(batch<T, A> const& self) noexcept;
     template <class B, class T, class A>
-    inline B bitwise_cast(batch<T, A> const& self) noexcept;
+    inline B XSIMD_CALLCONV bitwise_cast(batch<T, A> const& self) noexcept;
     template <class A>
-    inline batch_bool<float, A> bool_cast(batch_bool<int32_t, A> const& self) noexcept;
+    inline batch_bool<float, A> XSIMD_CALLCONV bool_cast(batch_bool<int32_t, A> const& self) noexcept;
     template <class A>
-    inline batch_bool<int32_t, A> bool_cast(batch_bool<float, A> const& self) noexcept;
+    inline batch_bool<int32_t, A> XSIMD_CALLCONV bool_cast(batch_bool<float, A> const& self) noexcept;
     template <class A>
-    inline batch_bool<double, A> bool_cast(batch_bool<int64_t, A> const& self) noexcept;
+    inline batch_bool<double, A> XSIMD_CALLCONV bool_cast(batch_bool<int64_t, A> const& self) noexcept;
     template <class A>
-    inline batch_bool<int64_t, A> bool_cast(batch_bool<double, A> const& self) noexcept;
+    inline batch_bool<int64_t, A> XSIMD_CALLCONV bool_cast(batch_bool<double, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> cos(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV cos(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> cosh(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV cosh(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> exp(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV exp(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept;
     template <class T, class A>
-    inline batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept;
     template <class T, class A>
-    inline batch<T, A> frexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& e) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV frexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& e) noexcept;
     template <class T, class A>
-    inline T hadd(batch<T, A> const&) noexcept;
+    inline T XSIMD_CALLCONV hadd(batch<T, A> const&) noexcept;
     template <class T, class A, uint64_t... Coefs>
-    inline batch<T, A> horner(const batch<T, A>& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV horner(const batch<T, A>& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> hypot(const batch<T, A>& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV hypot(const batch<T, A>& self) noexcept;
     template <class T, class A>
-    inline batch_bool<T, A> is_even(batch<T, A> const& self) noexcept;
+    inline batch_bool<T, A> XSIMD_CALLCONV is_even(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch_bool<T, A> is_flint(batch<T, A> const& self) noexcept;
+    inline batch_bool<T, A> XSIMD_CALLCONV is_flint(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch_bool<T, A> is_odd(batch<T, A> const& self) noexcept;
+    inline batch_bool<T, A> XSIMD_CALLCONV is_odd(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch_bool<T, A> isinf(batch<T, A> const& self) noexcept;
+    inline batch_bool<T, A> XSIMD_CALLCONV isinf(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline typename batch<T, A>::batch_bool_type isnan(batch<T, A> const& self) noexcept;
+    inline typename batch<T, A>::batch_bool_type XSIMD_CALLCONV isnan(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& e) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& e) noexcept;
     template <class T, class A>
-    inline batch<T, A> log(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV log(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> nearbyint(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV nearbyint(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<as_integer_t<T>, A> nearbyint_as_int(const batch<T, A>& x) noexcept;
+    inline batch<as_integer_t<T>, A> XSIMD_CALLCONV nearbyint_as_int(const batch<T, A>& x) noexcept;
     template <class T, class A>
-    inline batch<T, A> select(batch_bool<T, A> const&, batch<T, A> const&, batch<T, A> const&) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> const&, batch<T, A> const&, batch<T, A> const&) noexcept;
     template <class T, class A>
-    inline batch<std::complex<T>, A> select(batch_bool<T, A> const&, batch<std::complex<T>, A> const&, batch<std::complex<T>, A> const&) noexcept;
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV select(batch_bool<T, A> const&, batch<std::complex<T>, A> const&, batch<std::complex<T>, A> const&) noexcept;
     template <class T, class A>
-    inline batch<T, A> sign(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV sign(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> signnz(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV signnz(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> sin(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV sin(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> sinh(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV sinh(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline std::pair<batch<T, A>, batch<T, A>> sincos(batch<T, A> const& self) noexcept;
+    inline std::pair<batch<T, A>, batch<T, A>> XSIMD_CALLCONV sincos(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> sqrt(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV sqrt(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> tan(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV tan(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<as_float_t<T>, A> to_float(batch<T, A> const& self) noexcept;
+    inline batch<as_float_t<T>, A> XSIMD_CALLCONV to_float(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<as_integer_t<T>, A> to_int(batch<T, A> const& self) noexcept;
+    inline batch<as_integer_t<T>, A> XSIMD_CALLCONV to_int(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch<T, A> trunc(batch<T, A> const& self) noexcept;
+    inline batch<T, A> XSIMD_CALLCONV trunc(batch<T, A> const& self) noexcept;
 
     namespace kernel
     {
@@ -109,7 +110,7 @@ namespace xsimd
         namespace detail
         {
             template <class F, class A, class T, class... Batches>
-            inline batch<T, A> apply(F&& func, batch<T, A> const& self, batch<T, A> const& other) noexcept
+            inline batch<T, A> XSIMD_CALLCONV apply(F&& func, batch<T, A> const& self, batch<T, A> const& other) noexcept
             {
                 constexpr std::size_t size = batch<T, A>::size;
                 alignas(A::alignment()) T self_buffer[size];
@@ -124,7 +125,7 @@ namespace xsimd
             }
 
             template <class U, class F, class A, class T>
-            inline batch<U, A> apply_transform(F&& func, batch<T, A> const& self) noexcept
+            inline batch<U, A> XSIMD_CALLCONV apply_transform(F&& func, batch<T, A> const& self) noexcept
             {
                 static_assert(batch<T, A>::size == batch<U, A>::size,
                               "Source and destination sizes must match");
@@ -187,25 +188,25 @@ namespace xsimd
              * ====================================================
              */
             template <class B, uint64_t c>
-            inline B coef() noexcept
+            inline B XSIMD_CALLCONV coef() noexcept
             {
                 using value_type = typename B::value_type;
                 return B(bit_cast<value_type>(as_unsigned_integer_t<value_type>(c)));
             }
             template <class B>
-            inline B horner(const B&) noexcept
+            inline B XSIMD_CALLCONV horner(const B&) noexcept
             {
                 return B(typename B::value_type(0.));
             }
 
             template <class B, uint64_t c0>
-            inline B horner(const B&) noexcept
+            inline B XSIMD_CALLCONV horner(const B&) noexcept
             {
                 return coef<B, c0>();
             }
 
             template <class B, uint64_t c0, uint64_t c1, uint64_t... args>
-            inline B horner(const B& self) noexcept
+            inline B XSIMD_CALLCONV horner(const B& self) noexcept
             {
                 return fma(self, horner<B, c1, args...>(self), coef<B, c0>());
             }
@@ -220,19 +221,19 @@ namespace xsimd
              * ====================================================
              */
             template <class B>
-            inline B horner1(const B&) noexcept
+            inline B XSIMD_CALLCONV horner1(const B&) noexcept
             {
                 return B(1.);
             }
 
             template <class B, uint64_t c0>
-            inline B horner1(const B& x) noexcept
+            inline B XSIMD_CALLCONV horner1(const B& x) noexcept
             {
                 return x + detail::coef<B, c0>();
             }
 
             template <class B, uint64_t c0, uint64_t c1, uint64_t... args>
-            inline B horner1(const B& x) noexcept
+            inline B XSIMD_CALLCONV horner1(const B& x) noexcept
             {
                 return fma(x, horner1<B, c1, args...>(x), detail::coef<B, c0>());
             }

--- a/include/xsimd/arch/generic/xsimd_generic_logical.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_logical.hpp
@@ -24,7 +24,7 @@ namespace xsimd
 
         // from  mask
         template <class A, class T>
-        inline batch_bool<T, A> from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) bool buffer[batch_bool<T, A>::size];
             // This is inefficient but should never be called. It's just a
@@ -36,28 +36,28 @@ namespace xsimd
 
         // ge
         template <class A, class T>
-        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return other <= self;
         }
 
         // gt
         template <class A, class T>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return other < self;
         }
 
         // is_even
         template <class A, class T>
-        inline batch_bool<T, A> is_even(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV is_even(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return is_flint(self * T(0.5));
         }
 
         // is_flint
         template <class A, class T>
-        inline batch_bool<T, A> is_flint(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV is_flint(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             auto frac = select(isnan(self - self), constants::nan<batch<T, A>>(), self - trunc(self));
             return frac == T(0.);
@@ -65,69 +65,69 @@ namespace xsimd
 
         // is_odd
         template <class A, class T>
-        inline batch_bool<T, A> is_odd(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV is_odd(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return is_even(self - T(1.));
         }
 
         // isinf
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> isinf(batch<T, A> const&, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV isinf(batch<T, A> const&, requires_arch<generic>) noexcept
         {
             return batch_bool<T, A>(false);
         }
         template <class A>
-        inline batch_bool<float, A> isinf(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV isinf(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return abs(self) == std::numeric_limits<float>::infinity();
         }
         template <class A>
-        inline batch_bool<double, A> isinf(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV isinf(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return abs(self) == std::numeric_limits<double>::infinity();
         }
 
         // isfinite
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> isfinite(batch<T, A> const&, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV isfinite(batch<T, A> const&, requires_arch<generic>) noexcept
         {
             return batch_bool<T, A>(true);
         }
         template <class A>
-        inline batch_bool<float, A> isfinite(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV isfinite(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return (self - self) == 0.f;
         }
         template <class A>
-        inline batch_bool<double, A> isfinite(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV isfinite(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return (self - self) == 0.;
         }
 
         // isnan
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> isnan(batch<T, A> const&, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV isnan(batch<T, A> const&, requires_arch<generic>) noexcept
         {
             return batch_bool<T, A>(false);
         }
 
         // le
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return (self < other) || (self == other);
         }
 
         // neq
         template <class A, class T>
-        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return !(other == self);
         }
 
         // logical_and
         template <class A, class T>
-        inline batch<T, A> logical_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV logical_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept
                                  { return x && y; },
@@ -136,7 +136,7 @@ namespace xsimd
 
         // logical_or
         template <class A, class T>
-        inline batch<T, A> logical_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV logical_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept
                                  { return x || y; },
@@ -145,7 +145,7 @@ namespace xsimd
 
         // mask
         template <class A, class T>
-        inline uint64_t mask(batch_bool<T, A> const& self, requires_arch<generic>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<T, A> const& self, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) bool buffer[batch_bool<T, A>::size];
             self.store_aligned(buffer);

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -27,7 +27,7 @@ namespace xsimd
         using namespace types;
         // abs
         template <class A, class T, class /*=typename std::enable_if<std::is_integral<T>::value, void>::type*/>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             if (std::is_unsigned<T>::value)
                 return self;
@@ -40,14 +40,14 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> abs(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             return hypot(z.real(), z.imag());
         }
 
         // batch_cast
         template <class A, class T>
-        inline batch<T, A> batch_cast(batch<T, A> const& self, batch<T, A> const&, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV batch_cast(batch<T, A> const& self, batch<T, A> const&, requires_arch<generic>) noexcept
         {
             return self;
         }
@@ -55,12 +55,12 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T_out, class T_in>
-            inline batch<T_out, A> batch_cast(batch<T_in, A> const& self, batch<T_out, A> const& out, requires_arch<generic>, with_fast_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV batch_cast(batch<T_in, A> const& self, batch<T_out, A> const& out, requires_arch<generic>, with_fast_conversion) noexcept
             {
                 return fast_cast(self, out, A {});
             }
             template <class A, class T_out, class T_in>
-            inline batch<T_out, A> batch_cast(batch<T_in, A> const& self, batch<T_out, A> const&, requires_arch<generic>, with_slow_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV batch_cast(batch<T_in, A> const& self, batch<T_out, A> const&, requires_arch<generic>, with_slow_conversion) noexcept
             {
                 static_assert(!std::is_same<T_in, T_out>::value, "there should be no conversion for this type combination");
                 using batch_type_in = batch<T_in, A>;
@@ -76,14 +76,14 @@ namespace xsimd
         }
 
         template <class A, class T_out, class T_in>
-        inline batch<T_out, A> batch_cast(batch<T_in, A> const& self, batch<T_out, A> const& out, requires_arch<generic>) noexcept
+        inline batch<T_out, A> XSIMD_CALLCONV batch_cast(batch<T_in, A> const& self, batch<T_out, A> const& out, requires_arch<generic>) noexcept
         {
             return detail::batch_cast(self, out, A {}, detail::conversion_type<A, T_in, T_out> {});
         }
 
         // bitofsign
         template <class A, class T>
-        inline batch<T, A> bitofsign(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitofsign(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             static_assert(std::is_integral<T>::value, "int type implementation");
             if (std::is_unsigned<T>::value)
@@ -93,12 +93,12 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<float, A> bitofsign(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitofsign(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return self & constants::minuszero<batch<float, A>>();
         }
         template <class A>
-        inline batch<double, A> bitofsign(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitofsign(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return self & constants::minuszero<batch<double, A>>();
         }
@@ -114,7 +114,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A>
-        inline batch<float, A> cbrt(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV cbrt(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type z = abs(self);
@@ -161,7 +161,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> cbrt(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV cbrt(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type z = abs(self);
@@ -210,14 +210,14 @@ namespace xsimd
 
         // clip
         template <class A, class T>
-        inline batch<T, A> clip(batch<T, A> const& self, batch<T, A> const& lo, batch<T, A> const& hi, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV clip(batch<T, A> const& self, batch<T, A> const& lo, batch<T, A> const& hi, requires_arch<generic>) noexcept
         {
             return min(hi, max(self, lo));
         }
 
         // copysign
         template <class A, class T>
-        inline batch<T, A> copysign(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV copysign(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return abs(self) | bitofsign(other);
         }
@@ -244,7 +244,7 @@ namespace xsimd
                 using batch_type = batch<float, A>;
                 // computes erf(a0)/a0
                 // x is sqr(a0) and 0 <= abs(a0) <= 2/3
-                static inline batch_type erf1(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erf1(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0x3f906eba, //   1.128379154774254e+00
@@ -258,7 +258,7 @@ namespace xsimd
 
                 // computes erfc(x)*exp(sqr(x))
                 // x >=  2/3
-                static inline batch_type erfc2(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erfc2(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0x3f0a0e8b, //   5.392844046572836e-01
@@ -275,7 +275,7 @@ namespace xsimd
                                           >(x);
                 }
 
-                static inline batch_type erfc3(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erfc3(const batch_type& x) noexcept
                 {
                     return (batch_type(1.) - x) * detail::horner<batch_type,
                                                                  0x3f7ffffe, //   9.9999988e-01
@@ -297,7 +297,7 @@ namespace xsimd
                 using batch_type = batch<double, A>;
                 // computes erf(a0)/a0
                 // x is sqr(a0) and 0 <= abs(a0) <= 0.65
-                static inline batch_type erf1(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erf1(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0x3ff20dd750429b61ull, // 1.12837916709551
@@ -317,7 +317,7 @@ namespace xsimd
 
                 // computes erfc(x)*exp(x*x)
                 // 0.65 <= abs(x) <= 2.2
-                static inline batch_type erfc2(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erfc2(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0x3feffffffbbb552bull, // 0.999999992049799
@@ -341,7 +341,7 @@ namespace xsimd
 
                 // computes erfc(x)*exp(x*x)
                 // 2.2 <= abs(x) <= 6
-                static inline batch_type erfc3(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erfc3(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0x3fefff5a9e697ae2ull, // 0.99992114009714
@@ -365,7 +365,7 @@ namespace xsimd
 
                 // computes erfc(rx)*exp(rx*rx)
                 // x >=  6 rx = 1/x
-                static inline batch_type erfc4(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV erfc4(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0xbc7e4ad1ec7d0000ll, // -2.627435221016534e-17
@@ -397,7 +397,7 @@ namespace xsimd
          */
 
         template <class A>
-        inline batch<float, A> erf(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV erf(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type x = abs(self);
@@ -421,7 +421,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> erf(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV erf(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type x = abs(self);
@@ -457,7 +457,7 @@ namespace xsimd
 
         // erfc
         template <class A>
-        inline batch<float, A> erfc(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV erfc(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type x = abs(self);
@@ -481,7 +481,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> erfc(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV erfc(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type x = abs(self);
@@ -525,54 +525,54 @@ namespace xsimd
                 B x;
 
                 template <typename... Ts>
-                inline B operator()(const Ts&... coefs) noexcept
+                inline B XSIMD_CALLCONV operator()(const Ts&... coefs) noexcept
                 {
                     return eval(coefs...);
                 }
 
             private:
-                inline B eval(const B& c0) noexcept
+                inline B XSIMD_CALLCONV eval(const B& c0) noexcept
                 {
                     return c0;
                 }
 
-                inline B eval(const B& c0, const B& c1) noexcept
+                inline B XSIMD_CALLCONV eval(const B& c0, const B& c1) noexcept
                 {
                     return fma(x, c1, c0);
                 }
 
                 template <size_t... Is, class Tuple>
-                inline B eval(::xsimd::detail::index_sequence<Is...>, const Tuple& tuple)
+                inline B XSIMD_CALLCONV eval(::xsimd::detail::index_sequence<Is...>, const Tuple& tuple)
                 {
                     return estrin { x * x }(std::get<Is>(tuple)...);
                 }
 
                 template <class... Args>
-                inline B eval(const std::tuple<Args...>& tuple) noexcept
+                inline B XSIMD_CALLCONV eval(const std::tuple<Args...>& tuple) noexcept
                 {
                     return eval(::xsimd::detail::make_index_sequence<sizeof...(Args)>(), tuple);
                 }
 
                 template <class... Args>
-                inline B eval(const std::tuple<Args...>& tuple, const B& c0) noexcept
+                inline B XSIMD_CALLCONV eval(const std::tuple<Args...>& tuple, const B& c0) noexcept
                 {
                     return eval(std::tuple_cat(tuple, std::make_tuple(eval(c0))));
                 }
 
                 template <class... Args>
-                inline B eval(const std::tuple<Args...>& tuple, const B& c0, const B& c1) noexcept
+                inline B XSIMD_CALLCONV eval(const std::tuple<Args...>& tuple, const B& c0, const B& c1) noexcept
                 {
                     return eval(std::tuple_cat(tuple, std::make_tuple(eval(c0, c1))));
                 }
 
                 template <class... Args, class... Ts>
-                inline B eval(const std::tuple<Args...>& tuple, const B& c0, const B& c1, const Ts&... coefs) noexcept
+                inline B XSIMD_CALLCONV eval(const std::tuple<Args...>& tuple, const B& c0, const B& c1, const Ts&... coefs) noexcept
                 {
                     return eval(std::tuple_cat(tuple, std::make_tuple(eval(c0, c1))), coefs...);
                 }
 
                 template <class... Ts>
-                inline B eval(const B& c0, const B& c1, const Ts&... coefs) noexcept
+                inline B XSIMD_CALLCONV eval(const B& c0, const B& c1, const Ts&... coefs) noexcept
                 {
                     return eval(std::make_tuple(eval(c0, c1)), coefs...);
                 }
@@ -580,7 +580,7 @@ namespace xsimd
         }
 
         template <class T, class A, uint64_t... Coefs>
-        inline batch<T, A> estrin(const batch<T, A>& self) noexcept
+        inline batch<T, A> XSIMD_CALLCONV estrin(const batch<T, A>& self) noexcept
         {
             using batch_type = batch<T, A>;
             return detail::estrin<batch_type> { self }(detail::coef<batch_type, Coefs>()...);
@@ -611,12 +611,12 @@ namespace xsimd
             template <class B>
             struct exp_reduction_base<B, exp_tag>
             {
-                static constexpr B maxlog() noexcept
+                static constexpr B XSIMD_CALLCONV maxlog() noexcept
                 {
                     return constants::maxlog<B>();
                 }
 
-                static constexpr B minlog() noexcept
+                static constexpr B XSIMD_CALLCONV minlog() noexcept
                 {
                     return constants::minlog<B>();
                 }
@@ -625,12 +625,12 @@ namespace xsimd
             template <class B>
             struct exp_reduction_base<B, exp10_tag>
             {
-                static constexpr B maxlog() noexcept
+                static constexpr B XSIMD_CALLCONV maxlog() noexcept
                 {
                     return constants::maxlog10<B>();
                 }
 
-                static constexpr B minlog() noexcept
+                static constexpr B XSIMD_CALLCONV minlog() noexcept
                 {
                     return constants::minlog10<B>();
                 }
@@ -639,12 +639,12 @@ namespace xsimd
             template <class B>
             struct exp_reduction_base<B, exp2_tag>
             {
-                static constexpr B maxlog() noexcept
+                static constexpr B XSIMD_CALLCONV maxlog() noexcept
                 {
                     return constants::maxlog2<B>();
                 }
 
-                static constexpr B minlog() noexcept
+                static constexpr B XSIMD_CALLCONV minlog() noexcept
                 {
                     return constants::minlog2<B>();
                 }
@@ -657,7 +657,7 @@ namespace xsimd
             struct exp_reduction<float, A, exp_tag> : exp_reduction_base<batch<float, A>, exp_tag>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     batch_type y = detail::horner<batch_type,
                                                   0x3f000000, //  5.0000000e-01
@@ -669,7 +669,7 @@ namespace xsimd
                     return ++fma(y, x * x, x);
                 }
 
-                static inline batch_type reduce(const batch_type& a, batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV reduce(const batch_type& a, batch_type& x) noexcept
                 {
                     batch_type k = nearbyint(constants::invlog_2<batch_type>() * a);
                     x = fnma(k, constants::log_2hi<batch_type>(), a);
@@ -682,7 +682,7 @@ namespace xsimd
             struct exp_reduction<float, A, exp10_tag> : exp_reduction_base<batch<float, A>, exp10_tag>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     return ++(detail::horner<batch_type,
                                              0x40135d8e, //    2.3025851e+00
@@ -695,7 +695,7 @@ namespace xsimd
                               * x);
                 }
 
-                static inline batch_type reduce(const batch_type& a, batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV reduce(const batch_type& a, batch_type& x) noexcept
                 {
                     batch_type k = nearbyint(constants::invlog10_2<batch_type>() * a);
                     x = fnma(k, constants::log10_2hi<batch_type>(), a);
@@ -708,7 +708,7 @@ namespace xsimd
             struct exp_reduction<float, A, exp2_tag> : exp_reduction_base<batch<float, A>, exp2_tag>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     batch_type y = detail::horner<batch_type,
                                                   0x3e75fdf1, //    2.4022652e-01
@@ -720,7 +720,7 @@ namespace xsimd
                     return ++fma(y, x * x, x * constants::log_2<batch_type>());
                 }
 
-                static inline batch_type reduce(const batch_type& a, batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV reduce(const batch_type& a, batch_type& x) noexcept
                 {
                     batch_type k = nearbyint(a);
                     x = (a - k);
@@ -732,7 +732,7 @@ namespace xsimd
             struct exp_reduction<double, A, exp_tag> : exp_reduction_base<batch<double, A>, exp_tag>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     batch_type t = x * x;
                     return fnma(t,
@@ -745,7 +745,7 @@ namespace xsimd
                                 x);
                 }
 
-                static inline batch_type reduce(const batch_type& a, batch_type& hi, batch_type& lo, batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV reduce(const batch_type& a, batch_type& hi, batch_type& lo, batch_type& x) noexcept
                 {
                     batch_type k = nearbyint(constants::invlog_2<batch_type>() * a);
                     hi = fnma(k, constants::log_2hi<batch_type>(), a);
@@ -754,7 +754,7 @@ namespace xsimd
                     return k;
                 }
 
-                static inline batch_type finalize(const batch_type& x, const batch_type& c, const batch_type& hi, const batch_type& lo) noexcept
+                static inline batch_type XSIMD_CALLCONV finalize(const batch_type& x, const batch_type& c, const batch_type& hi, const batch_type& lo) noexcept
                 {
                     return batch_type(1.) - (((lo - (x * c) / (batch_type(2.) - c)) - hi));
                 }
@@ -764,7 +764,7 @@ namespace xsimd
             struct exp_reduction<double, A, exp10_tag> : exp_reduction_base<batch<double, A>, exp10_tag>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     batch_type xx = x * x;
                     batch_type px = x * detail::horner<batch_type, 0x40a2b4798e134a01ull, 0x40796b7a050349e4ull, 0x40277d9474c55934ull, 0x3fa4fd75f3062dd4ull>(xx);
@@ -780,7 +780,7 @@ namespace xsimd
                     return k;
                 }
 
-                static inline batch_type finalize(const batch_type&, const batch_type& c, const batch_type&, const batch_type&) noexcept
+                static inline batch_type XSIMD_CALLCONV finalize(const batch_type&, const batch_type& c, const batch_type&, const batch_type&) noexcept
                 {
                     return c;
                 }
@@ -790,7 +790,7 @@ namespace xsimd
             struct exp_reduction<double, A, exp2_tag> : exp_reduction_base<batch<double, A>, exp2_tag>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type approx(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV approx(const batch_type& x) noexcept
                 {
                     batch_type t = x * x;
                     return fnma(t,
@@ -803,21 +803,21 @@ namespace xsimd
                                 x);
                 }
 
-                static inline batch_type reduce(const batch_type& a, batch_type&, batch_type&, batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV reduce(const batch_type& a, batch_type&, batch_type&, batch_type& x) noexcept
                 {
                     batch_type k = nearbyint(a);
                     x = (a - k) * constants::log_2<batch_type>();
                     return k;
                 }
 
-                static inline batch_type finalize(const batch_type& x, const batch_type& c, const batch_type&, const batch_type&) noexcept
+                static inline batch_type XSIMD_CALLCONV finalize(const batch_type& x, const batch_type& c, const batch_type&, const batch_type&) noexcept
                 {
                     return batch_type(1.) + x + x * c / (batch_type(2.) - c);
                 }
             };
 
             template <exp_reduction_tag Tag, class A>
-            inline batch<float, A> exp(batch<float, A> const& self) noexcept
+            inline batch<float, A> XSIMD_CALLCONV exp(batch<float, A> const& self) noexcept
             {
                 using batch_type = batch<float, A>;
                 using reducer_t = exp_reduction<float, A, Tag>;
@@ -830,7 +830,7 @@ namespace xsimd
             }
 
             template <exp_reduction_tag Tag, class A>
-            inline batch<double, A> exp(batch<double, A> const& self) noexcept
+            inline batch<double, A> XSIMD_CALLCONV exp(batch<double, A> const& self) noexcept
             {
                 using batch_type = batch<double, A>;
                 using reducer_t = exp_reduction<double, A, Tag>;
@@ -845,13 +845,13 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> exp(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV exp(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::exp<detail::exp_tag>(self);
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> exp(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV exp(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             auto isincos = sincos(self.imag());
@@ -860,14 +860,14 @@ namespace xsimd
 
         // exp10
         template <class A, class T>
-        inline batch<T, A> exp10(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV exp10(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::exp<detail::exp10_tag>(self);
         }
 
         // exp2
         template <class A, class T>
-        inline batch<T, A> exp2(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV exp2(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::exp<detail::exp2_tag>(self);
         }
@@ -885,7 +885,7 @@ namespace xsimd
              * ====================================================
              */
             template <class A>
-            static inline batch<float, A> expm1(const batch<float, A>& a) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV expm1(const batch<float, A>& a) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type k = nearbyint(constants::invlog_2<batch_type>() * a);
@@ -909,7 +909,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<double, A> expm1(const batch<double, A>& a) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV expm1(const batch<double, A>& a) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type k = nearbyint(constants::invlog_2<batch_type>() * a);
@@ -940,7 +940,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> expm1(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV expm1(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             return select(self < constants::logeps<batch_type>(),
@@ -951,7 +951,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> expm1(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV expm1(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -964,7 +964,7 @@ namespace xsimd
 
         // polar
         template <class A, class T>
-        inline batch<std::complex<T>, A> polar(const batch<T, A>& r, const batch<T, A>& theta, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV polar(const batch<T, A>& r, const batch<T, A>& theta, requires_arch<generic>) noexcept
         {
             auto sincosTheta = sincos(theta);
             return { r * sincosTheta.second, r * sincosTheta.first };
@@ -972,14 +972,14 @@ namespace xsimd
 
         // fdim
         template <class A, class T>
-        inline batch<T, A> fdim(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fdim(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return fmax(batch<T, A>(0), self - other);
         }
 
         // fmod
         template <class A, class T>
-        inline batch<T, A> fmod(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV fmod(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return fnma(trunc(self / other), other, self);
         }
@@ -995,7 +995,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> frexp(const batch<T, A>& self, batch<as_integer_t<T>, A>& exp, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV frexp(const batch<T, A>& self, batch<as_integer_t<T>, A>& exp, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             using i_type = batch<as_integer_t<T>, A>;
@@ -1009,35 +1009,35 @@ namespace xsimd
 
         // from bool
         template <class A, class T>
-        inline batch<T, A> from_bool(batch_bool<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV from_bool(batch_bool<T, A> const& self, requires_arch<generic>) noexcept
         {
             return batch<T, A>(self.data) & batch<T, A>(1);
         }
 
         // hadd
         template <class A, class T>
-        inline std::complex<T> hadd(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline std::complex<T> XSIMD_CALLCONV hadd(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             return { hadd(self.real()), hadd(self.imag()) };
         }
 
         // horner
         template <class T, class A, uint64_t... Coefs>
-        inline batch<T, A> horner(const batch<T, A>& self) noexcept
+        inline batch<T, A> XSIMD_CALLCONV horner(const batch<T, A>& self) noexcept
         {
             return detail::horner<batch<T, A>, Coefs...>(self);
         }
 
         // hypot
         template <class A, class T>
-        inline batch<T, A> hypot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV hypot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return sqrt(fma(self, self, other * other));
         }
 
         // ipow
         template <class A, class T, class ITy>
-        inline batch<T, A> ipow(batch<T, A> const& self, ITy other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ipow(batch<T, A> const& self, ITy other, requires_arch<generic>) noexcept
         {
             return ::xsimd::detail::ipow(self, other);
         }
@@ -1053,7 +1053,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> ldexp(const batch<T, A>& self, const batch<as_integer_t<T>, A>& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ldexp(const batch<T, A>& self, const batch<as_integer_t<T>, A>& other, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             using itype = as_integer_t<batch_type>;
@@ -1064,7 +1064,7 @@ namespace xsimd
 
         // lgamma
         template <class A, class T>
-        inline batch<T, A> lgamma(batch<T, A> const& self, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV lgamma(batch<T, A> const& self, requires_arch<generic>) noexcept;
 
         namespace detail
         {
@@ -1078,7 +1078,7 @@ namespace xsimd
              * ====================================================
              */
             template <class A>
-            static inline batch<float, A> gammalnB(const batch<float, A>& x) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV gammalnB(const batch<float, A>& x) noexcept
             {
                 return horner<batch<float, A>,
                               0x3ed87730, //    4.227843421859038E-001
@@ -1093,7 +1093,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<float, A> gammalnC(const batch<float, A>& x) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV gammalnC(const batch<float, A>& x) noexcept
             {
                 return horner<batch<float, A>,
                               0xbf13c468, //   -5.772156501719101E-001
@@ -1108,7 +1108,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<float, A> gammaln2(const batch<float, A>& x) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV gammaln2(const batch<float, A>& x) noexcept
             {
                 return horner<batch<float, A>,
                               0x3daaaa94, //   8.333316229807355E-002f
@@ -1118,7 +1118,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<double, A> gammaln1(const batch<double, A>& x) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV gammaln1(const batch<double, A>& x) noexcept
             {
                 return horner<batch<double, A>,
                               0xc12a0c675418055eull, //  -8.53555664245765465627E5
@@ -1140,7 +1140,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<double, A> gammalnA(const batch<double, A>& x) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV gammalnA(const batch<double, A>& x) noexcept
             {
                 return horner<batch<double, A>,
                               0x3fb555555555554bull, //    8.33333333333331927722E-2
@@ -1167,7 +1167,7 @@ namespace xsimd
             struct lgamma_impl<batch<float, A>>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type compute(const batch_type& a) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& a) noexcept
                 {
                     auto inf_result = (a <= batch_type(0.)) && is_flint(a);
                     batch_type x = select(inf_result, constants::nan<batch_type>(), a);
@@ -1189,7 +1189,7 @@ namespace xsimd
                 }
 
             private:
-                static inline batch_type negative(const batch_type& q, const batch_type& w) noexcept
+                static inline batch_type XSIMD_CALLCONV negative(const batch_type& q, const batch_type& w) noexcept
                 {
                     batch_type p = floor(q);
                     batch_type z = q - p;
@@ -1199,7 +1199,7 @@ namespace xsimd
                     return -log(constants::invpi<batch_type>() * abs(z)) - w;
                 }
 
-                static inline batch_type other(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV other(const batch_type& x) noexcept
                 {
                     auto xlt650 = (x < batch_type(6.5));
                     batch_type r0x = x;
@@ -1288,7 +1288,7 @@ namespace xsimd
             {
                 using batch_type = batch<double, A>;
 
-                static inline batch_type compute(const batch_type& a) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& a) noexcept
                 {
                     auto inf_result = (a <= batch_type(0.)) && is_flint(a);
                     batch_type x = select(inf_result, constants::nan<batch_type>(), a);
@@ -1310,7 +1310,7 @@ namespace xsimd
                 }
 
             private:
-                static inline batch_type large_negative(const batch_type& q) noexcept
+                static inline batch_type XSIMD_CALLCONV large_negative(const batch_type& q) noexcept
                 {
                     batch_type w = lgamma(q);
                     batch_type p = floor(q);
@@ -1322,7 +1322,7 @@ namespace xsimd
                     return constants::logpi<batch_type>() - log(z) - w;
                 }
 
-                static inline batch_type other(const batch_type& xx) noexcept
+                static inline batch_type XSIMD_CALLCONV other(const batch_type& xx) noexcept
                 {
                     batch_type x = xx;
                     auto test = (x < batch_type(13.));
@@ -1365,7 +1365,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> lgamma(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV lgamma(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::lgamma_impl<batch<T, A>>::compute(self);
         }
@@ -1381,7 +1381,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A>
-        inline batch<float, A> log(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV log(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1420,7 +1420,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> log(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV log(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1462,14 +1462,14 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> log(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV log(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             return batch<std::complex<T>, A>(log(abs(z)), atan2(z.imag(), z.real()));
         }
 
         // log2
         template <class A>
-        inline batch<float, A> log2(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV log2(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1508,7 +1508,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> log2(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV log2(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1557,7 +1557,7 @@ namespace xsimd
         namespace detail
         {
             template <class T, class A>
-            inline batch<T, A> logN_complex_impl(const batch<T, A>& z, typename batch<T, A>::value_type base) noexcept
+            inline batch<T, A> XSIMD_CALLCONV logN_complex_impl(const batch<T, A>& z, typename batch<T, A>::value_type base) noexcept
             {
                 using batch_type = batch<T, A>;
                 using rv_type = typename batch_type::value_type;
@@ -1566,7 +1566,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> log2(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV log2(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::logN_complex_impl(self, std::log(2));
         }
@@ -1584,7 +1584,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A>
-        inline batch<float, A> log10(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV log10(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             const batch_type
@@ -1634,7 +1634,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> log10(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV log10(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             const batch_type
@@ -1687,7 +1687,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> log10(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV log10(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             return detail::logN_complex_impl(z, std::log(10));
         }
@@ -1703,7 +1703,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A>
-        inline batch<float, A> log1p(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV log1p(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1734,7 +1734,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> log1p(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV log1p(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             using i_type = as_integer_t<batch_type>;
@@ -1766,7 +1766,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> log1p(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV log1p(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -1781,7 +1781,7 @@ namespace xsimd
 
         // mod
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mod(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mod(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             return detail::apply([](T x, T y) noexcept -> T
                                  { return x % y; },
@@ -1790,27 +1790,27 @@ namespace xsimd
 
         // mul_real/imag
         template <class A, class T>
-        inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
         {
             return (a.real() * b.real()) - (a.imag() * b.imag());
         }
 
         template <class A, class T>
-        inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b, requires_arch<generic>) noexcept
         {
             return (a.real() * b.imag()) + (a.imag() * b.real());
         }
 
         // nearbyint
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> nearbyint(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV nearbyint(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return self;
         }
         namespace detail
         {
             template <class A, class T>
-            inline batch<T, A> nearbyintf(batch<T, A> const& self) noexcept
+            inline batch<T, A> XSIMD_CALLCONV nearbyintf(batch<T, A> const& self) noexcept
             {
                 using batch_type = batch<T, A>;
                 batch_type s = bitofsign(self);
@@ -1830,26 +1830,26 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> nearbyint(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV nearbyint(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::nearbyintf(self);
         }
         template <class A>
-        inline batch<double, A> nearbyint(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV nearbyint(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::nearbyintf(self);
         }
 
         // nearbyint_as_int
         template <class T, class A, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> nearbyint_as_int(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV nearbyint_as_int(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return self;
         }
 
         // nearbyint_as_int
         template <class A>
-        inline batch<as_integer_t<float>, A>
+        inline batch<as_integer_t<float>, A> XSIMD_CALLCONV
         nearbyint_as_int(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using U = as_integer_t<float>;
@@ -1859,7 +1859,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<as_integer_t<double>, A>
+        inline batch<as_integer_t<double>, A> XSIMD_CALLCONV
         nearbyint_as_int(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using U = as_integer_t<double>;
@@ -1876,12 +1876,12 @@ namespace xsimd
             {
                 using batch_type = batch<T, A>;
 
-                static inline batch_type next(batch_type const& b) noexcept
+                static inline batch_type XSIMD_CALLCONV next(batch_type const& b) noexcept
                 {
                     return b;
                 }
 
-                static inline batch_type prev(batch_type const& b) noexcept
+                static inline batch_type XSIMD_CALLCONV prev(batch_type const& b) noexcept
                 {
                     return b;
                 }
@@ -1909,13 +1909,13 @@ namespace xsimd
                 using int_batch = typename bitwise_cast_batch<T, A>::type;
                 using int_type = typename int_batch::value_type;
 
-                static inline batch_type next(const batch_type& b) noexcept
+                static inline batch_type XSIMD_CALLCONV next(const batch_type& b) noexcept
                 {
                     batch_type n = ::xsimd::bitwise_cast<batch_type>(::xsimd::bitwise_cast<int_batch>(b) + int_type(1));
                     return select(b == constants::infinity<batch_type>(), b, n);
                 }
 
-                static inline batch_type prev(const batch_type& b) noexcept
+                static inline batch_type XSIMD_CALLCONV prev(const batch_type& b) noexcept
                 {
                     batch_type p = ::xsimd::bitwise_cast<batch_type>(::xsimd::bitwise_cast<int_batch>(b) - int_type(1));
                     return select(b == constants::minusinfinity<batch_type>(), b, p);
@@ -1923,7 +1923,7 @@ namespace xsimd
             };
         }
         template <class A, class T>
-        inline batch<T, A> nextafter(batch<T, A> const& from, batch<T, A> const& to, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV nextafter(batch<T, A> const& from, batch<T, A> const& to, requires_arch<generic>) noexcept
         {
             using kernel = detail::nextafter_kernel<T, A>;
             return select(from == to, from,
@@ -1941,7 +1941,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> pow(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV pow(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const auto zero = batch_type(0.);
@@ -1957,7 +1957,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> pow(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV pow(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using cplx_batch = batch<std::complex<T>, A>;
             using real_batch = typename cplx_batch::real_batch;
@@ -1976,8 +1976,8 @@ namespace xsimd
 
         // reciprocal
         template <class T, class A, class = typename std::enable_if<std::is_floating_point<T>::value, void>::type>
-        inline batch<T, A> reciprocal(batch<T, A> const& self,
-                                      requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV reciprocal(batch<T, A> const& self,
+                                                     requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             return div(batch_type(1), self);
@@ -1985,17 +1985,17 @@ namespace xsimd
 
         // remainder
         template <class A>
-        inline batch<float, A> remainder(batch<float, A> const& self, batch<float, A> const& other, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV remainder(batch<float, A> const& self, batch<float, A> const& other, requires_arch<generic>) noexcept
         {
             return fnma(nearbyint(self / other), other, self);
         }
         template <class A>
-        inline batch<double, A> remainder(batch<double, A> const& self, batch<double, A> const& other, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV remainder(batch<double, A> const& self, batch<double, A> const& other, requires_arch<generic>) noexcept
         {
             return fnma(nearbyint(self / other), other, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> remainder(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV remainder(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             auto mod = self % other;
             return select(mod <= other / 2, mod, mod - other);
@@ -2003,14 +2003,14 @@ namespace xsimd
 
         // select
         template <class A, class T>
-        inline batch<std::complex<T>, A> select(batch_bool<T, A> const& cond, batch<std::complex<T>, A> const& true_br, batch<std::complex<T>, A> const& false_br, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV select(batch_bool<T, A> const& cond, batch<std::complex<T>, A> const& true_br, batch<std::complex<T>, A> const& false_br, requires_arch<generic>) noexcept
         {
             return { select(cond, true_br.real(), false_br.real()), select(cond, true_br.imag(), false_br.imag()) };
         }
 
         // sign
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sign(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sign(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type res = select(self > batch_type(0), batch_type(1), batch_type(0)) - select(self < batch_type(0), batch_type(1), batch_type(0));
@@ -2020,7 +2020,7 @@ namespace xsimd
         namespace detail
         {
             template <class T, class A>
-            inline batch<T, A> signf(batch<T, A> const& self) noexcept
+            inline batch<T, A> XSIMD_CALLCONV signf(batch<T, A> const& self) noexcept
             {
                 using batch_type = batch<T, A>;
                 batch_type res = select(self > batch_type(0.f), batch_type(1.f), batch_type(0.f)) - select(self < batch_type(0.f), batch_type(1.f), batch_type(0.f));
@@ -2033,17 +2033,17 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<float, A> sign(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sign(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::signf(self);
         }
         template <class A>
-        inline batch<double, A> sign(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sign(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::signf(self);
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> sign(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV sign(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -2056,7 +2056,7 @@ namespace xsimd
 
         // signnz
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> signnz(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV signnz(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             return (self >> (sizeof(T) * 8 - 1)) | batch_type(1.);
@@ -2065,7 +2065,7 @@ namespace xsimd
         namespace detail
         {
             template <class T, class A>
-            inline batch<T, A> signnzf(batch<T, A> const& self) noexcept
+            inline batch<T, A> XSIMD_CALLCONV signnzf(batch<T, A> const& self) noexcept
             {
                 using batch_type = batch<T, A>;
 #ifndef XSIMD_NO_NANS
@@ -2077,19 +2077,19 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<float, A> signnz(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV signnz(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::signnzf(self);
         }
         template <class A>
-        inline batch<double, A> signnz(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV signnz(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::signnzf(self);
         }
 
         // sqrt
         template <class A, class T>
-        inline batch<std::complex<T>, A> sqrt(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV sqrt(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
 
             constexpr T csqrt_scale_factor = std::is_same<T, float>::value ? 6.7108864e7f : 1.8014398509481984e16;
@@ -2144,7 +2144,7 @@ namespace xsimd
             struct stirling_kernel<batch<float, A>>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type compute(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& x) noexcept
                 {
                     return horner<batch_type,
                                   0x3daaaaab,
@@ -2153,12 +2153,12 @@ namespace xsimd
                                   0xb970b359>(x);
                 }
 
-                static inline batch_type split_limit() noexcept
+                static inline batch_type XSIMD_CALLCONV split_limit() noexcept
                 {
                     return batch_type(bit_cast<float>(uint32_t(0x41d628f6)));
                 }
 
-                static inline batch_type large_limit() noexcept
+                static inline batch_type XSIMD_CALLCONV large_limit() noexcept
                 {
                     return batch_type(bit_cast<float>(uint32_t(0x420c28f3)));
                 }
@@ -2168,7 +2168,7 @@ namespace xsimd
             struct stirling_kernel<batch<double, A>>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type compute(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& x) noexcept
                 {
                     return horner<batch_type,
                                   0x3fb5555555555986ull, //   8.33333333333482257126E-2
@@ -2179,12 +2179,12 @@ namespace xsimd
                                   >(x);
                 }
 
-                static inline batch_type split_limit() noexcept
+                static inline batch_type XSIMD_CALLCONV split_limit() noexcept
                 {
                     return batch_type(bit_cast<double>(uint64_t(0x4061e083ba3443d4)));
                 }
 
-                static inline batch_type large_limit() noexcept
+                static inline batch_type XSIMD_CALLCONV large_limit() noexcept
                 {
                     return batch_type(bit_cast<double>(uint64_t(0x4065800000000000)));
                 }
@@ -2200,7 +2200,7 @@ namespace xsimd
              * ====================================================
              */
             template <class T, class A>
-            inline batch<T, A> stirling(const batch<T, A>& a) noexcept
+            inline batch<T, A> XSIMD_CALLCONV stirling(const batch<T, A>& a) noexcept
             {
                 using batch_type = batch<T, A>;
                 const batch_type stirlingsplitlim = stirling_kernel<batch_type>::split_limit();
@@ -2238,7 +2238,7 @@ namespace xsimd
             struct tgamma_kernel<batch<float, A>>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type compute(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& x) noexcept
                 {
                     return horner<batch_type,
                                   0x3f800000UL, //  9.999999757445841E-01
@@ -2257,7 +2257,7 @@ namespace xsimd
             struct tgamma_kernel<batch<double, A>>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type compute(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV compute(const batch_type& x) noexcept
                 {
                     return horner<batch_type,
                                   0x3ff0000000000000ULL, // 9.99999999999999996796E-1
@@ -2291,7 +2291,7 @@ namespace xsimd
              * ====================================================
              */
             template <class B>
-            inline B tgamma_large_negative(const B& a) noexcept
+            inline B XSIMD_CALLCONV tgamma_large_negative(const B& a) noexcept
             {
                 B st = stirling(a);
                 B p = floor(a);
@@ -2305,7 +2305,7 @@ namespace xsimd
             }
 
             template <class B, class BB>
-            inline B tgamma_other(const B& a, const BB& test) noexcept
+            inline B XSIMD_CALLCONV tgamma_other(const B& a, const BB& test) noexcept
             {
                 B x = select(test, B(2.), a);
 #ifndef XSIMD_NO_INFINITIES
@@ -2344,7 +2344,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> tgamma(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV tgamma(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             auto nan_result = (self < batch_type(0.) && is_flint(self));

--- a/include/xsimd/arch/generic/xsimd_generic_memory.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_memory.hpp
@@ -31,7 +31,7 @@ namespace xsimd
 
         // extract_pair
         template <class A, class T>
-        inline batch<T, A> extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, requires_arch<generic>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
             assert(0 <= i && i < size && "index in bounds");
@@ -59,14 +59,14 @@ namespace xsimd
         namespace detail
         {
             template <size_t N, typename T, typename A, typename U, typename V, typename std::enable_if<N == 0, int>::type = 0>
-            inline batch<T, A> gather(U const* src, batch<V, A> const& index,
-                                      ::xsimd::index<N> I) noexcept
+            inline batch<T, A> XSIMD_CALLCONV gather(U const* src, batch<V, A> const& index,
+                                                     ::xsimd::index<N> I) noexcept
             {
                 return insert(batch<T, A> {}, static_cast<T>(src[index.get(I)]), I);
             }
 
             template <size_t N, typename T, typename A, typename U, typename V, typename std::enable_if<N != 0, int>::type = 0>
-            inline batch<T, A>
+            inline batch<T, A> XSIMD_CALLCONV
             gather(U const* src, batch<V, A> const& index, ::xsimd::index<N> I) noexcept
             {
                 static_assert(N <= batch<V, A>::size, "Incorrect value in recursion!");
@@ -77,7 +77,7 @@ namespace xsimd
         } // namespace detail
 
         template <typename T, typename A, typename V>
-        inline batch<T, A>
+        inline batch<T, A> XSIMD_CALLCONV
         gather(batch<T, A> const&, T const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
@@ -89,7 +89,7 @@ namespace xsimd
 
         // Gather with runtime indexes and mismatched strides.
         template <typename T, typename A, typename U, typename V>
-        inline detail::sizes_mismatch_t<T, U, batch<T, A>>
+        inline detail::sizes_mismatch_t<T, U, batch<T, A>> XSIMD_CALLCONV
         gather(batch<T, A> const&, U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
@@ -101,7 +101,7 @@ namespace xsimd
 
         // Gather with runtime indexes and matching strides.
         template <typename T, typename A, typename U, typename V>
-        inline detail::stride_match_t<T, U, batch<T, A>>
+        inline detail::stride_match_t<T, U, batch<T, A>> XSIMD_CALLCONV
         gather(batch<T, A> const&, U const* src, batch<V, A> const& index,
                kernel::requires_arch<generic>) noexcept
         {
@@ -113,7 +113,7 @@ namespace xsimd
 
         // insert
         template <class A, class T, size_t I>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I>, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> const& self, T val, index<I>, requires_arch<generic>) noexcept
         {
             struct index_mask
             {
@@ -128,7 +128,7 @@ namespace xsimd
 
         // get
         template <class A, size_t I, class T>
-        inline T get(batch<T, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept
+        inline T XSIMD_CALLCONV get(batch<T, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) T buffer[batch<T, A>::size];
             self.store_aligned(&buffer[0]);
@@ -136,7 +136,7 @@ namespace xsimd
         }
 
         template <class A, size_t I, class T>
-        inline T get(batch_bool<T, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept
+        inline T XSIMD_CALLCONV get(batch_bool<T, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) T buffer[batch_bool<T, A>::size];
             self.store_aligned(&buffer[0]);
@@ -144,7 +144,7 @@ namespace xsimd
         }
 
         template <class A, size_t I, class T>
-        inline auto get(batch<std::complex<T>, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept -> typename batch<std::complex<T>, A>::value_type
+        inline auto XSIMD_CALLCONV get(batch<std::complex<T>, A> const& self, ::xsimd::index<I>, requires_arch<generic>) noexcept -> typename batch<std::complex<T>, A>::value_type
         {
             alignas(A::alignment()) T buffer[batch<std::complex<T>, A>::size];
             self.store_aligned(&buffer[0]);
@@ -152,7 +152,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline T get(batch<T, A> const& self, std::size_t i, requires_arch<generic>) noexcept
+        inline T XSIMD_CALLCONV get(batch<T, A> const& self, std::size_t i, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) T buffer[batch<T, A>::size];
             self.store_aligned(&buffer[0]);
@@ -160,7 +160,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline T get(batch_bool<T, A> const& self, std::size_t i, requires_arch<generic>) noexcept
+        inline T XSIMD_CALLCONV get(batch_bool<T, A> const& self, std::size_t i, requires_arch<generic>) noexcept
         {
             alignas(A::alignment()) bool buffer[batch_bool<T, A>::size];
             self.store_aligned(&buffer[0]);
@@ -168,7 +168,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline auto get(batch<std::complex<T>, A> const& self, std::size_t i, requires_arch<generic>) noexcept -> typename batch<std::complex<T>, A>::value_type
+        inline auto XSIMD_CALLCONV get(batch<std::complex<T>, A> const& self, std::size_t i, requires_arch<generic>) noexcept -> typename batch<std::complex<T>, A>::value_type
         {
             using T2 = typename batch<std::complex<T>, A>::value_type;
             alignas(A::alignment()) T2 buffer[batch<std::complex<T>, A>::size];
@@ -180,14 +180,14 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T_in, class T_out>
-            inline batch<T_out, A> load_aligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_fast_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV load_aligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_fast_conversion) noexcept
             {
                 using batch_type_in = batch<T_in, A>;
                 using batch_type_out = batch<T_out, A>;
                 return fast_cast(batch_type_in::load_aligned(mem), batch_type_out(), A {});
             }
             template <class A, class T_in, class T_out>
-            inline batch<T_out, A> load_aligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_slow_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV load_aligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_slow_conversion) noexcept
             {
                 static_assert(!std::is_same<T_in, T_out>::value, "there should be a direct load for this type combination");
                 using batch_type_out = batch<T_out, A>;
@@ -197,7 +197,7 @@ namespace xsimd
             }
         }
         template <class A, class T_in, class T_out>
-        inline batch<T_out, A> load_aligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>) noexcept
+        inline batch<T_out, A> XSIMD_CALLCONV load_aligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>) noexcept
         {
             return detail::load_aligned<A>(mem, cvt, A {}, detail::conversion_type<A, T_in, T_out> {});
         }
@@ -206,7 +206,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T_in, class T_out>
-            inline batch<T_out, A> load_unaligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_fast_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV load_unaligned(T_in const* mem, convert<T_out>, requires_arch<generic>, with_fast_conversion) noexcept
             {
                 using batch_type_in = batch<T_in, A>;
                 using batch_type_out = batch<T_out, A>;
@@ -214,14 +214,14 @@ namespace xsimd
             }
 
             template <class A, class T_in, class T_out>
-            inline batch<T_out, A> load_unaligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>, with_slow_conversion) noexcept
+            inline batch<T_out, A> XSIMD_CALLCONV load_unaligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>, with_slow_conversion) noexcept
             {
                 static_assert(!std::is_same<T_in, T_out>::value, "there should be a direct load for this type combination");
                 return load_aligned<A>(mem, cvt, generic {}, with_slow_conversion {});
             }
         }
         template <class A, class T_in, class T_out>
-        inline batch<T_out, A> load_unaligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>) noexcept
+        inline batch<T_out, A> XSIMD_CALLCONV load_unaligned(T_in const* mem, convert<T_out> cvt, requires_arch<generic>) noexcept
         {
             return detail::load_unaligned<A>(mem, cvt, generic {}, detail::conversion_type<A, T_in, T_out> {});
         }
@@ -230,15 +230,15 @@ namespace xsimd
         {
             // Scatter with runtime indexes.
             template <size_t N, typename T, typename A, typename U, typename V, typename std::enable_if<N == 0, int>::type = 0>
-            inline void scatter(batch<T, A> const& src, U* dst,
-                                batch<V, A> const& index,
-                                ::xsimd::index<N> I) noexcept
+            inline void XSIMD_CALLCONV scatter(batch<T, A> const& src, U* dst,
+                                               batch<V, A> const& index,
+                                               ::xsimd::index<N> I) noexcept
             {
                 dst[index.get(I)] = static_cast<U>(src.get(I));
             }
 
             template <size_t N, typename T, typename A, typename U, typename V, typename std::enable_if<N != 0, int>::type = 0>
-            inline void
+            inline void XSIMD_CALLCONV
             scatter(batch<T, A> const& src, U* dst, batch<V, A> const& index,
                     ::xsimd::index<N> I) noexcept
             {
@@ -251,7 +251,7 @@ namespace xsimd
         } // namespace detail
 
         template <typename A, typename T, typename V>
-        inline void
+        inline void XSIMD_CALLCONV
         scatter(batch<T, A> const& src, T* dst,
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
@@ -263,7 +263,7 @@ namespace xsimd
         }
 
         template <typename A, typename T, typename U, typename V>
-        inline detail::sizes_mismatch_t<T, U, void>
+        inline detail::sizes_mismatch_t<T, U, void> XSIMD_CALLCONV
         scatter(batch<T, A> const& src, U* dst,
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
@@ -275,7 +275,7 @@ namespace xsimd
         }
 
         template <typename A, typename T, typename U, typename V>
-        inline detail::stride_match_t<T, U, void>
+        inline detail::stride_match_t<T, U, void> XSIMD_CALLCONV
         scatter(batch<T, A> const& src, U* dst,
                 batch<V, A> const& index,
                 kernel::requires_arch<generic>) noexcept
@@ -288,7 +288,7 @@ namespace xsimd
 
         // store
         template <class T, class A>
-        inline void store(batch_bool<T, A> const& self, bool* mem, requires_arch<generic>) noexcept
+        inline void XSIMD_CALLCONV store(batch_bool<T, A> const& self, bool* mem, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             constexpr auto size = batch_bool<T, A>::size;
@@ -300,7 +300,7 @@ namespace xsimd
 
         // store_aligned
         template <class A, class T_in, class T_out>
-        inline void store_aligned(T_out* mem, batch<T_in, A> const& self, requires_arch<generic>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T_out* mem, batch<T_in, A> const& self, requires_arch<generic>) noexcept
         {
             static_assert(!std::is_same<T_in, T_out>::value, "there should be a direct store for this type combination");
             alignas(A::alignment()) T_in buffer[batch<T_in, A>::size];
@@ -310,7 +310,7 @@ namespace xsimd
 
         // store_unaligned
         template <class A, class T_in, class T_out>
-        inline void store_unaligned(T_out* mem, batch<T_in, A> const& self, requires_arch<generic>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T_out* mem, batch<T_in, A> const& self, requires_arch<generic>) noexcept
         {
             static_assert(!std::is_same<T_in, T_out>::value, "there should be a direct store for this type combination");
             return store_aligned<A>(mem, self, generic {});
@@ -318,7 +318,7 @@ namespace xsimd
 
         // swizzle
         template <class A, class T, class ITy, ITy... Vs>
-        inline batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& self, batch_constant<batch<ITy, A>, Vs...> mask, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV swizzle(batch<std::complex<T>, A> const& self, batch_constant<batch<ITy, A>, Vs...> mask, requires_arch<generic>) noexcept
         {
             return { swizzle(self.real(), mask), swizzle(self.imag(), mask) };
         }
@@ -326,19 +326,19 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T>
-            inline batch<std::complex<T>, A> load_complex(batch<T, A> const& /*hi*/, batch<T, A> const& /*lo*/, requires_arch<generic>) noexcept
+            inline batch<std::complex<T>, A> XSIMD_CALLCONV load_complex(batch<T, A> const& /*hi*/, batch<T, A> const& /*lo*/, requires_arch<generic>) noexcept
             {
                 static_assert(std::is_same<T, void>::value, "load_complex not implemented for the required architecture");
             }
 
             template <class A, class T>
-            inline batch<T, A> complex_high(batch<std::complex<T>, A> const& /*src*/, requires_arch<generic>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV complex_high(batch<std::complex<T>, A> const& /*src*/, requires_arch<generic>) noexcept
             {
                 static_assert(std::is_same<T, void>::value, "complex_high not implemented for the required architecture");
             }
 
             template <class A, class T>
-            inline batch<T, A> complex_low(batch<std::complex<T>, A> const& /*src*/, requires_arch<generic>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV complex_low(batch<std::complex<T>, A> const& /*src*/, requires_arch<generic>) noexcept
             {
                 static_assert(std::is_same<T, void>::value, "complex_low not implemented for the required architecture");
             }
@@ -346,7 +346,7 @@ namespace xsimd
 
         // load_complex_aligned
         template <class A, class T_out, class T_in>
-        inline batch<std::complex<T_out>, A> load_complex_aligned(std::complex<T_in> const* mem, convert<std::complex<T_out>>, requires_arch<generic>) noexcept
+        inline batch<std::complex<T_out>, A> XSIMD_CALLCONV load_complex_aligned(std::complex<T_in> const* mem, convert<std::complex<T_out>>, requires_arch<generic>) noexcept
         {
             using real_batch = batch<T_out, A>;
             T_in const* buffer = reinterpret_cast<T_in const*>(mem);
@@ -357,7 +357,7 @@ namespace xsimd
 
         // load_complex_unaligned
         template <class A, class T_out, class T_in>
-        inline batch<std::complex<T_out>, A> load_complex_unaligned(std::complex<T_in> const* mem, convert<std::complex<T_out>>, requires_arch<generic>) noexcept
+        inline batch<std::complex<T_out>, A> XSIMD_CALLCONV load_complex_unaligned(std::complex<T_in> const* mem, convert<std::complex<T_out>>, requires_arch<generic>) noexcept
         {
             using real_batch = batch<T_out, A>;
             T_in const* buffer = reinterpret_cast<T_in const*>(mem);
@@ -368,7 +368,7 @@ namespace xsimd
 
         // store_complex_aligned
         template <class A, class T_out, class T_in>
-        inline void store_complex_aligned(std::complex<T_out>* dst, batch<std::complex<T_in>, A> const& src, requires_arch<generic>) noexcept
+        inline void XSIMD_CALLCONV store_complex_aligned(std::complex<T_out>* dst, batch<std::complex<T_in>, A> const& src, requires_arch<generic>) noexcept
         {
             using real_batch = batch<T_in, A>;
             real_batch hi = detail::complex_high(src, A {});
@@ -380,7 +380,7 @@ namespace xsimd
 
         // store_compelx_unaligned
         template <class A, class T_out, class T_in>
-        inline void store_complex_unaligned(std::complex<T_out>* dst, batch<std::complex<T_in>, A> const& src, requires_arch<generic>) noexcept
+        inline void XSIMD_CALLCONV store_complex_unaligned(std::complex<T_out>* dst, batch<std::complex<T_in>, A> const& src, requires_arch<generic>) noexcept
         {
             using real_batch = batch<T_in, A>;
             real_batch hi = detail::complex_high(src, A {});

--- a/include/xsimd/arch/generic/xsimd_generic_rounding.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_rounding.hpp
@@ -24,7 +24,7 @@ namespace xsimd
 
         // ceil
         template <class A, class T>
-        inline batch<T, A> ceil(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ceil(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             batch<T, A> truncated_self = trunc(self);
             return select(truncated_self < self, truncated_self + 1, truncated_self);
@@ -32,7 +32,7 @@ namespace xsimd
 
         // floor
         template <class A, class T>
-        inline batch<T, A> floor(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV floor(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             batch<T, A> truncated_self = trunc(self);
             return select(truncated_self > self, truncated_self - 1, truncated_self);
@@ -40,7 +40,7 @@ namespace xsimd
 
         // round
         template <class A, class T>
-        inline batch<T, A> round(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV round(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             auto v = abs(self);
             auto c = ceil(v);
@@ -50,17 +50,17 @@ namespace xsimd
 
         // trunc
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> trunc(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV trunc(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return self;
         }
         template <class A>
-        inline batch<float, A> trunc(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV trunc(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             return select(abs(self) < constants::maxflint<batch<float, A>>(), to_float(to_int(self)), self);
         }
         template <class A>
-        inline batch<double, A> trunc(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV trunc(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             return select(abs(self) < constants::maxflint<batch<double, A>>(), to_float(to_int(self)), self);
         }

--- a/include/xsimd/arch/generic/xsimd_generic_trigo.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_trigo.hpp
@@ -35,7 +35,7 @@ namespace xsimd
 
         // acos
         template <class A, class T>
-        inline batch<T, A> acos(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV acos(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type x = abs(self);
@@ -47,7 +47,7 @@ namespace xsimd
             return select(x_larger_05, x, constants::pio2<batch_type>() - x);
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> acos(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV acos(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -66,7 +66,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> acosh(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV acosh(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type x = self - batch_type(1.);
@@ -76,7 +76,7 @@ namespace xsimd
             return select(test, l1pz + constants::log_2<batch_type>(), l1pz);
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> acosh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV acosh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             batch_type w = acos(z);
@@ -86,7 +86,7 @@ namespace xsimd
 
         // asin
         template <class A>
-        inline batch<float, A> asin(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV asin(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type x = abs(self);
@@ -105,7 +105,7 @@ namespace xsimd
             return z ^ sign;
         }
         template <class A>
-        inline batch<double, A> asin(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV asin(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type x = abs(self);
@@ -127,7 +127,7 @@ namespace xsimd
                               ^ bitofsign(self));
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> asin(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV asin(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -159,32 +159,32 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-            inline batch<T, A>
+            inline batch<T, A> XSIMD_CALLCONV
             average(const batch<T, A>& x1, const batch<T, A>& x2) noexcept
             {
                 return (x1 & x2) + ((x1 ^ x2) >> 1);
             }
 
             template <class A, class T>
-            inline batch<T, A>
+            inline batch<T, A> XSIMD_CALLCONV
             averagef(const batch<T, A>& x1, const batch<T, A>& x2) noexcept
             {
                 using batch_type = batch<T, A>;
                 return fma(x1, batch_type(0.5), x2 * batch_type(0.5));
             }
             template <class A>
-            inline batch<float, A> average(batch<float, A> const& x1, batch<float, A> const& x2) noexcept
+            inline batch<float, A> XSIMD_CALLCONV average(batch<float, A> const& x1, batch<float, A> const& x2) noexcept
             {
                 return averagef(x1, x2);
             }
             template <class A>
-            inline batch<double, A> average(batch<double, A> const& x1, batch<double, A> const& x2) noexcept
+            inline batch<double, A> XSIMD_CALLCONV average(batch<double, A> const& x1, batch<double, A> const& x2) noexcept
             {
                 return averagef(x1, x2);
             }
         }
         template <class A>
-        inline batch<float, A> asinh(batch<float, A> const& self, requires_arch<generic>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV asinh(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type x = abs(self);
@@ -212,7 +212,7 @@ namespace xsimd
 #endif
         }
         template <class A>
-        inline batch<double, A> asinh(batch<double, A> const& self, requires_arch<generic>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV asinh(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type x = abs(self);
@@ -226,7 +226,7 @@ namespace xsimd
             return bitofsign(self) ^ z;
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> asinh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV asinh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             batch_type w = asin(batch_type(-z.imag(), z.real()));
@@ -238,7 +238,7 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            static inline batch<float, A> kernel_atan(const batch<float, A>& x, const batch<float, A>& recx) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV kernel_atan(const batch<float, A>& x, const batch<float, A>& recx) noexcept
             {
                 using batch_type = batch<float, A>;
                 const auto flag1 = x < constants::tan3pio8<batch_type>();
@@ -259,7 +259,7 @@ namespace xsimd
                 return yy + z1;
             }
             template <class A>
-            static inline batch<double, A> kernel_atan(const batch<double, A>& x, const batch<double, A>& recx) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV kernel_atan(const batch<double, A>& x, const batch<double, A>& recx) noexcept
             {
                 using batch_type = batch<double, A>;
                 const auto flag1 = x < constants::tan3pio8<batch_type>();
@@ -288,7 +288,7 @@ namespace xsimd
             }
         }
         template <class A, class T>
-        inline batch<T, A> atan(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV atan(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const batch_type absa = abs(self);
@@ -296,7 +296,7 @@ namespace xsimd
             return x ^ bitofsign(self);
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> atan(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV atan(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -327,7 +327,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> atanh(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV atanh(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type x = abs(self);
@@ -338,7 +338,7 @@ namespace xsimd
             return bitofsign(self) ^ (batch_type(0.5) * log1p(select(test, fma(t, tmp, t), tmp)));
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> atanh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV atanh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             batch_type w = atan(batch_type(-z.imag(), z.real()));
@@ -348,7 +348,7 @@ namespace xsimd
 
         // atan2
         template <class A, class T>
-        inline batch<T, A> atan2(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV atan2(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const batch_type q = abs(self / other);
@@ -360,19 +360,19 @@ namespace xsimd
         namespace detail
         {
             template <class T, class A>
-            inline batch<T, A> quadrant(const batch<T, A>& x) noexcept
+            inline batch<T, A> XSIMD_CALLCONV quadrant(const batch<T, A>& x) noexcept
             {
                 return x & batch<T, A>(3);
             }
 
             template <class A>
-            inline batch<float, A> quadrant(const batch<float, A>& x) noexcept
+            inline batch<float, A> XSIMD_CALLCONV quadrant(const batch<float, A>& x) noexcept
             {
                 return to_float(quadrant(to_int(x)));
             }
 
             template <class A>
-            inline batch<double, A> quadrant(const batch<double, A>& x) noexcept
+            inline batch<double, A> XSIMD_CALLCONV quadrant(const batch<double, A>& x) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type a = x * batch_type(0.25);
@@ -389,7 +389,7 @@ namespace xsimd
              */
 
             template <class A>
-            inline batch<float, A> cos_eval(const batch<float, A>& z) noexcept
+            inline batch<float, A> XSIMD_CALLCONV cos_eval(const batch<float, A>& z) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type y = detail::horner<batch_type,
@@ -400,7 +400,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<float, A> sin_eval(const batch<float, A>& z, const batch<float, A>& x) noexcept
+            inline batch<float, A> XSIMD_CALLCONV sin_eval(const batch<float, A>& z, const batch<float, A>& x) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type y = detail::horner<batch_type,
@@ -411,7 +411,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<float, A> base_tancot_eval(const batch<float, A>& z) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV base_tancot_eval(const batch<float, A>& z) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type zz = z * z;
@@ -426,7 +426,7 @@ namespace xsimd
             }
 
             template <class A, class BB>
-            static inline batch<float, A> tan_eval(const batch<float, A>& z, const BB& test) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV tan_eval(const batch<float, A>& z, const BB& test) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type y = base_tancot_eval(z);
@@ -434,7 +434,7 @@ namespace xsimd
             }
 
             template <class A, class BB>
-            static inline batch<float, A> cot_eval(const batch<float, A>& z, const BB& test) noexcept
+            static inline batch<float, A> XSIMD_CALLCONV cot_eval(const batch<float, A>& z, const BB& test) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type y = base_tancot_eval(z);
@@ -451,7 +451,7 @@ namespace xsimd
              * ====================================================
              */
             template <class A>
-            static inline batch<double, A> cos_eval(const batch<double, A>& z) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV cos_eval(const batch<double, A>& z) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type y = detail::horner<batch_type,
@@ -466,7 +466,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<double, A> sin_eval(const batch<double, A>& z, const batch<double, A>& x) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV sin_eval(const batch<double, A>& z, const batch<double, A>& x) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type y = detail::horner<batch_type,
@@ -480,7 +480,7 @@ namespace xsimd
             }
 
             template <class A>
-            static inline batch<double, A> base_tancot_eval(const batch<double, A>& z) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV base_tancot_eval(const batch<double, A>& z) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type zz = z * z;
@@ -497,7 +497,7 @@ namespace xsimd
             }
 
             template <class A, class BB>
-            static inline batch<double, A> tan_eval(const batch<double, A>& z, const BB& test) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV tan_eval(const batch<double, A>& z, const BB& test) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type y = base_tancot_eval(z);
@@ -505,7 +505,7 @@ namespace xsimd
             }
 
             template <class A, class BB>
-            static inline batch<double, A> cot_eval(const batch<double, A>& z, const BB& test) noexcept
+            static inline batch<double, A> XSIMD_CALLCONV cot_eval(const batch<double, A>& z, const BB& test) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type y = base_tancot_eval(z);
@@ -531,7 +531,7 @@ namespace xsimd
             template <class B, class Tag = trigo_radian_tag>
             struct trigo_reducer
             {
-                static inline B reduce(const B& x, B& xr) noexcept
+                static inline B XSIMD_CALLCONV reduce(const B& x, B& xr) noexcept
                 {
                     if (all(x <= constants::pio4<B>()))
                     {
@@ -606,7 +606,7 @@ namespace xsimd
             template <class B>
             struct trigo_reducer<B, trigo_pi_tag>
             {
-                static inline B reduce(const B& x, B& xr) noexcept
+                static inline B XSIMD_CALLCONV reduce(const B& x, B& xr) noexcept
                 {
                     B xi = nearbyint(x * B(2.));
                     B x2 = x - xi * B(0.5);
@@ -617,7 +617,7 @@ namespace xsimd
 
         }
         template <class A, class T>
-        inline batch<T, A> cos(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV cos(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const batch_type x = abs(self);
@@ -634,7 +634,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> cos(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV cos(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             return { cos(z.real()) * cosh(z.imag()), -sin(z.real()) * sinh(z.imag()) };
         }
@@ -652,7 +652,7 @@ namespace xsimd
          */
 
         template <class A, class T>
-        inline batch<T, A> cosh(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV cosh(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type x = abs(self);
@@ -663,7 +663,7 @@ namespace xsimd
             return select(test1, tmp1 * tmp, detail::average(tmp, batch_type(1.) / tmp));
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> cosh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV cosh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             auto x = z.real();
             auto y = z.imag();
@@ -674,7 +674,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, class Tag = trigo_radian_tag>
-            inline batch<T, A> sin(batch<T, A> const& self, Tag = Tag()) noexcept
+            inline batch<T, A> XSIMD_CALLCONV sin(batch<T, A> const& self, Tag = Tag()) noexcept
             {
                 using batch_type = batch<T, A>;
                 const batch_type x = abs(self);
@@ -692,20 +692,20 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline batch<T, A> sin(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sin(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             return detail::sin(self);
         }
 
         template <class A, class T>
-        inline batch<std::complex<T>, A> sin(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV sin(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             return { sin(z.real()) * cosh(z.imag()), cos(z.real()) * sinh(z.imag()) };
         }
 
         // sincos
         template <class A, class T>
-        inline std::pair<batch<T, A>, batch<T, A>> sincos(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline std::pair<batch<T, A>, batch<T, A>> XSIMD_CALLCONV sincos(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const batch_type x = abs(self);
@@ -724,7 +724,7 @@ namespace xsimd
         }
 
         template <class A, class T>
-        inline std::pair<batch<std::complex<T>, A>, batch<std::complex<T>, A>>
+        inline std::pair<batch<std::complex<T>, A>, batch<std::complex<T>, A>> XSIMD_CALLCONV
         sincos(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
@@ -749,7 +749,7 @@ namespace xsimd
              * ====================================================
              */
             template <class A>
-            inline batch<float, A> sinh_kernel(batch<float, A> const& self) noexcept
+            inline batch<float, A> XSIMD_CALLCONV sinh_kernel(batch<float, A> const& self) noexcept
             {
                 using batch_type = batch<float, A>;
                 batch_type sqr_self = self * self;
@@ -763,7 +763,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> sinh_kernel(batch<double, A> const& self) noexcept
+            inline batch<double, A> XSIMD_CALLCONV sinh_kernel(batch<double, A> const& self) noexcept
             {
                 using batch_type = batch<double, A>;
                 batch_type sqrself = self * self;
@@ -792,7 +792,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> sinh(batch<T, A> const& a, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sinh(batch<T, A> const& a, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type half(0.5);
@@ -814,7 +814,7 @@ namespace xsimd
             return select(lt1, z, r) ^ bts;
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> sinh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV sinh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             auto x = z.real();
             auto y = z.imag();
@@ -823,7 +823,7 @@ namespace xsimd
 
         // tan
         template <class A, class T>
-        inline batch<T, A> tan(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV tan(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             const batch_type x = abs(self);
@@ -836,7 +836,7 @@ namespace xsimd
             return y ^ bitofsign(self);
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> tan(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV tan(batch<std::complex<T>, A> const& z, requires_arch<generic>) noexcept
         {
             using batch_type = batch<std::complex<T>, A>;
             using real_batch = typename batch_type::real_batch;
@@ -867,7 +867,7 @@ namespace xsimd
             struct tanh_kernel<batch<float, A>>
             {
                 using batch_type = batch<float, A>;
-                static inline batch_type tanh(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV tanh(const batch_type& x) noexcept
                 {
                     batch_type sqrx = x * x;
                     return fma(detail::horner<batch_type,
@@ -881,7 +881,7 @@ namespace xsimd
                                x, x);
                 }
 
-                static inline batch_type cotanh(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV cotanh(const batch_type& x) noexcept
                 {
                     return batch_type(1.) / tanh(x);
                 }
@@ -891,20 +891,20 @@ namespace xsimd
             struct tanh_kernel<batch<double, A>>
             {
                 using batch_type = batch<double, A>;
-                static inline batch_type tanh(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV tanh(const batch_type& x) noexcept
                 {
                     batch_type sqrx = x * x;
                     return fma(sqrx * p(sqrx) / q(sqrx), x, x);
                 }
 
-                static inline batch_type cotanh(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV cotanh(const batch_type& x) noexcept
                 {
                     batch_type sqrx = x * x;
                     batch_type qval = q(sqrx);
                     return qval / (x * fma(p(sqrx), sqrx, qval));
                 }
 
-                static inline batch_type p(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV p(const batch_type& x) noexcept
                 {
                     return detail::horner<batch_type,
                                           0xc0993ac030580563, // -1.61468768441708447952E3
@@ -913,7 +913,7 @@ namespace xsimd
                                           >(x);
                 }
 
-                static inline batch_type q(const batch_type& x) noexcept
+                static inline batch_type XSIMD_CALLCONV q(const batch_type& x) noexcept
                 {
                     return detail::horner1<batch_type,
                                            0x40b2ec102442040c, //  4.84406305325125486048E3
@@ -934,7 +934,7 @@ namespace xsimd
          * ====================================================
          */
         template <class A, class T>
-        inline batch<T, A> tanh(batch<T, A> const& self, requires_arch<generic>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV tanh(batch<T, A> const& self, requires_arch<generic>) noexcept
         {
             using batch_type = batch<T, A>;
             batch_type one(1.);
@@ -952,7 +952,7 @@ namespace xsimd
             return select(test, z, r) ^ bts;
         }
         template <class A, class T>
-        inline batch<std::complex<T>, A> tanh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
+        inline batch<std::complex<T>, A> XSIMD_CALLCONV tanh(const batch<std::complex<T>, A>& z, requires_arch<generic>) noexcept
         {
             using real_batch = typename batch<std::complex<T>, A>::real_batch;
             auto x = z.real();

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -27,39 +27,39 @@ namespace xsimd
 
         // fwd
         template <class A, class T, size_t I>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I>, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> XSIMD_CREF self, T val, index<I>, requires_arch<generic>) noexcept;
 
         namespace detail
         {
-            inline void split_avx(__m256i val, __m128i& low, __m128i& high) noexcept
+            inline void XSIMD_CALLCONV split_avx(__m256i val, __m128i& low, __m128i& high) noexcept
             {
                 low = _mm256_castsi256_si128(val);
                 high = _mm256_extractf128_si256(val, 1);
             }
-            inline void split_avx(__m256 val, __m128& low, __m128& high) noexcept
+            inline void XSIMD_CALLCONV split_avx(__m256 val, __m128& low, __m128& high) noexcept
             {
                 low = _mm256_castps256_ps128(val);
                 high = _mm256_extractf128_ps(val, 1);
             }
-            inline void split_avx(__m256d val, __m128d& low, __m128d& high) noexcept
+            inline void XSIMD_CALLCONV split_avx(__m256d val, __m128d& low, __m128d& high) noexcept
             {
                 low = _mm256_castpd256_pd128(val);
                 high = _mm256_extractf128_pd(val, 1);
             }
-            inline __m256i merge_sse(__m128i low, __m128i high) noexcept
+            inline __m256i XSIMD_CALLCONV merge_sse(__m128i low, __m128i high) noexcept
             {
                 return _mm256_insertf128_si256(_mm256_castsi128_si256(low), high, 1);
             }
-            inline __m256 merge_sse(__m128 low, __m128 high) noexcept
+            inline __m256 XSIMD_CALLCONV merge_sse(__m128 low, __m128 high) noexcept
             {
                 return _mm256_insertf128_ps(_mm256_castps128_ps256(low), high, 1);
             }
-            inline __m256d merge_sse(__m128d low, __m128d high) noexcept
+            inline __m256d XSIMD_CALLCONV merge_sse(__m128d low, __m128d high) noexcept
             {
                 return _mm256_insertf128_pd(_mm256_castpd128_pd256(low), high, 1);
             }
             template <class F>
-            inline __m256i fwd_to_sse(F f, __m256i self) noexcept
+            inline __m256i XSIMD_CALLCONV fwd_to_sse(F f, __m256i self) noexcept
             {
                 __m128i self_low, self_high;
                 split_avx(self, self_low, self_high);
@@ -68,7 +68,7 @@ namespace xsimd
                 return merge_sse(res_low, res_high);
             }
             template <class F>
-            inline __m256i fwd_to_sse(F f, __m256i self, __m256i other) noexcept
+            inline __m256i XSIMD_CALLCONV fwd_to_sse(F f, __m256i self, __m256i other) noexcept
             {
                 __m128i self_low, self_high, other_low, other_high;
                 split_avx(self, self_low, self_high);
@@ -78,7 +78,7 @@ namespace xsimd
                 return merge_sse(res_low, res_high);
             }
             template <class F>
-            inline __m256i fwd_to_sse(F f, __m256i self, int32_t other) noexcept
+            inline __m256i XSIMD_CALLCONV fwd_to_sse(F f, __m256i self, int32_t other) noexcept
             {
                 __m128i self_low, self_high;
                 split_avx(self, self_low, self_high);
@@ -90,13 +90,13 @@ namespace xsimd
 
         // abs
         template <class A>
-        inline batch<float, A> abs(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV abs(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             __m256 sign_mask = _mm256_set1_ps(-0.f); // -0.f = 1 << 31
             return _mm256_andnot_ps(sign_mask, self);
         }
         template <class A>
-        inline batch<double, A> abs(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV abs(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             __m256d sign_mask = _mm256_set1_pd(-0.f); // -0.f = 1 << 31
             return _mm256_andnot_pd(sign_mask, self);
@@ -104,89 +104,89 @@ namespace xsimd
 
         // add
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV add(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return add(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                       self, other);
         }
         template <class A>
-        inline batch<float, A> add(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV add(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_add_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> add(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV add(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_add_pd(self, other);
         }
 
         // all
         template <class A>
-        inline bool all(batch_bool<float, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_testc_ps(self, batch_bool<float, A>(true)) != 0;
         }
         template <class A>
-        inline bool all(batch_bool<double, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_testc_pd(self, batch_bool<double, A>(true)) != 0;
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline bool all(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_testc_si256(self, batch_bool<T, A>(true)) != 0;
         }
 
         // any
         template <class A>
-        inline bool any(batch_bool<float, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return !_mm256_testz_ps(self, self);
         }
         template <class A>
-        inline bool any(batch_bool<double, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return !_mm256_testz_pd(self, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline bool any(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return !_mm256_testz_si256(self, self);
         }
 
         // bitwise_and
         template <class A>
-        inline batch<float, A> bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_and(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_and_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_and(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_and_pd(self, other);
         }
 
         template <class A>
-        inline batch_bool<float, A> bitwise_and(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_and(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_and_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_and(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_and(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_and_pd(self, other);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_and(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_and(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                       self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_and(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_and(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
@@ -195,36 +195,36 @@ namespace xsimd
 
         // bitwise_andnot
         template <class A>
-        inline batch<float, A> bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_andnot(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_andnot_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_andnot(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_andnot_pd(self, other);
         }
 
         template <class A>
-        inline batch_bool<float, A> bitwise_andnot(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_andnot_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_andnot(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_andnot_pd(self, other);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_andnot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_andnot(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_andnot(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                       self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_andnot(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
@@ -233,7 +233,7 @@ namespace xsimd
 
         // bitwise_lshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, int32_t o) noexcept
                                       { return bitwise_lshift(batch<T, sse4_2>(s), o, sse4_2 {}); },
@@ -242,14 +242,14 @@ namespace xsimd
 
         // bitwise_not
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_not(batch<T, A> const& self, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_not(batch<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s) noexcept
                                       { return bitwise_not(batch<T, sse4_2>(s), sse4_2 {}); },
                                       self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_not(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s) noexcept
                                       { return bitwise_not(batch_bool<T, sse4_2>(s), sse4_2 {}); },
@@ -258,34 +258,34 @@ namespace xsimd
 
         // bitwise_or
         template <class A>
-        inline batch<float, A> bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_or(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_or_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_or(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_or_pd(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_or(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_or(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_or_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_or(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_or(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_or_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_or(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_or(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                       self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_or(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_or(batch_bool<T, sse4_2>(s), batch_bool<T, sse4_2>(o)); },
@@ -294,7 +294,7 @@ namespace xsimd
 
         // bitwise_rshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, int32_t o) noexcept
                                       { return bitwise_rshift(batch<T, sse4_2>(s), o, sse4_2 {}); },
@@ -303,34 +303,34 @@ namespace xsimd
 
         // bitwise_xor
         template <class A>
-        inline batch<float, A> bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_xor(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_xor(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_xor(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_xor(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_xor(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_xor(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_xor(batch<T, sse4_2>(s), batch<T, sse4_2>(o), sse4_2 {}); },
                                       self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return bitwise_xor(batch_bool<T, sse4_2>(s), batch_bool<T, sse4_2>(o), sse4_2 {}); },
@@ -339,88 +339,88 @@ namespace xsimd
 
         // bitwise_cast
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<float, A> bitwise_cast(batch<T, A> const& self, batch<float, A> const&, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_ps(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<double, A> bitwise_cast(batch<T, A> const& self, batch<double, A> const&, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_pd(self);
         }
         template <class A, class T, class Tp, class = typename std::enable_if<std::is_integral<typename std::common_type<T, Tp>::type>::value, void>::type>
-        inline batch<Tp, A> bitwise_cast(batch<T, A> const& self, batch<Tp, A> const&, requires_arch<avx>) noexcept
+        inline batch<Tp, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<Tp, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return batch<Tp, A>(self.data);
         }
         template <class A>
-        inline batch<double, A> bitwise_cast(batch<float, A> const& self, batch<double, A> const&, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castps_pd(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<float, A> const& self, batch<T, A> const&, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castps_si256(self);
         }
         template <class A>
-        inline batch<float, A> bitwise_cast(batch<double, A> const& self, batch<float, A> const&, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castpd_ps(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<double, A> const& self, batch<T, A> const&, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF, requires_arch<avx>) noexcept
         {
             return _mm256_castpd_si256(self);
         }
 
         // bitwise_not
         template <class A>
-        inline batch<float, A> bitwise_not(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_not(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_xor_ps(self, _mm256_castsi256_ps(_mm256_set1_epi32(-1)));
         }
         template <class A>
-        inline batch<double, A> bitwise_not(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_not(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, _mm256_castsi256_pd(_mm256_set1_epi32(-1)));
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_not(batch_bool<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_not(batch_bool<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_xor_ps(self, _mm256_castsi256_ps(_mm256_set1_epi32(-1)));
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_not(batch_bool<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_not(batch_bool<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, _mm256_castsi256_pd(_mm256_set1_epi32(-1)));
         }
 
         // bool_cast
         template <class A>
-        inline batch_bool<int32_t, A> bool_cast(batch_bool<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<int32_t, A> XSIMD_CALLCONV bool_cast(batch_bool<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_castps_si256(self);
         }
         template <class A>
-        inline batch_bool<float, A> bool_cast(batch_bool<int32_t, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bool_cast(batch_bool<int32_t, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_ps(self);
         }
         template <class A>
-        inline batch_bool<int64_t, A> bool_cast(batch_bool<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<int64_t, A> XSIMD_CALLCONV bool_cast(batch_bool<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_castpd_si256(self);
         }
         template <class A>
-        inline batch_bool<double, A> bool_cast(batch_bool<int64_t, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bool_cast(batch_bool<int64_t, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_pd(self);
         }
 
         // broadcast
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> broadcast(T val, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV broadcast(T val, requires_arch<avx>) noexcept
         {
             switch (sizeof(T))
             {
@@ -438,24 +438,24 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> broadcast(float val, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV broadcast(float val, requires_arch<avx>) noexcept
         {
             return _mm256_set1_ps(val);
         }
         template <class A>
-        inline batch<double, A> broadcast(double val, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV broadcast(double val, requires_arch<avx>) noexcept
         {
             return _mm256_set1_pd(val);
         }
 
         // ceil
         template <class A>
-        inline batch<float, A> ceil(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ceil(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_ceil_ps(self);
         }
         template <class A>
-        inline batch<double, A> ceil(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ceil(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_ceil_pd(self);
         }
@@ -465,7 +465,7 @@ namespace xsimd
             // On clang, _mm256_extractf128_ps is built upon build_shufflevector
             // which require index parameter to be a constant
             template <int index, class B>
-            inline B get_half_complex_f(const B& real, const B& imag) noexcept
+            inline B XSIMD_CALLCONV get_half_complex_f(const B& real, const B& imag) noexcept
             {
                 __m128 tmp0 = _mm256_extractf128_ps(real, index);
                 __m128 tmp1 = _mm256_extractf128_ps(imag, index);
@@ -477,7 +477,7 @@ namespace xsimd
                 return res;
             }
             template <int index, class B>
-            inline B get_half_complex_d(const B& real, const B& imag) noexcept
+            inline B XSIMD_CALLCONV get_half_complex_d(const B& real, const B& imag) noexcept
             {
                 __m128d tmp0 = _mm256_extractf128_pd(real, index);
                 __m128d tmp1 = _mm256_extractf128_pd(imag, index);
@@ -491,24 +491,24 @@ namespace xsimd
 
             // complex_low
             template <class A>
-            inline batch<float, A> complex_low(batch<std::complex<float>, A> const& self, requires_arch<avx>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_low(batch<std::complex<float>, A> const& self, requires_arch<avx>) noexcept
             {
                 return get_half_complex_f<0>(self.real(), self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx>) noexcept
             {
                 return get_half_complex_d<0>(self.real(), self.imag());
             }
 
             // complex_high
             template <class A>
-            inline batch<float, A> complex_high(batch<std::complex<float>, A> const& self, requires_arch<avx>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_high(batch<std::complex<float>, A> const& self, requires_arch<avx>) noexcept
             {
                 return get_half_complex_f<1>(self.real(), self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx>) noexcept
             {
                 return get_half_complex_d<1>(self.real(), self.imag());
             }
@@ -518,13 +518,13 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<float, A> fast_cast(batch<int32_t, A> const& self, batch<float, A> const&, requires_arch<avx>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<int32_t, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<avx>) noexcept
             {
                 return _mm256_cvtepi32_ps(self);
             }
 
             template <class A>
-            inline batch<float, A> fast_cast(batch<uint32_t, A> const& v, batch<float, A> const&, requires_arch<avx>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<uint32_t, A> XSIMD_CREF v, batch<float, A> XSIMD_CREF, requires_arch<avx>) noexcept
             {
                 // see https://stackoverflow.com/questions/34066228/how-to-perform-uint32-float-conversion-with-sse
                 // adapted to avx
@@ -540,13 +540,13 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<int32_t, A> fast_cast(batch<float, A> const& self, batch<int32_t, A> const&, requires_arch<avx>) noexcept
+            inline batch<int32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> XSIMD_CREF self, batch<int32_t, A> XSIMD_CREF, requires_arch<avx>) noexcept
             {
                 return _mm256_cvttps_epi32(self);
             }
 
             template <class A>
-            inline batch<uint32_t, A> fast_cast(batch<float, A> const& self, batch<uint32_t, A> const&, requires_arch<avx>) noexcept
+            inline batch<uint32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> XSIMD_CREF self, batch<uint32_t, A> XSIMD_CREF, requires_arch<avx>) noexcept
             {
                 return _mm256_castps_si256(
                     _mm256_blendv_ps(_mm256_castsi256_ps(_mm256_cvttps_epi32(self)),
@@ -559,43 +559,43 @@ namespace xsimd
 
         // div
         template <class A>
-        inline batch<float, A> div(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV div(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_div_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> div(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV div(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_div_pd(self, other);
         }
 
         // eq
         template <class A>
-        inline batch_bool<float, A> eq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV eq(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_ps(self, other, _CMP_EQ_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> eq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV eq(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_pd(self, other, _CMP_EQ_OQ);
         }
         template <class A>
-        inline batch_bool<float, A> eq(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV eq(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_ps(detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                                           { return eq(batch_bool<int32_t, sse4_2>(s), batch_bool<int32_t, sse4_2>(o), sse4_2 {}); },
                                                           _mm256_castps_si256(self), _mm256_castps_si256(other)));
         }
         template <class A>
-        inline batch_bool<double, A> eq(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV eq(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_castsi256_pd(detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                                           { return eq(batch_bool<int32_t, sse4_2>(s), batch_bool<int32_t, sse4_2>(o), sse4_2 {}); },
                                                           _mm256_castpd_si256(self), _mm256_castpd_si256(other)));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return eq(batch<T, sse4_2>(s), batch<T, sse4_2>(o), sse4_2 {}); },
@@ -603,26 +603,26 @@ namespace xsimd
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return eq(batch<T, A>(self.data), batch<T, A>(other.data));
         }
 
         // floor
         template <class A>
-        inline batch<float, A> floor(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV floor(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_floor_ps(self);
         }
         template <class A>
-        inline batch<double, A> floor(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV floor(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_floor_pd(self);
         }
 
         // from_mask
         template <class A>
-        inline batch_bool<float, A> from_mask(batch_bool<float, A> const&, uint64_t mask, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV from_mask(batch_bool<float, A> XSIMD_CREF, uint64_t mask, requires_arch<avx>) noexcept
         {
             alignas(A::alignment()) static const uint64_t lut32[] = {
                 0x0000000000000000ul,
@@ -634,7 +634,7 @@ namespace xsimd
             return _mm256_castsi256_ps(_mm256_setr_epi64x(lut32[mask & 0x3], lut32[(mask >> 2) & 0x3], lut32[(mask >> 4) & 0x3], lut32[mask >> 6]));
         }
         template <class A>
-        inline batch_bool<double, A> from_mask(batch_bool<double, A> const&, uint64_t mask, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV from_mask(batch_bool<double, A> XSIMD_CREF, uint64_t mask, requires_arch<avx>) noexcept
         {
             alignas(A::alignment()) static const uint64_t lut64[][4] = {
                 { 0x0000000000000000ul, 0x0000000000000000ul, 0x0000000000000000ul, 0x0000000000000000ul },
@@ -658,7 +658,7 @@ namespace xsimd
             return _mm256_castsi256_pd(_mm256_load_si256((const __m256i*)lut64[mask]));
         }
         template <class T, class A, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV from_mask(batch_bool<T, A> XSIMD_CREF, uint64_t mask, requires_arch<avx>) noexcept
         {
             alignas(A::alignment()) static const uint32_t lut32[] = {
                 0x00000000,
@@ -716,7 +716,7 @@ namespace xsimd
 
         // hadd
         template <class A>
-        inline float hadd(batch<float, A> const& rhs, requires_arch<avx>) noexcept
+        inline float XSIMD_CALLCONV hadd(batch<float, A> XSIMD_CREF rhs, requires_arch<avx>) noexcept
         {
             // Warning about _mm256_hadd_ps:
             // _mm256_hadd_ps(a,b) gives
@@ -734,7 +734,7 @@ namespace xsimd
             return _mm_cvtss_f32(_mm256_extractf128_ps(tmp, 0));
         }
         template <class A>
-        inline double hadd(batch<double, A> const& rhs, requires_arch<avx>) noexcept
+        inline double XSIMD_CALLCONV hadd(batch<double, A> XSIMD_CREF rhs, requires_arch<avx>) noexcept
         {
             // rhs = (x0, x1, x2, x3)
             // tmp = (x2, x3, x0, x1)
@@ -746,7 +746,7 @@ namespace xsimd
             return _mm_cvtsd_f64(_mm256_extractf128_pd(tmp, 0));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline T hadd(batch<T, A> const& self, requires_arch<avx>) noexcept
+        inline T XSIMD_CALLCONV hadd(batch<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             __m128i low, high;
             detail::split_avx(self, low, high);
@@ -756,7 +756,7 @@ namespace xsimd
 
         // haddp
         template <class A>
-        inline batch<float, A> haddp(batch<float, A> const* row, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV haddp(batch<float, A> const* row, requires_arch<avx>) noexcept
         {
             // row = (a,b,c,d,e,f,g,h)
             // tmp0 = (a0+a1, a2+a3, b0+b1, b2+b3, a4+a5, a6+a7, b4+b5, b6+b7)
@@ -782,7 +782,7 @@ namespace xsimd
             return _mm256_add_ps(tmp0, tmp1);
         }
         template <class A>
-        inline batch<double, A> haddp(batch<double, A> const* row, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV haddp(batch<double, A> const* row, requires_arch<avx>) noexcept
         {
             // row = (a,b,c,d)
             // tmp0 = (a0+a1, b0+b1, a2+a3, b2+b3)
@@ -798,7 +798,7 @@ namespace xsimd
 
         // insert
         template <class A, class T, size_t I, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I> pos, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> XSIMD_CREF self, T val, index<I> pos, requires_arch<avx>) noexcept
         {
             switch (sizeof(T))
             {
@@ -817,41 +817,41 @@ namespace xsimd
 
         // isnan
         template <class A>
-        inline batch_bool<float, A> isnan(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV isnan(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_ps(self, self, _CMP_UNORD_Q);
         }
         template <class A>
-        inline batch_bool<double, A> isnan(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV isnan(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_pd(self, self, _CMP_UNORD_Q);
         }
 
         // le
         template <class A>
-        inline batch_bool<float, A> le(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV le(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_ps(self, other, _CMP_LE_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> le(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV le(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_pd(self, other, _CMP_LE_OQ);
         }
 
         // load_aligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_aligned(T const* mem, convert<T>, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_aligned(T const* mem, convert<T>, requires_arch<avx>) noexcept
         {
             return _mm256_load_si256((__m256i const*)mem);
         }
         template <class A>
-        inline batch<float, A> load_aligned(float const* mem, convert<float>, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_aligned(float const* mem, convert<float>, requires_arch<avx>) noexcept
         {
             return _mm256_load_ps(mem);
         }
         template <class A>
-        inline batch<double, A> load_aligned(double const* mem, convert<double>, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_aligned(double const* mem, convert<double>, requires_arch<avx>) noexcept
         {
             return _mm256_load_pd(mem);
         }
@@ -860,7 +860,7 @@ namespace xsimd
         {
             // load_complex
             template <class A>
-            inline batch<std::complex<float>, A> load_complex(batch<float, A> const& hi, batch<float, A> const& lo, requires_arch<avx>) noexcept
+            inline batch<std::complex<float>, A> XSIMD_CALLCONV load_complex(batch<float, A> XSIMD_CREF hi, batch<float, A> XSIMD_CREF lo, requires_arch<avx>) noexcept
             {
                 using batch_type = batch<float, A>;
                 __m128 tmp0 = _mm256_extractf128_ps(hi, 0);
@@ -880,7 +880,7 @@ namespace xsimd
                 return { real, imag };
             }
             template <class A>
-            inline batch<std::complex<double>, A> load_complex(batch<double, A> const& hi, batch<double, A> const& lo, requires_arch<avx>) noexcept
+            inline batch<std::complex<double>, A> XSIMD_CALLCONV load_complex(batch<double, A> XSIMD_CREF hi, batch<double, A> XSIMD_CREF lo, requires_arch<avx>) noexcept
             {
                 using batch_type = batch<double, A>;
                 __m128d tmp0 = _mm256_extractf128_pd(hi, 0);
@@ -900,35 +900,35 @@ namespace xsimd
 
         // load_unaligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_unaligned(T const* mem, convert<T>, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_unaligned(T const* mem, convert<T>, requires_arch<avx>) noexcept
         {
             return _mm256_loadu_si256((__m256i const*)mem);
         }
         template <class A>
-        inline batch<float, A> load_unaligned(float const* mem, convert<float>, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_unaligned(float const* mem, convert<float>, requires_arch<avx>) noexcept
         {
             return _mm256_loadu_ps(mem);
         }
         template <class A>
-        inline batch<double, A> load_unaligned(double const* mem, convert<double>, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_unaligned(double const* mem, convert<double>, requires_arch<avx>) noexcept
         {
             return _mm256_loadu_pd(mem);
         }
 
         // lt
         template <class A>
-        inline batch_bool<float, A> lt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV lt(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_ps(self, other, _CMP_LT_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> lt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV lt(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_pd(self, other, _CMP_LT_OQ);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return lt(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
@@ -937,7 +937,7 @@ namespace xsimd
 
         // mask
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline uint64_t mask(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             switch (sizeof(T))
             {
@@ -958,166 +958,166 @@ namespace xsimd
             }
         }
         template <class A>
-        inline uint64_t mask(batch_bool<float, A> const& self, requires_arch<avx>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_movemask_ps(self);
         }
 
         template <class A>
-        inline uint64_t mask(batch_bool<double, A> const& self, requires_arch<avx>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_movemask_pd(self);
         }
 
         // max
         template <class A>
-        inline batch<float, A> max(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV max(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_max_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> max(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV max(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_max_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return select(self > other, self, other);
         }
 
         // min
         template <class A>
-        inline batch<float, A> min(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV min(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_min_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> min(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV min(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_min_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return select(self <= other, self, other);
         }
 
         // mul
         template <class A>
-        inline batch<float, A> mul(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV mul(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_mul_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> mul(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV mul(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_mul_pd(self, other);
         }
 
         // nearbyint
         template <class A>
-        inline batch<float, A> nearbyint(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV nearbyint(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_round_ps(self, _MM_FROUND_TO_NEAREST_INT);
         }
         template <class A>
-        inline batch<double, A> nearbyint(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV nearbyint(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_round_pd(self, _MM_FROUND_TO_NEAREST_INT);
         }
 
         // nearbyint_as_int
         template <class A>
-        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
-                                                  requires_arch<avx>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV nearbyint_as_int(batch<float, A> XSIMD_CREF self,
+                                                                 requires_arch<avx>) noexcept
         {
             return _mm256_cvtps_epi32(self);
         }
 
         // neg
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> neg(batch<T, A> const& self, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV neg(batch<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return 0 - self;
         }
         template <class A>
-        batch<float, A> neg(batch<float, A> const& self, requires_arch<avx>)
+        batch<float, A> XSIMD_CALLCONV neg(batch<float, A> XSIMD_CREF self, requires_arch<avx>)
         {
             return _mm256_xor_ps(self, _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000)));
         }
         template <class A>
-        inline batch<double, A> neg(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV neg(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, _mm256_castsi256_pd(_mm256_set1_epi64x(0x8000000000000000)));
         }
 
         // neq
         template <class A>
-        inline batch_bool<float, A> neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV neq(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_ps(self, other, _CMP_NEQ_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV neq(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_cmp_pd(self, other, _CMP_NEQ_OQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return ~(self == other);
         }
 
         template <class A>
-        inline batch_bool<float, A> neq(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV neq(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> neq(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV neq(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_xor_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return ~(self == other);
         }
 
         // reciprocal
         template <class A>
-        inline batch<float, A> reciprocal(batch<float, A> const& self,
-                                          kernel::requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV reciprocal(batch<float, A> XSIMD_CREF self,
+                                                         kernel::requires_arch<avx>) noexcept
         {
             return _mm256_rcp_ps(self);
         }
 
         // rsqrt
         template <class A>
-        inline batch<float, A> rsqrt(batch<float, A> const& val, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV rsqrt(batch<float, A> XSIMD_CREF val, requires_arch<avx>) noexcept
         {
             return _mm256_rsqrt_ps(val);
         }
         template <class A>
-        inline batch<double, A> rsqrt(batch<double, A> const& val, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV rsqrt(batch<double, A> XSIMD_CREF val, requires_arch<avx>) noexcept
         {
             return _mm256_cvtps_pd(_mm_rsqrt_ps(_mm256_cvtpd_ps(val)));
         }
 
         // sadd
         template <class A>
-        inline batch<float, A> sadd(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sadd(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return add(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A>
-        inline batch<double, A> sadd(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sadd(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return add(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sadd(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1136,17 +1136,17 @@ namespace xsimd
 
         // select
         template <class A>
-        inline batch<float, A> select(batch_bool<float, A> const& cond, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool<float, A> XSIMD_CREF cond, batch<float, A> XSIMD_CREF true_br, batch<float, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             return _mm256_blendv_ps(false_br, true_br, cond);
         }
         template <class A>
-        inline batch<double, A> select(batch_bool<double, A> const& cond, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool<double, A> XSIMD_CREF cond, batch<double, A> XSIMD_CREF true_br, batch<double, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             return _mm256_blendv_pd(false_br, true_br, cond);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> XSIMD_CREF cond, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             __m128i cond_low, cond_hi;
             detail::split_avx(cond, cond_low, cond_hi);
@@ -1162,20 +1162,20 @@ namespace xsimd
             return detail::merge_sse(res_low, res_hi);
         }
         template <class A, class T, bool... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             return select(batch_bool<T, A> { Values... }, true_br, false_br, avx2 {});
         }
 
         template <class A, bool... Values>
-        inline batch<float, A> select(batch_bool_constant<batch<float, A>, Values...> const&, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool_constant<batch<float, A>, Values...> const&, batch<float, A> XSIMD_CREF true_br, batch<float, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             constexpr auto mask = batch_bool_constant<batch<float, A>, Values...>::mask();
             return _mm256_blend_ps(false_br, true_br, mask);
         }
 
         template <class A, bool... Values>
-        inline batch<double, A> select(batch_bool_constant<batch<double, A>, Values...> const&, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool_constant<batch<double, A>, Values...> const&, batch<double, A> XSIMD_CREF true_br, batch<double, A> XSIMD_CREF false_br, requires_arch<avx>) noexcept
         {
             constexpr auto mask = batch_bool_constant<batch<double, A>, Values...>::mask();
             return _mm256_blend_pd(false_br, true_br, mask);
@@ -1183,55 +1183,55 @@ namespace xsimd
 
         // set
         template <class A, class... Values>
-        inline batch<float, A> set(batch<float, A> const&, requires_arch<avx>, Values... values) noexcept
+        inline batch<float, A> XSIMD_CALLCONV set(batch<float, A> XSIMD_CREF, requires_arch<avx>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch<float, A>::size, "consistent init");
             return _mm256_setr_ps(values...);
         }
 
         template <class A, class... Values>
-        inline batch<double, A> set(batch<double, A> const&, requires_arch<avx>, Values... values) noexcept
+        inline batch<double, A> XSIMD_CALLCONV set(batch<double, A> XSIMD_CREF, requires_arch<avx>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch<double, A>::size, "consistent init");
             return _mm256_setr_pd(values...);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx>, T v0, T v1, T v2, T v3) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<avx>, T v0, T v1, T v2, T v3) noexcept
         {
             return _mm256_set_epi64x(v3, v2, v1, v0);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
         {
             return _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
         {
             return _mm256_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
-                               T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23, T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<avx>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
+                                              T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23, T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
         {
             return _mm256_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
         }
 
         template <class A, class T, class... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<avx>, Values... values) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV set(batch_bool<T, A> XSIMD_CREF, requires_arch<avx>, Values... values) noexcept
         {
             return set(batch<T, A>(), A {}, static_cast<T>(values ? -1LL : 0LL)...).data;
         }
 
         template <class A, class... Values>
-        inline batch_bool<float, A> set(batch_bool<float, A> const&, requires_arch<avx>, Values... values) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV set(batch_bool<float, A> XSIMD_CREF, requires_arch<avx>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch_bool<float, A>::size, "consistent init");
             return _mm256_castsi256_ps(set(batch<int32_t, A>(), A {}, static_cast<int32_t>(values ? -1LL : 0LL)...).data);
         }
 
         template <class A, class... Values>
-        inline batch_bool<double, A> set(batch_bool<double, A> const&, requires_arch<avx>, Values... values) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV set(batch_bool<double, A> XSIMD_CREF, requires_arch<avx>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch_bool<double, A>::size, "consistent init");
             return _mm256_castsi256_pd(set(batch<int64_t, A>(), A {}, static_cast<int64_t>(values ? -1LL : 0LL)...).data);
@@ -1239,7 +1239,7 @@ namespace xsimd
 
         // slide_left
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_left(batch<T, A> const& x, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_left(batch<T, A> XSIMD_CREF x, requires_arch<avx>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -1280,7 +1280,7 @@ namespace xsimd
 
         // slide_right
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_right(batch<T, A> const& x, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_right(batch<T, A> XSIMD_CREF x, requires_arch<avx>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -1320,29 +1320,29 @@ namespace xsimd
 
         // sqrt
         template <class A>
-        inline batch<float, A> sqrt(batch<float, A> const& val, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sqrt(batch<float, A> XSIMD_CREF val, requires_arch<avx>) noexcept
         {
             return _mm256_sqrt_ps(val);
         }
         template <class A>
-        inline batch<double, A> sqrt(batch<double, A> const& val, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sqrt(batch<double, A> XSIMD_CREF val, requires_arch<avx>) noexcept
         {
             return _mm256_sqrt_pd(val);
         }
 
         // ssub
         template <class A>
-        inline batch<float, A> ssub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ssub(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_sub_ps(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A>
-        inline batch<double, A> ssub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ssub(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_sub_pd(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ssub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1357,70 +1357,70 @@ namespace xsimd
 
         // store_aligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch<T, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_store_si256((__m256i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_store_si256((__m256i*)mem, self);
         }
         template <class A>
-        inline void store_aligned(float* mem, batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(float* mem, batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_store_ps(mem, self);
         }
         template <class A>
-        inline void store_aligned(double* mem, batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(double* mem, batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_store_pd(mem, self);
         }
 
         // store_unaligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch<T, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_storeu_si256((__m256i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch_bool<T, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_storeu_si256((__m256i*)mem, self);
         }
         template <class A>
-        inline void store_unaligned(float* mem, batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(float* mem, batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_storeu_ps(mem, self);
         }
         template <class A>
-        inline void store_unaligned(double* mem, batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(double* mem, batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_storeu_pd(mem, self);
         }
 
         // sub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return detail::fwd_to_sse([](__m128i s, __m128i o) noexcept
                                       { return sub(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                       self, other);
         }
         template <class A>
-        inline batch<float, A> sub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sub(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_sub_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> sub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sub(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_sub_pd(self, other);
         }
 
         // swizzle
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3, uint32_t V4, uint32_t V5, uint32_t V6, uint32_t V7>
-        inline batch<float, A> swizzle(batch<float, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7>, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV swizzle(batch<float, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7>, requires_arch<avx>) noexcept
         {
             // duplicate low and high part of input
             __m256 hi = _mm256_castps128_ps256(_mm256_extractf128_ps(self, 1));
@@ -1445,7 +1445,7 @@ namespace xsimd
         }
 
         template <class A, uint64_t V0, uint64_t V1, uint64_t V2, uint64_t V3>
-        inline batch<double, A> swizzle(batch<double, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV swizzle(batch<double, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx>) noexcept
         {
             // duplicate low and high part of input
             __m256d hi = _mm256_castpd128_pd256(_mm256_extractf128_pd(self, 1));
@@ -1479,17 +1479,17 @@ namespace xsimd
                   uint32_t V6,
                   uint32_t V7,
                   detail::enable_sized_integral_t<T, 4> = 0>
-        inline batch<T, A> swizzle(batch<T, A> const& self,
-                                   batch_constant<batch<uint32_t, A>,
-                                                  V0,
-                                                  V1,
-                                                  V2,
-                                                  V3,
-                                                  V4,
-                                                  V5,
-                                                  V6,
-                                                  V7> const& mask,
-                                   requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV swizzle(batch<T, A> XSIMD_CREF self,
+                                                  batch_constant<batch<uint32_t, A>,
+                                                                 V0,
+                                                                 V1,
+                                                                 V2,
+                                                                 V3,
+                                                                 V4,
+                                                                 V5,
+                                                                 V6,
+                                                                 V7> const& mask,
+                                                  requires_arch<avx>) noexcept
         {
             return bitwise_cast<batch<T, A>>(
                 swizzle(bitwise_cast<batch<float, A>>(self), mask));
@@ -1501,8 +1501,8 @@ namespace xsimd
                   uint32_t V2,
                   uint32_t V3,
                   detail::enable_sized_integral_t<T, 8> = 0>
-        inline batch<T, A>
-        swizzle(batch<T, A> const& self,
+        inline batch<T, A> XSIMD_CALLCONV
+        swizzle(batch<T, A> XSIMD_CREF self,
                 batch_constant<batch<uint64_t, A>, V0, V1, V2, V3> const& mask,
                 requires_arch<avx>) noexcept
         {
@@ -1512,19 +1512,19 @@ namespace xsimd
 
         // trunc
         template <class A>
-        inline batch<float, A> trunc(batch<float, A> const& self, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV trunc(batch<float, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_round_ps(self, _MM_FROUND_TO_ZERO);
         }
         template <class A>
-        inline batch<double, A> trunc(batch<double, A> const& self, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV trunc(batch<double, A> XSIMD_CREF self, requires_arch<avx>) noexcept
         {
             return _mm256_round_pd(self, _MM_FROUND_TO_ZERO);
         }
 
         // zip_hi
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_hi(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1569,19 +1569,19 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> zip_hi(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_hi(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_unpackhi_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> zip_hi(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_hi(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_unpackhi_pd(self, other);
         }
 
         // zip_lo
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_lo(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1626,12 +1626,12 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<float, A> zip_lo(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_lo(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_unpacklo_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> zip_lo(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_lo(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<avx>) noexcept
         {
             return _mm256_unpacklo_pd(self, other);
         }

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -26,7 +26,7 @@ namespace xsimd
 
         // abs
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> XSIMD_CREF self, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -47,7 +47,7 @@ namespace xsimd
 
         // add
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV add(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -66,43 +66,43 @@ namespace xsimd
 
         // bitwise_and
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_and(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_and_si256(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_and(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_and_si256(self, other);
         }
 
         // bitwise_andnot
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_andnot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_andnot(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_andnot_si256(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_andnot_si256(self, other);
         }
 
         // bitwise_not
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_not(batch<T, A> const& self, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_not(batch<T, A> XSIMD_CREF self, requires_arch<avx2>) noexcept
         {
             return _mm256_xor_si256(self, _mm256_set1_epi32(-1));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& self, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_not(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx2>) noexcept
         {
             return _mm256_xor_si256(self, _mm256_set1_epi32(-1));
         }
 
         // bitwise_lshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -118,7 +118,7 @@ namespace xsimd
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -133,19 +133,19 @@ namespace xsimd
 
         // bitwise_or
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_or(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_or_si256(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_or(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_or_si256(self, other);
         }
 
         // bitwise_rshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -187,7 +187,7 @@ namespace xsimd
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -215,19 +215,19 @@ namespace xsimd
 
         // bitwise_xor
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_xor_si256(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             return _mm256_xor_si256(self, other);
         }
 
         // complex_low
         template <class A>
-        inline batch<double, A> complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx2>) noexcept
         {
             __m256d tmp0 = _mm256_permute4x64_pd(self.real(), _MM_SHUFFLE(3, 1, 1, 0));
             __m256d tmp1 = _mm256_permute4x64_pd(self.imag(), _MM_SHUFFLE(1, 2, 0, 0));
@@ -236,7 +236,7 @@ namespace xsimd
 
         // complex_high
         template <class A>
-        inline batch<double, A> complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx2>) noexcept
         {
             __m256d tmp0 = _mm256_permute4x64_pd(self.real(), _MM_SHUFFLE(3, 3, 1, 2));
             __m256d tmp1 = _mm256_permute4x64_pd(self.imag(), _MM_SHUFFLE(3, 2, 2, 0));
@@ -248,7 +248,7 @@ namespace xsimd
         {
 
             template <class A>
-            inline batch<float, A> fast_cast(batch<uint32_t, A> const& v, batch<float, A> const&, requires_arch<avx2>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<uint32_t, A> XSIMD_CREF v, batch<float, A> XSIMD_CREF, requires_arch<avx2>) noexcept
             {
                 // see https://stackoverflow.com/questions/34066228/how-to-perform-uint32-float-conversion-with-sse
                 __m256i msk_lo = _mm256_set1_epi32(0xFFFF);
@@ -263,7 +263,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> fast_cast(batch<uint64_t, A> const& x, batch<double, A> const&, requires_arch<avx2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<uint64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<avx2>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 // adapted to avx
@@ -277,7 +277,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> fast_cast(batch<int64_t, A> const& x, batch<double, A> const&, requires_arch<avx2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<int64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<avx2>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 // adapted to avx
@@ -294,7 +294,7 @@ namespace xsimd
 
         // eq
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -313,16 +313,16 @@ namespace xsimd
 
         // gather
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 4> = 0, detail::enable_sized_integral_t<U, 4> = 0>
-        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
-                                  kernel::requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV gather(batch<T, A> XSIMD_CREF, T const* src, batch<U, A> XSIMD_CREF index,
+                                                 kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i32gather_epi32(reinterpret_cast<const int*>(src), index, sizeof(T));
         }
 
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
-        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
-                                  kernel::requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV gather(batch<T, A> XSIMD_CREF, T const* src, batch<U, A> XSIMD_CREF index,
+                                                 kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i64gather_epi64(reinterpret_cast<const long long int*>(src), index, sizeof(T));
@@ -330,18 +330,18 @@ namespace xsimd
 
         template <class A, class U,
                   detail::enable_sized_integral_t<U, 4> = 0>
-        inline batch<float, A> gather(batch<float, A> const&, float const* src,
-                                      batch<U, A> const& index,
-                                      kernel::requires_arch<avx2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV gather(batch<float, A> XSIMD_CREF, float const* src,
+                                                     batch<U, A> XSIMD_CREF index,
+                                                     kernel::requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i32gather_ps(src, index, sizeof(float));
         }
 
         template <class A, class U, detail::enable_sized_integral_t<U, 8> = 0>
-        inline batch<double, A> gather(batch<double, A> const&, double const* src,
-                                       batch<U, A> const& index,
-                                       requires_arch<avx2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV gather(batch<double, A> XSIMD_CREF, double const* src,
+                                                      batch<U, A> XSIMD_CREF index,
+                                                      requires_arch<avx2>) noexcept
         {
             // scatter for this one is AVX512F+AVX512VL
             return _mm256_i64gather_pd(src, index, sizeof(double));
@@ -349,9 +349,9 @@ namespace xsimd
 
         // gather: handmade conversions
         template <class A, class V, detail::enable_sized_integral_t<V, 4> = 0>
-        inline batch<float, A> gather(batch<float, A> const&, double const* src,
-                                      batch<V, A> const& index,
-                                      requires_arch<avx2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV gather(batch<float, A> XSIMD_CREF, double const* src,
+                                                     batch<V, A> XSIMD_CREF index,
+                                                     requires_arch<avx2>) noexcept
         {
             const batch<double, A> low(_mm256_i32gather_pd(src, _mm256_castsi256_si128(index.data), sizeof(double)));
             const batch<double, A> high(_mm256_i32gather_pd(src, _mm256_extractf128_si256(index.data, 1), sizeof(double)));
@@ -359,9 +359,9 @@ namespace xsimd
         }
 
         template <class A, class V, detail::enable_sized_integral_t<V, 4> = 0>
-        inline batch<int32_t, A> gather(batch<int32_t, A> const&, double const* src,
-                                        batch<V, A> const& index,
-                                        requires_arch<avx2>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV gather(batch<int32_t, A> XSIMD_CREF, double const* src,
+                                                       batch<V, A> XSIMD_CREF index,
+                                                       requires_arch<avx2>) noexcept
         {
             const batch<double, A> low(_mm256_i32gather_pd(src, _mm256_castsi256_si128(index.data), sizeof(double)));
             const batch<double, A> high(_mm256_i32gather_pd(src, _mm256_extractf128_si256(index.data, 1), sizeof(double)));
@@ -370,7 +370,7 @@ namespace xsimd
 
         // lt
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -396,7 +396,7 @@ namespace xsimd
 
         // hadd
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline T hadd(batch<T, A> const& self, requires_arch<avx2>) noexcept
+        inline T XSIMD_CALLCONV hadd(batch<T, A> XSIMD_CREF self, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -430,7 +430,7 @@ namespace xsimd
         }
         // load_complex
         template <class A>
-        inline batch<std::complex<float>, A> load_complex(batch<float, A> const& hi, batch<float, A> const& lo, requires_arch<avx2>) noexcept
+        inline batch<std::complex<float>, A> XSIMD_CALLCONV load_complex(batch<float, A> XSIMD_CREF hi, batch<float, A> XSIMD_CREF lo, requires_arch<avx2>) noexcept
         {
             using batch_type = batch<float, A>;
             batch_type real = _mm256_castpd_ps(
@@ -444,7 +444,7 @@ namespace xsimd
             return { real, imag };
         }
         template <class A>
-        inline batch<std::complex<double>, A> load_complex(batch<double, A> const& hi, batch<double, A> const& lo, requires_arch<avx2>) noexcept
+        inline batch<std::complex<double>, A> XSIMD_CALLCONV load_complex(batch<double, A> XSIMD_CREF hi, batch<double, A> XSIMD_CREF lo, requires_arch<avx2>) noexcept
         {
             using batch_type = batch<double, A>;
             batch_type real = _mm256_permute4x64_pd(_mm256_unpacklo_pd(hi, lo), _MM_SHUFFLE(3, 1, 2, 0));
@@ -453,7 +453,7 @@ namespace xsimd
         }
         // mask
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline uint64_t mask(batch_bool<T, A> const& self, requires_arch<avx2>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<T, A> XSIMD_CREF self, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -471,7 +471,7 @@ namespace xsimd
 
         // max
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -505,7 +505,7 @@ namespace xsimd
 
         // min
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -539,7 +539,7 @@ namespace xsimd
 
         // mul
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -554,7 +554,7 @@ namespace xsimd
 
         // sadd
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sadd(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -584,7 +584,7 @@ namespace xsimd
 
         // select
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> XSIMD_CREF cond, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -601,7 +601,7 @@ namespace xsimd
             }
         }
         template <class A, class T, bool... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<avx2>) noexcept
         {
             constexpr int mask = batch_bool_constant<batch<T, A>, Values...>::mask();
             switch (sizeof(T))
@@ -623,7 +623,7 @@ namespace xsimd
 
         // slide_left
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_left(batch<T, A> const& x, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_left(batch<T, A> XSIMD_CREF x, requires_arch<avx2>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -654,7 +654,7 @@ namespace xsimd
 
         // slide_right
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_right(batch<T, A> const& x, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_right(batch<T, A> XSIMD_CREF x, requires_arch<avx2>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -685,7 +685,7 @@ namespace xsimd
 
         // ssub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ssub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -715,7 +715,7 @@ namespace xsimd
 
         // sub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -734,43 +734,43 @@ namespace xsimd
 
         // swizzle
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3, uint32_t V4, uint32_t V5, uint32_t V6, uint32_t V7>
-        inline batch<float, A> swizzle(batch<float, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV swizzle(batch<float, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
         {
             return _mm256_permutevar8x32_ps(self, (batch<uint32_t, A>)mask);
         }
 
         template <class A, uint64_t V0, uint64_t V1, uint64_t V2, uint64_t V3>
-        inline batch<double, A> swizzle(batch<double, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV swizzle(batch<double, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx2>) noexcept
         {
             constexpr auto mask = detail::shuffle(V0, V1, V2, V3);
             return _mm256_permute4x64_pd(self, mask);
         }
 
         template <class A, uint64_t V0, uint64_t V1, uint64_t V2, uint64_t V3>
-        inline batch<uint64_t, A> swizzle(batch<uint64_t, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx2>) noexcept
+        inline batch<uint64_t, A> XSIMD_CALLCONV swizzle(batch<uint64_t, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3>, requires_arch<avx2>) noexcept
         {
             constexpr auto mask = detail::shuffle(V0, V1, V2, V3);
             return _mm256_permute4x64_epi64(self, mask);
         }
         template <class A, uint64_t V0, uint64_t V1, uint64_t V2, uint64_t V3>
-        inline batch<int64_t, A> swizzle(batch<int64_t, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3> mask, requires_arch<avx2>) noexcept
+        inline batch<int64_t, A> XSIMD_CALLCONV swizzle(batch<int64_t, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1, V2, V3> mask, requires_arch<avx2>) noexcept
         {
             return bitwise_cast<batch<int64_t, A>>(swizzle(bitwise_cast<batch<uint64_t, A>>(self), mask, avx2 {}));
         }
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3, uint32_t V4, uint32_t V5, uint32_t V6, uint32_t V7>
-        inline batch<uint32_t, A> swizzle(batch<uint32_t, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
+        inline batch<uint32_t, A> XSIMD_CALLCONV swizzle(batch<uint32_t, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
         {
             return _mm256_permutevar8x32_epi32(self, (batch<uint32_t, A>)mask);
         }
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3, uint32_t V4, uint32_t V5, uint32_t V6, uint32_t V7>
-        inline batch<int32_t, A> swizzle(batch<int32_t, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV swizzle(batch<int32_t, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<avx2>) noexcept
         {
             return bitwise_cast<batch<int32_t, A>>(swizzle(bitwise_cast<batch<uint32_t, A>>(self), mask, avx2 {}));
         }
 
         // zip_hi
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_hi(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -790,7 +790,7 @@ namespace xsimd
 
         // zip_lo
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_lo(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<avx2>) noexcept
         {
             switch (sizeof(T))
             {

--- a/include/xsimd/arch/xsimd_avx512bw.hpp
+++ b/include/xsimd/arch/xsimd_avx512bw.hpp
@@ -27,7 +27,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, int Cmp>
-            inline batch_bool<T, A> compare_int_avx512bw(batch<T, A> const& self, batch<T, A> const& other) noexcept
+            inline batch_bool<T, A> XSIMD_CALLCONV compare_int_avx512bw(batch<T, A> const& self, batch<T, A> const& other) noexcept
             {
                 using register_type = typename batch_bool<T, A>::register_type;
                 if (std::is_signed<T>::value)
@@ -63,7 +63,7 @@ namespace xsimd
 
         // abs
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& self, requires_arch<avx512bw>) noexcept
         {
             if (std::is_unsigned<T>::value)
                 return self;
@@ -81,7 +81,7 @@ namespace xsimd
 
         // add
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             switch (sizeof(T))
             {
@@ -96,7 +96,7 @@ namespace xsimd
 
         // bitwise_lshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx512bw>) noexcept
         {
             switch (sizeof(T))
             {
@@ -114,7 +114,7 @@ namespace xsimd
 
         // bitwise_rshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx512bw>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -163,42 +163,42 @@ namespace xsimd
 
         // eq
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_EQ>(self, other);
         }
 
         // ge
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_GE>(self, other);
         }
 
         // gt
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_GT>(self, other);
         }
 
         // le
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_LE>(self, other);
         }
 
         // lt
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_LT>(self, other);
         }
 
         // max
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -228,7 +228,7 @@ namespace xsimd
 
         // min
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -258,7 +258,7 @@ namespace xsimd
 
         // mul
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             switch (sizeof(T))
             {
@@ -277,14 +277,14 @@ namespace xsimd
 
         // neq
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             return detail::compare_int_avx512bw<A, T, _MM_CMPINT_NE>(self, other);
         }
 
         // sadd
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -314,7 +314,7 @@ namespace xsimd
 
         // select
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512bw>) noexcept
         {
             switch (sizeof(T))
             {
@@ -349,7 +349,7 @@ namespace xsimd
         }
 
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_left(batch<T, A> const& x, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_left(batch<T, A> const& x, requires_arch<avx512bw>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -408,7 +408,7 @@ namespace xsimd
             }
         }
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_right(batch<T, A> const& x, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_right(batch<T, A> const& x, requires_arch<avx512bw>) noexcept
         {
             constexpr unsigned BitCount = N * 8;
             if (BitCount == 0)
@@ -441,7 +441,7 @@ namespace xsimd
 
         // ssub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -471,7 +471,7 @@ namespace xsimd
 
         // sub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept
         {
             switch (sizeof(T))
             {
@@ -487,25 +487,25 @@ namespace xsimd
         // swizzle
 
         template <class A, uint16_t... Vs>
-        inline batch<uint16_t, A> swizzle(batch<uint16_t, A> const& self, batch_constant<batch<uint16_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
+        inline batch<uint16_t, A> XSIMD_CALLCONV swizzle(batch<uint16_t, A> const& self, batch_constant<batch<uint16_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
         {
             return _mm512_permutexvar_epi16((batch<uint16_t, A>)mask, self);
         }
 
         template <class A, uint16_t... Vs>
-        inline batch<int16_t, A> swizzle(batch<int16_t, A> const& self, batch_constant<batch<uint16_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
+        inline batch<int16_t, A> XSIMD_CALLCONV swizzle(batch<int16_t, A> const& self, batch_constant<batch<uint16_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
         {
             return bitwise_cast<batch<int16_t, A>>(swizzle(bitwise_cast<batch<uint16_t, A>>(self), mask, avx512bw {}));
         }
 
         template <class A, uint8_t... Vs>
-        inline batch<uint8_t, A> swizzle(batch<uint8_t, A> const& self, batch_constant<batch<uint8_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
+        inline batch<uint8_t, A> XSIMD_CALLCONV swizzle(batch<uint8_t, A> const& self, batch_constant<batch<uint8_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
         {
             return _mm512_permutexvar_epi8((batch<uint8_t, A>)mask, self);
         }
 
         template <class A, uint8_t... Vs>
-        inline batch<int8_t, A> swizzle(batch<int8_t, A> const& self, batch_constant<batch<uint8_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
+        inline batch<int8_t, A> XSIMD_CALLCONV swizzle(batch<int8_t, A> const& self, batch_constant<batch<uint8_t, A>, Vs...> mask, requires_arch<avx512bw>) noexcept
         {
             return bitwise_cast<batch<int8_t, A>>(swizzle(bitwise_cast<batch<uint8_t, A>>(self), mask, avx512bw {}));
         }

--- a/include/xsimd/arch/xsimd_avx512dq.hpp
+++ b/include/xsimd/arch/xsimd_avx512dq.hpp
@@ -23,42 +23,42 @@ namespace xsimd
 
         // bitwise_and
         template <class A>
-        inline batch<float, A> bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_and_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_and_pd(self, other);
         }
 
         // bitwise_andnot
         template <class A>
-        inline batch<float, A> bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_andnot_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_andnot_pd(self, other);
         }
 
         // bitwise_or
         template <class A>
-        inline batch<float, A> bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_or_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_or_pd(self, other);
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512dq>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data | other.data);
@@ -66,20 +66,20 @@ namespace xsimd
 
         // bitwise_xor
         template <class A>
-        inline batch<float, A> bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_xor_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512dq>) noexcept
         {
             return _mm512_xor_pd(self, other);
         }
 
         // nearbyint_as_int
         template <class A>
-        inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& self,
-                                                  requires_arch<avx512dq>) noexcept
+        inline batch<int64_t, A> XSIMD_CALLCONV nearbyint_as_int(batch<double, A> const& self,
+                                                                 requires_arch<avx512dq>) noexcept
         {
             return _mm512_cvtpd_epi64(self);
         }
@@ -88,13 +88,13 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<double, A> fast_cast(batch<int64_t, A> const& x, batch<double, A> const&, requires_arch<avx512dq>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<int64_t, A> const& x, batch<double, A> const&, requires_arch<avx512dq>) noexcept
             {
                 return _mm512_cvtepi64_pd(self);
             }
 
             template <class A>
-            inline batch<int64_t, A> fast_cast(batch<double, A> const& self, batch<int64_t, A> const&, requires_arch<avx512dq>) noexcept
+            inline batch<int64_t, A> XSIMD_CALLCONV fast_cast(batch<double, A> const& self, batch<int64_t, A> const&, requires_arch<avx512dq>) noexcept
             {
                 return _mm512_cvttpd_epi64(self);
             }

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -27,35 +27,35 @@ namespace xsimd
 
         namespace detail
         {
-            inline void split_avx512(__m512 val, __m256& low, __m256& high) noexcept
+            inline void XSIMD_CALLCONV split_avx512(__m512 val, __m256& low, __m256& high) noexcept
             {
                 low = _mm512_castps512_ps256(val);
                 high = _mm512_extractf32x8_ps(val, 1);
             }
-            inline void split_avx512(__m512d val, __m256d& low, __m256d& high) noexcept
+            inline void XSIMD_CALLCONV split_avx512(__m512d val, __m256d& low, __m256d& high) noexcept
             {
                 low = _mm512_castpd512_pd256(val);
                 high = _mm512_extractf64x4_pd(val, 1);
             }
-            inline void split_avx512(__m512i val, __m256i& low, __m256i& high) noexcept
+            inline void XSIMD_CALLCONV split_avx512(__m512i val, __m256i& low, __m256i& high) noexcept
             {
                 low = _mm512_castsi512_si256(val);
                 high = _mm512_extracti64x4_epi64(val, 1);
             }
-            inline __m512i merge_avx(__m256i low, __m256i high) noexcept
+            inline __m512i XSIMD_CALLCONV merge_avx(__m256i low, __m256i high) noexcept
             {
                 return _mm512_inserti64x4(_mm512_castsi256_si512(low), high, 1);
             }
-            inline __m512 merge_avx(__m256 low, __m256 high) noexcept
+            inline __m512 XSIMD_CALLCONV merge_avx(__m256 low, __m256 high) noexcept
             {
                 return _mm512_insertf32x8(_mm512_castps256_ps512(low), high, 1);
             }
-            inline __m512d merge_avx(__m256d low, __m256d high) noexcept
+            inline __m512d XSIMD_CALLCONV merge_avx(__m256d low, __m256d high) noexcept
             {
                 return _mm512_insertf64x4(_mm512_castpd256_pd512(low), high, 1);
             }
             template <class F>
-            __m512i fwd_to_avx(F f, __m512i self)
+            __m512i XSIMD_CALLCONV fwd_to_avx(F f, __m512i self)
             {
                 __m256i self_low, self_high;
                 split_avx512(self, self_low, self_high);
@@ -64,7 +64,7 @@ namespace xsimd
                 return merge_avx(res_low, res_high);
             }
             template <class F>
-            __m512i fwd_to_avx(F f, __m512i self, __m512i other)
+            __m512i XSIMD_CALLCONV fwd_to_avx(F f, __m512i self, __m512i other)
             {
                 __m256i self_low, self_high, other_low, other_high;
                 split_avx512(self, self_low, self_high);
@@ -74,7 +74,7 @@ namespace xsimd
                 return merge_avx(res_low, res_high);
             }
             template <class F>
-            __m512i fwd_to_avx(F f, __m512i self, int32_t other)
+            __m512i XSIMD_CALLCONV fwd_to_avx(F f, __m512i self, int32_t other)
             {
                 __m256i self_low, self_high;
                 split_avx512(self, self_low, self_high);
@@ -86,7 +86,7 @@ namespace xsimd
         namespace detail
         {
 
-            inline uint32_t morton(uint16_t x, uint16_t y) noexcept
+            inline uint32_t XSIMD_CALLCONV morton(uint16_t x, uint16_t y) noexcept
             {
 
                 static const unsigned short MortonTable256[256] = {
@@ -129,7 +129,7 @@ namespace xsimd
             }
 
             template <class A, class T, int Cmp>
-            inline batch_bool<T, A> compare_int_avx512f(batch<T, A> const& self, batch<T, A> const& other) noexcept
+            inline batch_bool<T, A> XSIMD_CALLCONV compare_int_avx512f(batch<T, A> const& self, batch<T, A> const& other) noexcept
             {
                 using register_type = typename batch_bool<T, A>::register_type;
                 if (std::is_signed<T>::value)
@@ -215,7 +215,7 @@ namespace xsimd
 
         // abs
         template <class A>
-        inline batch<float, A> abs(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV abs(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             __m512 self_asf = (__m512)self;
             __m512i self_asi = *reinterpret_cast<__m512i*>(&self_asf);
@@ -223,7 +223,7 @@ namespace xsimd
             return *reinterpret_cast<__m512*>(&res_asi);
         }
         template <class A>
-        inline batch<double, A> abs(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV abs(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             __m512d self_asd = (__m512d)self;
             __m512i self_asi = *reinterpret_cast<__m512i*>(&self_asd);
@@ -232,7 +232,7 @@ namespace xsimd
             return *reinterpret_cast<__m512d*>(&res_asi);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             if (std::is_unsigned<T>::value)
                 return self;
@@ -259,7 +259,7 @@ namespace xsimd
 
         // add
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -281,19 +281,19 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> add(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV add(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_add_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> add(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV add(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_add_pd(self, other);
         }
 
         // all
         template <class A, class T>
-        inline bool all(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return self.data == register_type(-1);
@@ -301,7 +301,7 @@ namespace xsimd
 
         // any
         template <class A, class T>
-        inline bool any(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return self.data != register_type(0);
@@ -309,24 +309,24 @@ namespace xsimd
 
         // bitwise_and
         template <class A>
-        inline batch<float, A> bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(self), _mm512_castps_si512(other)));
         }
         template <class A>
-        inline batch<double, A> bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_pd(_mm512_and_si512(_mm512_castpd_si512(self), _mm512_castpd_si512(other)));
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_and_si512(self, other);
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_and(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data & other.data);
@@ -334,24 +334,24 @@ namespace xsimd
 
         // bitwise_andnot
         template <class A>
-        inline batch<float, A> bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_ps(_mm512_andnot_si512(_mm512_castps_si512(self), _mm512_castps_si512(other)));
         }
         template <class A>
-        inline batch<double, A> bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_pd(_mm512_andnot_si512(_mm512_castpd_si512(self), _mm512_castpd_si512(other)));
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_andnot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_andnot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_andnot_si512(self, other);
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data & ~other.data);
@@ -359,7 +359,7 @@ namespace xsimd
 
         // bitwise_lshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -395,56 +395,56 @@ namespace xsimd
 
         // bitwise_not
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_not(batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_not(batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_xor_si512(self, _mm512_set1_epi32(-1));
         }
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_not(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(~self.data);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_not(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_not(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_xor_ps(self, _mm512_castsi512_ps(_mm512_set1_epi32(-1)));
         }
         template <class A>
-        inline batch<double, A> bitwise_not(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_not(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_xor_pd(self, _mm512_castsi512_pd(_mm512_set1_epi32(-1)));
         }
 
         // bitwise_or
         template <class A>
-        inline batch<float, A> bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_ps(_mm512_or_si512(_mm512_castps_si512(self), _mm512_castps_si512(other)));
         }
         template <class A>
-        inline batch<double, A> bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_pd(_mm512_or_si512(_mm512_castpd_si512(self), _mm512_castpd_si512(other)));
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data | other.data);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_or_si512(self, other);
         }
 
         // bitwise_rshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<avx512f>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -501,37 +501,37 @@ namespace xsimd
 
         // bitwise_xor
         template <class A>
-        inline batch<float, A> bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_ps(_mm512_xor_si512(_mm512_castps_si512(self), _mm512_castps_si512(other)));
         }
         template <class A>
-        inline batch<double, A> bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_pd(_mm512_xor_si512(_mm512_castpd_si512(self), _mm512_castpd_si512(other)));
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_xor(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data | other.data);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_xor_si512(self, other);
         }
 
         // bitwise_cast
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<float, A> bitwise_cast(batch<T, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_ps(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<double, A> bitwise_cast(batch<T, A> const& self, batch<double, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> const& self, batch<double, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castsi512_pd(self);
         }
@@ -541,51 +541,51 @@ namespace xsimd
             return batch<Tp, A>(self.data);
         }
         template <class A>
-        inline batch<double, A> bitwise_cast(batch<float, A> const& self, batch<double, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> const& self, batch<double, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castps_pd(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<float, A> const& self, batch<T, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> const& self, batch<T, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castps_si512(self);
         }
         template <class A>
-        inline batch<float, A> bitwise_cast(batch<double, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castpd_ps(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<double, A> const& self, batch<T, A> const&, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> const& self, batch<T, A> const&, requires_arch<avx512f>) noexcept
         {
             return _mm512_castpd_si512(self);
         }
 
         // bool_cast
         template <class A>
-        inline batch_bool<int32_t, A> bool_cast(batch_bool<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<int32_t, A> XSIMD_CALLCONV bool_cast(batch_bool<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return self.data;
         }
         template <class A>
-        inline batch_bool<float, A> bool_cast(batch_bool<int32_t, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bool_cast(batch_bool<int32_t, A> const& self, requires_arch<avx512f>) noexcept
         {
             return self.data;
         }
         template <class A>
-        inline batch_bool<int64_t, A> bool_cast(batch_bool<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<int64_t, A> XSIMD_CALLCONV bool_cast(batch_bool<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return self.data;
         }
         template <class A>
-        inline batch_bool<double, A> bool_cast(batch_bool<int64_t, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bool_cast(batch_bool<int64_t, A> const& self, requires_arch<avx512f>) noexcept
         {
             return self.data;
         }
 
         // broadcast
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> broadcast(T val, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV broadcast(T val, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -603,24 +603,24 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> broadcast(float val, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV broadcast(float val, requires_arch<avx512f>) noexcept
         {
             return _mm512_set1_ps(val);
         }
         template <class A>
-        batch<double, A> inline broadcast(double val, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV broadcast(double val, requires_arch<avx512f>) noexcept
         {
             return _mm512_set1_pd(val);
         }
 
         // ceil
         template <class A>
-        inline batch<float, A> ceil(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ceil(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_ps(self, _MM_FROUND_TO_POS_INF);
         }
         template <class A>
-        inline batch<double, A> ceil(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ceil(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_pd(self, _MM_FROUND_TO_POS_INF);
         }
@@ -629,25 +629,25 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<float, A> fast_cast(batch<int32_t, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<int32_t, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
             {
                 return _mm512_cvtepi32_ps(self);
             }
 
             template <class A>
-            inline batch<int32_t, A> fast_cast(batch<float, A> const& self, batch<int32_t, A> const&, requires_arch<avx512f>) noexcept
+            inline batch<int32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> const& self, batch<int32_t, A> const&, requires_arch<avx512f>) noexcept
             {
                 return _mm512_cvttps_epi32(self);
             }
 
             template <class A>
-            inline batch<float, A> fast_cast(batch<uint32_t, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<uint32_t, A> const& self, batch<float, A> const&, requires_arch<avx512f>) noexcept
             {
                 return _mm512_cvtepu32_ps(self);
             }
 
             template <class A>
-            batch<uint32_t, A> fast_cast(batch<float, A> const& self, batch<uint32_t, A> const&, requires_arch<avx512f>)
+            batch<uint32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> const& self, batch<uint32_t, A> const&, requires_arch<avx512f>)
             {
                 return _mm512_cvttps_epu32(self);
             }
@@ -657,13 +657,13 @@ namespace xsimd
         {
             // complex_low
             template <class A>
-            inline batch<float, A> complex_low(batch<std::complex<float>, A> const& self, requires_arch<avx512f>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_low(batch<std::complex<float>, A> const& self, requires_arch<avx512f>) noexcept
             {
                 __m512i idx = _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
                 return _mm512_permutex2var_ps(self.real(), idx, self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx512f>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_low(batch<std::complex<double>, A> const& self, requires_arch<avx512f>) noexcept
             {
                 __m512i idx = _mm512_setr_epi64(0, 8, 1, 9, 2, 10, 3, 11);
                 return _mm512_permutex2var_pd(self.real(), idx, self.imag());
@@ -671,13 +671,13 @@ namespace xsimd
 
             // complex_high
             template <class A>
-            inline batch<float, A> complex_high(batch<std::complex<float>, A> const& self, requires_arch<avx512f>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_high(batch<std::complex<float>, A> const& self, requires_arch<avx512f>) noexcept
             {
                 __m512i idx = _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
                 return _mm512_permutex2var_ps(self.real(), idx, self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx512f>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_high(batch<std::complex<double>, A> const& self, requires_arch<avx512f>) noexcept
             {
                 __m512i idx = _mm512_setr_epi64(4, 12, 5, 13, 6, 14, 7, 15);
                 return _mm512_permutex2var_pd(self.real(), idx, self.imag());
@@ -686,35 +686,35 @@ namespace xsimd
 
         // div
         template <class A>
-        inline batch<float, A> div(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV div(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_div_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> div(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV div(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_div_pd(self, other);
         }
 
         // eq
         template <class A>
-        inline batch_bool<float, A> eq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV eq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_EQ_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> eq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV eq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_EQ_OQ);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return detail::compare_int_avx512f<A, T, _MM_CMPINT_EQ>(self, other);
         }
         template <class A, class T>
-        inline batch_bool<T, A> eq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(~self.data ^ other.data);
@@ -722,55 +722,55 @@ namespace xsimd
 
         // floor
         template <class A>
-        inline batch<float, A> floor(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV floor(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_ps(self, _MM_FROUND_TO_NEG_INF);
         }
         template <class A>
-        inline batch<double, A> floor(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV floor(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_pd(self, _MM_FROUND_TO_NEG_INF);
         }
 
         // from bool
         template <class A, class T>
-        inline batch<T, A> from_bool(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV from_bool(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return select(self, batch<T, A>(1), batch<T, A>(0));
         }
 
         // from_mask
         template <class T, class A>
-        inline batch_bool<T, A> from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<avx512f>) noexcept
         {
             return static_cast<typename batch_bool<T, A>::register_type>(mask);
         }
 
         // gather
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 4> = 0, detail::enable_sized_integral_t<U, 4> = 0>
-        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
-                                  kernel::requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
+                                                 kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i32gather_epi32(index, static_cast<const void*>(src), sizeof(T));
         }
 
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 8> = 0, detail::enable_sized_integral_t<U, 8> = 0>
-        inline batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
-                                  kernel::requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV gather(batch<T, A> const&, T const* src, batch<U, A> const& index,
+                                                 kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i64gather_epi64(index, static_cast<const void*>(src), sizeof(T));
         }
 
         template <class A, class U, detail::enable_sized_integral_t<U, 4> = 0>
-        inline batch<float, A> gather(batch<float, A> const&, float const* src,
-                                      batch<U, A> const& index,
-                                      kernel::requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV gather(batch<float, A> const&, float const* src,
+                                                     batch<U, A> const& index,
+                                                     kernel::requires_arch<avx512f>) noexcept
         {
             return _mm512_i32gather_ps(index, src, sizeof(float));
         }
 
         template <class A, class U, detail::enable_sized_integral_t<U, 8> = 0>
-        inline batch<double, A>
+        inline batch<double, A> XSIMD_CALLCONV
         gather(batch<double, A> const&, double const* src, batch<U, A> const& index,
                kernel::requires_arch<avx512f>) noexcept
         {
@@ -779,9 +779,9 @@ namespace xsimd
 
         // gather: handmade conversions
         template <class A, class V, detail::enable_sized_integral_t<V, 4> = 0>
-        inline batch<float, A> gather(batch<float, A> const&, double const* src,
-                                      batch<V, A> const& index,
-                                      requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV gather(batch<float, A> const&, double const* src,
+                                                     batch<V, A> const& index,
+                                                     requires_arch<avx512f>) noexcept
         {
             const batch<double, A> low(_mm512_i32gather_pd(_mm512_castsi512_si256(index.data), src, sizeof(double)));
             const batch<double, A> high(_mm512_i32gather_pd(_mm256_castpd_si256(_mm512_extractf64x4_pd(_mm512_castsi512_pd(index.data), 1)), src, sizeof(double)));
@@ -789,9 +789,9 @@ namespace xsimd
         }
 
         template <class A, class V, detail::enable_sized_integral_t<V, 4> = 0>
-        inline batch<int32_t, A> gather(batch<int32_t, A> const&, double const* src,
-                                        batch<V, A> const& index,
-                                        requires_arch<avx512f>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV gather(batch<int32_t, A> const&, double const* src,
+                                                       batch<V, A> const& index,
+                                                       requires_arch<avx512f>) noexcept
         {
             const batch<double, A> low(_mm512_i32gather_pd(_mm512_castsi512_si256(index.data), src, sizeof(double)));
             const batch<double, A> high(_mm512_i32gather_pd(_mm256_castpd_si256(_mm512_extractf64x4_pd(_mm512_castsi512_pd(index.data), 1)), src, sizeof(double)));
@@ -800,41 +800,41 @@ namespace xsimd
 
         // ge
         template <class A>
-        inline batch_bool<float, A> ge(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV ge(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_GE_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> ge(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV ge(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_GE_OQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV ge(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return detail::compare_int_avx512f<A, T, _MM_CMPINT_GE>(self, other);
         }
 
         // gt
         template <class A>
-        inline batch_bool<float, A> gt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV gt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_GT_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> gt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV gt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_GT_OQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return detail::compare_int_avx512f<A, T, _MM_CMPINT_GT>(self, other);
         }
 
         // hadd
         template <class A>
-        inline float hadd(batch<float, A> const& rhs, requires_arch<avx512f>) noexcept
+        inline float XSIMD_CALLCONV hadd(batch<float, A> const& rhs, requires_arch<avx512f>) noexcept
         {
             __m256 tmp1 = _mm512_extractf32x8_ps(rhs, 1);
             __m256 tmp2 = _mm512_extractf32x8_ps(rhs, 0);
@@ -842,7 +842,7 @@ namespace xsimd
             return hadd(batch<float, avx2>(res1), avx2 {});
         }
         template <class A>
-        inline double hadd(batch<double, A> const& rhs, requires_arch<avx512f>) noexcept
+        inline double XSIMD_CALLCONV hadd(batch<double, A> const& rhs, requires_arch<avx512f>) noexcept
         {
             __m256d tmp1 = _mm512_extractf64x4_pd(rhs, 1);
             __m256d tmp2 = _mm512_extractf64x4_pd(rhs, 0);
@@ -850,7 +850,7 @@ namespace xsimd
             return hadd(batch<double, avx2>(res1), avx2 {});
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline T hadd(batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline T XSIMD_CALLCONV hadd(batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             __m256i low, high;
             detail::split_avx512(self, low, high);
@@ -860,7 +860,7 @@ namespace xsimd
 
         // haddp
         template <class A>
-        inline batch<float, A> haddp(batch<float, A> const* row, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV haddp(batch<float, A> const* row, requires_arch<avx512f>) noexcept
         {
             // The following folds over the vector once:
             // tmp1 = [a0..8, b0..8]
@@ -921,7 +921,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> haddp(batch<double, A> const* row, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV haddp(batch<double, A> const* row, requires_arch<avx512f>) noexcept
         {
 #define step1(I, a, b)                                                   \
     batch<double, avx512f> res##I;                                       \
@@ -956,46 +956,46 @@ namespace xsimd
 
         // isnan
         template <class A>
-        inline batch_bool<float, A> isnan(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV isnan(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, self, _CMP_UNORD_Q);
         }
         template <class A>
-        inline batch_bool<double, A> isnan(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV isnan(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, self, _CMP_UNORD_Q);
         }
 
         // le
         template <class A>
-        inline batch_bool<float, A> le(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV le(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_LE_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> le(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV le(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_LE_OQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV le(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return detail::compare_int_avx512f<A, T, _MM_CMPINT_LE>(self, other);
         }
 
         // load_aligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_aligned(T const* mem, convert<T>, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_aligned(T const* mem, convert<T>, requires_arch<avx512f>) noexcept
         {
             return _mm512_load_si512((__m512i const*)mem);
         }
         template <class A>
-        inline batch<float, A> load_aligned(float const* mem, convert<float>, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_aligned(float const* mem, convert<float>, requires_arch<avx512f>) noexcept
         {
             return _mm512_load_ps(mem);
         }
         template <class A>
-        inline batch<double, A> load_aligned(double const* mem, convert<double>, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_aligned(double const* mem, convert<double>, requires_arch<avx512f>) noexcept
         {
             return _mm512_load_pd(mem);
         }
@@ -1004,7 +1004,7 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<std::complex<float>, A> load_complex(batch<float, A> const& hi, batch<float, A> const& lo, requires_arch<avx512f>) noexcept
+            inline batch<std::complex<float>, A> XSIMD_CALLCONV load_complex(batch<float, A> const& hi, batch<float, A> const& lo, requires_arch<avx512f>) noexcept
             {
                 __m512i real_idx = _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
                 __m512i imag_idx = _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
@@ -1013,7 +1013,7 @@ namespace xsimd
                 return { real, imag };
             }
             template <class A>
-            inline batch<std::complex<double>, A> load_complex(batch<double, A> const& hi, batch<double, A> const& lo, requires_arch<avx512f>) noexcept
+            inline batch<std::complex<double>, A> XSIMD_CALLCONV load_complex(batch<double, A> const& hi, batch<double, A> const& lo, requires_arch<avx512f>) noexcept
             {
                 __m512i real_idx = _mm512_setr_epi64(0, 2, 4, 6, 8, 10, 12, 14);
                 __m512i imag_idx = _mm512_setr_epi64(1, 3, 5, 7, 9, 11, 13, 15);
@@ -1025,59 +1025,59 @@ namespace xsimd
 
         // load_unaligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_unaligned(T const* mem, convert<T>, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_unaligned(T const* mem, convert<T>, requires_arch<avx512f>) noexcept
         {
             return _mm512_loadu_si512((__m512i const*)mem);
         }
         template <class A>
-        inline batch<float, A> load_unaligned(float const* mem, convert<float>, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_unaligned(float const* mem, convert<float>, requires_arch<avx512f>) noexcept
         {
             return _mm512_loadu_ps(mem);
         }
         template <class A>
-        inline batch<double, A> load_unaligned(double const* mem, convert<double>, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_unaligned(double const* mem, convert<double>, requires_arch<avx512f>) noexcept
         {
             return _mm512_loadu_pd(mem);
         }
 
         // lt
         template <class A>
-        inline batch_bool<float, A> lt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV lt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_LT_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> lt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV lt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_LT_OQ);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return detail::compare_int_avx512f<A, T, _MM_CMPINT_LT>(self, other);
         }
 
         // mask
         template <class A, class T>
-        inline uint64_t mask(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return self.data;
         }
 
         // max
         template <class A>
-        inline batch<float, A> max(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV max(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_max_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> max(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV max(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_max_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1111,12 +1111,12 @@ namespace xsimd
 
         // min
         template <class A>
-        inline batch<float, A> min(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV min(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_min_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> min(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV min(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_min_pd(self, other);
         }
@@ -1155,17 +1155,17 @@ namespace xsimd
 
         // mul
         template <class A>
-        inline batch<float, A> mul(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV mul(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_mul_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> mul(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV mul(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_mul_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1182,50 +1182,50 @@ namespace xsimd
 
         // nearbyint
         template <class A>
-        inline batch<float, A> nearbyint(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV nearbyint(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_round_ps(self, _MM_FROUND_TO_NEAREST_INT, _MM_FROUND_CUR_DIRECTION);
         }
         template <class A>
-        inline batch<double, A> nearbyint(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV nearbyint(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_round_pd(self, _MM_FROUND_TO_NEAREST_INT, _MM_FROUND_CUR_DIRECTION);
         }
 
         // nearbyint_as_int
         template <class A>
-        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
-                                                  requires_arch<avx512f>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV nearbyint_as_int(batch<float, A> const& self,
+                                                                 requires_arch<avx512f>) noexcept
         {
             return _mm512_cvtps_epi32(self);
         }
 
         // neg
         template <class A, class T>
-        inline batch<T, A> neg(batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV neg(batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return 0 - self;
         }
 
         // neq
         template <class A>
-        inline batch_bool<float, A> neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_ps_mask(self, other, _CMP_NEQ_OQ);
         }
         template <class A>
-        inline batch_bool<double, A> neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_cmp_pd_mask(self, other, _CMP_NEQ_OQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             return ~(self == other);
         }
 
         template <class A, class T>
-        inline batch_bool<T, A> neq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             return register_type(self.data ^ other.data);
@@ -1233,7 +1233,7 @@ namespace xsimd
 
         // reciprocal
         template <class A>
-        inline batch<float, A>
+        inline batch<float, A> XSIMD_CALLCONV
         reciprocal(batch<float, A> const& self,
                    kernel::requires_arch<avx512f>) noexcept
         {
@@ -1241,7 +1241,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A>
+        inline batch<double, A> XSIMD_CALLCONV
         reciprocal(batch<double, A> const& self,
                    kernel::requires_arch<avx512f>) noexcept
         {
@@ -1250,29 +1250,29 @@ namespace xsimd
 
         // rsqrt
         template <class A>
-        inline batch<float, A> rsqrt(batch<float, A> const& val, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV rsqrt(batch<float, A> const& val, requires_arch<avx512f>) noexcept
         {
             return _mm512_rsqrt14_ps(val);
         }
         template <class A>
-        inline batch<double, A> rsqrt(batch<double, A> const& val, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV rsqrt(batch<double, A> const& val, requires_arch<avx512f>) noexcept
         {
             return _mm512_rsqrt14_pd(val);
         }
 
         // sadd
         template <class A>
-        inline batch<float, A> sadd(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sadd(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return add(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A>
-        inline batch<double, A> sadd(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sadd(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return add(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1293,9 +1293,9 @@ namespace xsimd
         template <class A, class T,
                   typename std::enable_if<std::is_same<uint32_t, T>::value || std::is_same<int32_t, T>::value,
                                           void>::type>
-        inline void scatter(batch<T, A> const& src, T* dst,
-                            batch<int32_t, A> const& index,
-                            kernel::requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV scatter(batch<T, A> const& src, T* dst,
+                                           batch<int32_t, A> const& index,
+                                           kernel::requires_arch<avx512f>) noexcept
         {
             _mm512_i32scatter_epi32(dst, index, src, sizeof(T));
         }
@@ -1303,43 +1303,43 @@ namespace xsimd
         template <class T, class A,
                   typename std::enable_if<std::is_same<uint64_t, T>::value || std::is_same<int64_t, T>::value,
                                           void>::type>
-        inline void scatter(batch<T, A> const& src, T* dst,
-                            batch<int64_t, A> const& index,
-                            kernel::requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV scatter(batch<T, A> const& src, T* dst,
+                                           batch<int64_t, A> const& index,
+                                           kernel::requires_arch<avx512f>) noexcept
         {
             _mm512_i64scatter_epi64(dst, index, src, sizeof(T));
         }
 
         template <class A>
-        inline void scatter(batch<float, A> const& src, float* dst,
-                            batch<int32_t, A> const& index,
-                            kernel::requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV scatter(batch<float, A> const& src, float* dst,
+                                           batch<int32_t, A> const& index,
+                                           kernel::requires_arch<avx512f>) noexcept
         {
             _mm512_i32scatter_ps(dst, index, src, sizeof(float));
         }
 
         template <class A>
-        inline void scatter(batch<double, A> const& src, double* dst,
-                            batch<int64_t, A> const& index,
-                            kernel::requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV scatter(batch<double, A> const& src, double* dst,
+                                           batch<int64_t, A> const& index,
+                                           kernel::requires_arch<avx512f>) noexcept
         {
             _mm512_i64scatter_pd(dst, index, src, sizeof(double));
         }
 
         // select
         template <class A>
-        inline batch<float, A> select(batch_bool<float, A> const& cond, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool<float, A> const& cond, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<avx512f>) noexcept
         {
             return _mm512_mask_blend_ps(cond, false_br, true_br);
         }
         template <class A>
-        inline batch<double, A> select(batch_bool<double, A> const& cond, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool<double, A> const& cond, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<avx512f>) noexcept
         {
             return _mm512_mask_blend_pd(cond, false_br, true_br);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1388,7 +1388,7 @@ namespace xsimd
         }
 
         template <class A, class T, bool... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx512f>) noexcept
         {
             return select(batch_bool<T, A> { Values... }, true_br, false_br, avx512f {});
         }
@@ -1406,32 +1406,32 @@ namespace xsimd
 
         // set
         template <class A>
-        inline batch<float, A> set(batch<float, A> const&, requires_arch<avx512f>, float v0, float v1, float v2, float v3, float v4, float v5, float v6, float v7, float v8, float v9, float v10, float v11, float v12, float v13, float v14, float v15) noexcept
+        inline batch<float, A> XSIMD_CALLCONV set(batch<float, A> const&, requires_arch<avx512f>, float v0, float v1, float v2, float v3, float v4, float v5, float v6, float v7, float v8, float v9, float v10, float v11, float v12, float v13, float v14, float v15) noexcept
         {
             return _mm512_setr_ps(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
         }
 
         template <class A>
-        inline batch<double, A> set(batch<double, A> const&, requires_arch<avx512f>, double v0, double v1, double v2, double v3, double v4, double v5, double v6, double v7) noexcept
+        inline batch<double, A> XSIMD_CALLCONV set(batch<double, A> const&, requires_arch<avx512f>, double v0, double v1, double v2, double v3, double v4, double v5, double v6, double v7) noexcept
         {
             return _mm512_setr_pd(v0, v1, v2, v3, v4, v5, v6, v7);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
         {
             return _mm512_set_epi64(v7, v6, v5, v4, v3, v2, v1, v0);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
-                               T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
+                                              T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
         {
             return _mm512_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
         }
         template <class A, class T, detail::enable_signed_integer_t<T> = 0>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
-                               T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
-                               T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
-                               T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
+                                              T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
+                                              T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
+                                              T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
         {
 #if defined(__clang__) || __GNUC__
             return __extension__(__m512i)(__v32hi) {
@@ -1445,10 +1445,10 @@ namespace xsimd
         }
 
         template <class A, class T, detail::enable_unsigned_integer_t<T> = 0>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
-                               T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
-                               T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
-                               T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
+                                              T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
+                                              T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
+                                              T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31) noexcept
         {
 #if defined(__clang__) || __GNUC__
             return __extension__(__m512i)(__v32hu) {
@@ -1462,14 +1462,14 @@ namespace xsimd
         }
 
         template <class A, class T, detail::enable_signed_integer_t<T> = 0>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
-                               T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
-                               T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
-                               T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31,
-                               T v32, T v33, T v34, T v35, T v36, T v37, T v38, T v39,
-                               T v40, T v41, T v42, T v43, T v44, T v45, T v46, T v47,
-                               T v48, T v49, T v50, T v51, T v52, T v53, T v54, T v55,
-                               T v56, T v57, T v58, T v59, T v60, T v61, T v62, T v63) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
+                                              T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
+                                              T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
+                                              T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31,
+                                              T v32, T v33, T v34, T v35, T v36, T v37, T v38, T v39,
+                                              T v40, T v41, T v42, T v43, T v44, T v45, T v46, T v47,
+                                              T v48, T v49, T v50, T v51, T v52, T v53, T v54, T v55,
+                                              T v56, T v57, T v58, T v59, T v60, T v61, T v62, T v63) noexcept
         {
 
 #if defined(__clang__) || __GNUC__
@@ -1487,14 +1487,14 @@ namespace xsimd
 #endif
         }
         template <class A, class T, detail::enable_unsigned_integer_t<T> = 0>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
-                               T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
-                               T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
-                               T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31,
-                               T v32, T v33, T v34, T v35, T v36, T v37, T v38, T v39,
-                               T v40, T v41, T v42, T v43, T v44, T v45, T v46, T v47,
-                               T v48, T v49, T v50, T v51, T v52, T v53, T v54, T v55,
-                               T v56, T v57, T v58, T v59, T v60, T v61, T v62, T v63) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> const&, requires_arch<avx512f>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7,
+                                              T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15,
+                                              T v16, T v17, T v18, T v19, T v20, T v21, T v22, T v23,
+                                              T v24, T v25, T v26, T v27, T v28, T v29, T v30, T v31,
+                                              T v32, T v33, T v34, T v35, T v36, T v37, T v38, T v39,
+                                              T v40, T v41, T v42, T v43, T v44, T v45, T v46, T v47,
+                                              T v48, T v49, T v50, T v51, T v52, T v53, T v54, T v55,
+                                              T v56, T v57, T v58, T v59, T v60, T v61, T v62, T v63) noexcept
         {
 
 #if defined(__clang__) || __GNUC__
@@ -1513,7 +1513,7 @@ namespace xsimd
         }
 
         template <class A, class T, class... Values>
-        inline batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<avx512f>, Values... values) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV set(batch_bool<T, A> const&, requires_arch<avx512f>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch_bool<T, A>::size, "consistent init");
             using register_type = typename batch_bool<T, A>::register_type;
@@ -1525,29 +1525,29 @@ namespace xsimd
 
         // sqrt
         template <class A>
-        inline batch<float, A> sqrt(batch<float, A> const& val, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sqrt(batch<float, A> const& val, requires_arch<avx512f>) noexcept
         {
             return _mm512_sqrt_ps(val);
         }
         template <class A>
-        inline batch<double, A> sqrt(batch<double, A> const& val, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sqrt(batch<double, A> const& val, requires_arch<avx512f>) noexcept
         {
             return _mm512_sqrt_pd(val);
         }
 
         // ssub
         template <class A>
-        inline batch<float, A> ssub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ssub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_sub_ps(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A>
-        inline batch<double, A> ssub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ssub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_sub_pd(self, other); // no saturated arithmetic on floating point numbers
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1562,7 +1562,7 @@ namespace xsimd
 
         // store
         template <class T, class A>
-        inline void store(batch_bool<T, A> const& self, bool* mem, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store(batch_bool<T, A> const& self, bool* mem, requires_arch<avx512f>) noexcept
         {
             using register_type = typename batch_bool<T, A>::register_type;
             constexpr auto size = batch_bool<T, A>::size;
@@ -1572,51 +1572,51 @@ namespace xsimd
 
         // store_aligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_store_si512((__m512i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_store_si512((__m512i*)mem, self);
         }
         template <class A>
-        inline void store_aligned(float* mem, batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(float* mem, batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_store_ps(mem, self);
         }
         template <class A>
-        inline void store_aligned(double* mem, batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(double* mem, batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_store_pd(mem, self);
         }
 
         // store_unaligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_storeu_si512((__m512i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_storeu_si512((__m512i*)mem, self);
         }
         template <class A>
-        inline void store_unaligned(float* mem, batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(float* mem, batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_storeu_ps(mem, self);
         }
         template <class A>
-        inline void store_unaligned(double* mem, batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(double* mem, batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_storeu_pd(mem, self);
         }
 
         // sub
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1638,68 +1638,68 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> sub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_sub_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> sub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_sub_pd(self, other);
         }
 
         // swizzle
         template <class A, uint32_t... Vs>
-        inline batch<float, A> swizzle(batch<float, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV swizzle(batch<float, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return _mm512_permutexvar_ps((batch<uint32_t, A>)mask, self);
         }
 
         template <class A, uint64_t... Vs>
-        inline batch<double, A> swizzle(batch<double, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV swizzle(batch<double, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return _mm512_permutexvar_pd((batch<uint64_t, A>)mask, self);
         }
 
         template <class A, uint64_t... Vs>
-        inline batch<uint64_t, A> swizzle(batch<uint64_t, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<uint64_t, A> XSIMD_CALLCONV swizzle(batch<uint64_t, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return _mm512_permutexvar_epi64((batch<uint64_t, A>)mask, self);
         }
 
         template <class A, uint64_t... Vs>
-        inline batch<int64_t, A> swizzle(batch<int64_t, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<int64_t, A> XSIMD_CALLCONV swizzle(batch<int64_t, A> const& self, batch_constant<batch<uint64_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return bitwise_cast<batch<int64_t, A>>(swizzle(bitwise_cast<batch<uint64_t, A>>(self), mask, avx512f {}));
         }
 
         template <class A, uint32_t... Vs>
-        inline batch<uint32_t, A> swizzle(batch<uint32_t, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<uint32_t, A> XSIMD_CALLCONV swizzle(batch<uint32_t, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return _mm512_permutexvar_epi32((batch<uint32_t, A>)mask, self);
         }
 
         template <class A, uint32_t... Vs>
-        inline batch<int32_t, A> swizzle(batch<int32_t, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV swizzle(batch<int32_t, A> const& self, batch_constant<batch<uint32_t, A>, Vs...> mask, requires_arch<avx512f>) noexcept
         {
             return bitwise_cast<batch<int32_t, A>>(swizzle(bitwise_cast<batch<uint32_t, A>>(self), mask, avx512f {}));
         }
 
         // trunc
         template <class A>
-        inline batch<float, A> trunc(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV trunc(batch<float, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_round_ps(self, _MM_FROUND_TO_ZERO, _MM_FROUND_CUR_DIRECTION);
         }
         template <class A>
-        inline batch<double, A> trunc(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV trunc(batch<double, A> const& self, requires_arch<avx512f>) noexcept
         {
             return _mm512_roundscale_round_pd(self, _MM_FROUND_TO_ZERO, _MM_FROUND_CUR_DIRECTION);
         }
 
         // zip_hi
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1717,19 +1717,19 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> zip_hi(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_hi(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_unpackhi_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> zip_hi(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_hi(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_unpackhi_pd(self, other);
         }
 
         // zip_lo
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1747,12 +1747,12 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<float, A> zip_lo(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_lo(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_unpacklo_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> zip_lo(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_lo(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
             return _mm512_unpacklo_pd(self, other);
         }

--- a/include/xsimd/arch/xsimd_constants.hpp
+++ b/include/xsimd/arch/xsimd_constants.hpp
@@ -22,38 +22,38 @@ namespace xsimd
     namespace constants
     {
 
-#define XSIMD_DEFINE_CONSTANT(NAME, SINGLE, DOUBLE) \
-    template <class T>                              \
-    inline T NAME() noexcept                        \
-    {                                               \
-        return T(NAME<typename T::value_type>());   \
-    }                                               \
-    template <>                                     \
-    inline float NAME<float>() noexcept             \
-    {                                               \
-        return SINGLE;                              \
-    }                                               \
-    template <>                                     \
-    inline double NAME<double>() noexcept           \
-    {                                               \
-        return DOUBLE;                              \
+#define XSIMD_DEFINE_CONSTANT(NAME, SINGLE, DOUBLE)                 \
+    template <class T>                                              \
+    XSIMD_FORCEINLINE T XSIMD_CALLCONV NAME() noexcept              \
+    {                                                               \
+        return T(NAME<typename T::value_type>());                   \
+    }                                                               \
+    template <>                                                     \
+    XSIMD_FORCEINLINE float XSIMD_CALLCONV NAME<float>() noexcept   \
+    {                                                               \
+        return SINGLE;                                              \
+    }                                                               \
+    template <>                                                     \
+    XSIMD_FORCEINLINE double XSIMD_CALLCONV NAME<double>() noexcept \
+    {                                                               \
+        return DOUBLE;                                              \
     }
 
-#define XSIMD_DEFINE_CONSTANT_HEX(NAME, SINGLE, DOUBLE) \
-    template <class T>                                  \
-    inline T NAME() noexcept                            \
-    {                                                   \
-        return T(NAME<typename T::value_type>());       \
-    }                                                   \
-    template <>                                         \
-    inline float NAME<float>() noexcept                 \
-    {                                                   \
-        return bit_cast<float>((uint32_t)SINGLE);       \
-    }                                                   \
-    template <>                                         \
-    inline double NAME<double>() noexcept               \
-    {                                                   \
-        return bit_cast<double>((uint64_t)DOUBLE);      \
+#define XSIMD_DEFINE_CONSTANT_HEX(NAME, SINGLE, DOUBLE)             \
+    template <class T>                                              \
+    XSIMD_FORCEINLINE T XSIMD_CALLCONV NAME() noexcept              \
+    {                                                               \
+        return T(NAME<typename T::value_type>());                   \
+    }                                                               \
+    template <>                                                     \
+    XSIMD_FORCEINLINE float XSIMD_CALLCONV NAME<float>() noexcept   \
+    {                                                               \
+        return bit_cast<float>((uint32_t)SINGLE);                   \
+    }                                                               \
+    template <>                                                     \
+    XSIMD_FORCEINLINE double XSIMD_CALLCONV NAME<double>() noexcept \
+    {                                                               \
+        return bit_cast<double>((uint64_t)DOUBLE);                  \
     }
 
         XSIMD_DEFINE_CONSTANT(infinity, (std::numeric_limits<float>::infinity()), (std::numeric_limits<double>::infinity()))
@@ -109,31 +109,31 @@ namespace xsimd
 #undef XSIMD_DEFINE_CONSTANT_HEX
 
         template <class T>
-        constexpr T allbits() noexcept;
+        constexpr T XSIMD_CALLCONV allbits() noexcept;
 
         template <class T>
-        constexpr as_integer_t<T> mask1frexp() noexcept;
+        constexpr as_integer_t<T> XSIMD_CALLCONV mask1frexp() noexcept;
 
         template <class T>
-        constexpr as_integer_t<T> mask2frexp() noexcept;
+        constexpr as_integer_t<T> XSIMD_CALLCONV mask2frexp() noexcept;
 
         template <class T>
-        constexpr as_integer_t<T> maxexponent() noexcept;
+        constexpr as_integer_t<T> XSIMD_CALLCONV maxexponent() noexcept;
 
         template <class T>
-        constexpr as_integer_t<T> maxexponentm1() noexcept;
+        constexpr as_integer_t<T> XSIMD_CALLCONV maxexponentm1() noexcept;
 
         template <class T>
-        constexpr int32_t nmb() noexcept;
+        constexpr int32_t XSIMD_CALLCONV nmb() noexcept;
 
         template <class T>
-        constexpr T zero() noexcept;
+        constexpr T XSIMD_CALLCONV zero() noexcept;
 
         template <class T>
-        constexpr T minvalue() noexcept;
+        constexpr T XSIMD_CALLCONV minvalue() noexcept;
 
         template <class T>
-        constexpr T maxvalue() noexcept;
+        constexpr T XSIMD_CALLCONV maxvalue() noexcept;
 
         /**************************
          * allbits implementation *
@@ -144,7 +144,8 @@ namespace xsimd
             template <class T, bool = std::is_integral<T>::value>
             struct allbits_impl
             {
-                static constexpr T get_value() noexcept
+                XSIMD_FORCEINLINE
+                static constexpr T XSIMD_CALLCONV get_value() noexcept
                 {
                     return T(~0);
                 }
@@ -153,7 +154,8 @@ namespace xsimd
             template <class T>
             struct allbits_impl<T, false>
             {
-                static constexpr T get_value() noexcept
+                XSIMD_FORCEINLINE
+                static constexpr T XSIMD_CALLCONV get_value() noexcept
                 {
                     return nan<T>();
                 }
@@ -161,7 +163,7 @@ namespace xsimd
         }
 
         template <class T>
-        inline constexpr T allbits() noexcept
+        XSIMD_FORCEINLINE constexpr T XSIMD_CALLCONV allbits() noexcept
         {
             return T(detail::allbits_impl<typename T::value_type>::get_value());
         }
@@ -171,19 +173,19 @@ namespace xsimd
          *****************************/
 
         template <class T>
-        inline constexpr as_integer_t<T> mask1frexp() noexcept
+        XSIMD_FORCEINLINE constexpr as_integer_t<T> XSIMD_CALLCONV mask1frexp() noexcept
         {
             return as_integer_t<T>(mask1frexp<typename T::value_type>());
         }
 
         template <>
-        inline constexpr int32_t mask1frexp<float>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV mask1frexp<float>() noexcept
         {
             return 0x7f800000;
         }
 
         template <>
-        inline constexpr int64_t mask1frexp<double>() noexcept
+        XSIMD_FORCEINLINE constexpr int64_t XSIMD_CALLCONV mask1frexp<double>() noexcept
         {
             return 0x7ff0000000000000;
         }
@@ -193,19 +195,19 @@ namespace xsimd
          *****************************/
 
         template <class T>
-        inline constexpr as_integer_t<T> mask2frexp() noexcept
+        XSIMD_FORCEINLINE constexpr as_integer_t<T> XSIMD_CALLCONV mask2frexp() noexcept
         {
             return as_integer_t<T>(mask2frexp<typename T::value_type>());
         }
 
         template <>
-        inline constexpr int32_t mask2frexp<float>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV mask2frexp<float>() noexcept
         {
             return 0x3f000000;
         }
 
         template <>
-        inline constexpr int64_t mask2frexp<double>() noexcept
+        XSIMD_FORCEINLINE constexpr int64_t XSIMD_CALLCONV mask2frexp<double>() noexcept
         {
             return 0x3fe0000000000000;
         }
@@ -215,19 +217,19 @@ namespace xsimd
          ******************************/
 
         template <class T>
-        inline constexpr as_integer_t<T> maxexponent() noexcept
+        XSIMD_FORCEINLINE constexpr as_integer_t<T> XSIMD_CALLCONV maxexponent() noexcept
         {
             return as_integer_t<T>(maxexponent<typename T::value_type>());
         }
 
         template <>
-        inline constexpr int32_t maxexponent<float>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV maxexponent<float>() noexcept
         {
             return 127;
         }
 
         template <>
-        inline constexpr int64_t maxexponent<double>() noexcept
+        XSIMD_FORCEINLINE constexpr int64_t XSIMD_CALLCONV maxexponent<double>() noexcept
         {
             return 1023;
         }
@@ -237,19 +239,19 @@ namespace xsimd
          ******************************/
 
         template <class T>
-        inline constexpr as_integer_t<T> maxexponentm1() noexcept
+        XSIMD_FORCEINLINE constexpr as_integer_t<T> XSIMD_CALLCONV maxexponentm1() noexcept
         {
             return as_integer_t<T>(maxexponentm1<typename T::value_type>());
         }
 
         template <>
-        inline constexpr int32_t maxexponentm1<float>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV maxexponentm1<float>() noexcept
         {
             return 126;
         }
 
         template <>
-        inline constexpr int64_t maxexponentm1<double>() noexcept
+        XSIMD_FORCEINLINE constexpr int64_t XSIMD_CALLCONV maxexponentm1<double>() noexcept
         {
             return 1022;
         }
@@ -259,19 +261,19 @@ namespace xsimd
          **********************/
 
         template <class T>
-        inline constexpr int32_t nmb() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV nmb() noexcept
         {
             return nmb<typename T::value_type>();
         }
 
         template <>
-        inline constexpr int32_t nmb<float>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV nmb<float>() noexcept
         {
             return 23;
         }
 
         template <>
-        inline constexpr int32_t nmb<double>() noexcept
+        XSIMD_FORCEINLINE constexpr int32_t XSIMD_CALLCONV nmb<double>() noexcept
         {
             return 52;
         }
@@ -281,7 +283,7 @@ namespace xsimd
          ***********************/
 
         template <class T>
-        inline constexpr T zero() noexcept
+        XSIMD_FORCEINLINE constexpr T XSIMD_CALLCONV zero() noexcept
         {
             return T(typename T::value_type(0));
         }
@@ -295,7 +297,8 @@ namespace xsimd
             template <class T>
             struct minvalue_impl
             {
-                static constexpr T get_value() noexcept
+                XSIMD_FORCEINLINE
+                static constexpr T XSIMD_CALLCONV get_value() noexcept
                 {
                     return std::numeric_limits<typename T::value_type>::min();
                 }
@@ -304,7 +307,8 @@ namespace xsimd
             template <class T>
             struct minvalue_common
             {
-                static constexpr T get_value() noexcept
+                XSIMD_FORCEINLINE
+                static constexpr T XSIMD_CALLCONV get_value() noexcept
                 {
                     return std::numeric_limits<T>::min();
                 }
@@ -346,7 +350,8 @@ namespace xsimd
             template <>
             struct minvalue_impl<float>
             {
-                static float get_value() noexcept
+                XSIMD_FORCEINLINE
+                static float XSIMD_CALLCONV get_value() noexcept
                 {
                     return bit_cast<float>((uint32_t)0xff7fffff);
                 }
@@ -355,7 +360,8 @@ namespace xsimd
             template <>
             struct minvalue_impl<double>
             {
-                static double get_value() noexcept
+                XSIMD_FORCEINLINE
+                static double XSIMD_CALLCONV get_value() noexcept
                 {
                     return bit_cast<double>((uint64_t)0xffefffffffffffff);
                 }
@@ -363,7 +369,7 @@ namespace xsimd
         }
 
         template <class T>
-        inline constexpr T minvalue() noexcept
+        XSIMD_FORCEINLINE constexpr T XSIMD_CALLCONV minvalue() noexcept
         {
             return T(detail::minvalue_impl<typename T::value_type>::get_value());
         }
@@ -373,7 +379,7 @@ namespace xsimd
          ***************************/
 
         template <class T>
-        inline constexpr T maxvalue() noexcept
+        XSIMD_FORCEINLINE constexpr T XSIMD_CALLCONV maxvalue() noexcept
         {
             return T(std::numeric_limits<typename T::value_type>::max());
         }

--- a/include/xsimd/arch/xsimd_fma3_avx.hpp
+++ b/include/xsimd/arch/xsimd_fma3_avx.hpp
@@ -23,52 +23,52 @@ namespace xsimd
 
         // fnma
         template <class A>
-        inline batch<float, A> fnma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fnmadd_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fnmadd_pd(x, y, z);
         }
 
         // fnms
         template <class A>
-        inline batch<float, A> fnms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fnmsub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fnmsub_pd(x, y, z);
         }
 
         // fma
         template <class A>
-        inline batch<float, A> fma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fmadd_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fmadd_pd(x, y, z);
         }
 
         // fms
         template <class A>
-        inline batch<float, A> fms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fmsub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<avx>>) noexcept
         {
             return _mm256_fmsub_pd(x, y, z);
         }

--- a/include/xsimd/arch/xsimd_fma3_sse.hpp
+++ b/include/xsimd/arch/xsimd_fma3_sse.hpp
@@ -22,52 +22,52 @@ namespace xsimd
         using namespace types;
         // fnma
         template <class A>
-        inline batch<float, A> fnma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fnmadd_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fnmadd_pd(x, y, z);
         }
 
         // fnms
         template <class A>
-        inline batch<float, A> fnms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fnmsub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fnmsub_pd(x, y, z);
         }
 
         // fma
         template <class A>
-        inline batch<float, A> fma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fma(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fmadd_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fma(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fmadd_pd(x, y, z);
         }
 
         // fms
         template <class A>
-        inline batch<float, A> fms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fms(batch<float, A> const& x, batch<float, A> const& y, batch<float, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fmsub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fms(batch<double, A> const& x, batch<double, A> const& y, batch<double, A> const& z, requires_arch<fma3<sse4_2>>) noexcept
         {
             return _mm_fmsub_pd(x, y, z);
         }

--- a/include/xsimd/arch/xsimd_fma4.hpp
+++ b/include/xsimd/arch/xsimd_fma4.hpp
@@ -23,52 +23,52 @@ namespace xsimd
 
         // fnma
         template <class A>
-        inline batch<float, A> fnma(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnma(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_nmacc_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnma(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnma(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_nmacc_pd(x, y, z);
         }
 
         // fnms
         template <class A>
-        inline batch<float, A> fnms(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fnms(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_nmsub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fnms(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fnms(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_nmsub_pd(x, y, z);
         }
 
         // fma
         template <class A>
-        inline batch<float, A> fma(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fma(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_macc_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fma(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fma(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_macc_pd(x, y, z);
         }
 
         // fms
         template <class A>
-        inline batch<float, A> fms(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV fms(simd_register<float, A> const& x, simd_register<float, A> const& y, simd_register<float, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_msub_ps(x, y, z);
         }
 
         template <class A>
-        inline batch<double, A> fms(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV fms(simd_register<double, A> const& x, simd_register<double, A> const& y, simd_register<double, A> const& z, requires_arch<fma4>) noexcept
         {
             return _mm_msub_pd(x, y, z);
         }

--- a/include/xsimd/arch/xsimd_generic_fwd.hpp
+++ b/include/xsimd/arch/xsimd_generic_fwd.hpp
@@ -21,15 +21,15 @@ namespace xsimd
     {
         // forward declaration
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& self, requires_arch<generic>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
         template <class A, class T>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
+        inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<generic>) noexcept;
 
     }
 }

--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -23,120 +23,120 @@
 // Wrap intrinsics so we can pass them as function pointers
 // - OP: intrinsics name prefix, e.g., vorrq
 // - RT: type traits to deduce intrinsics return types
-#define WRAP_BINARY_INT_EXCLUDING_64(OP, RT)                                \
-    namespace wrap                                                          \
-    {                                                                       \
-        inline RT<uint8x16_t> OP##_u8(uint8x16_t a, uint8x16_t b) noexcept  \
-        {                                                                   \
-            return ::OP##_u8(a, b);                                         \
-        }                                                                   \
-        inline RT<int8x16_t> OP##_s8(int8x16_t a, int8x16_t b) noexcept     \
-        {                                                                   \
-            return ::OP##_s8(a, b);                                         \
-        }                                                                   \
-        inline RT<uint16x8_t> OP##_u16(uint16x8_t a, uint16x8_t b) noexcept \
-        {                                                                   \
-            return ::OP##_u16(a, b);                                        \
-        }                                                                   \
-        inline RT<int16x8_t> OP##_s16(int16x8_t a, int16x8_t b) noexcept    \
-        {                                                                   \
-            return ::OP##_s16(a, b);                                        \
-        }                                                                   \
-        inline RT<uint32x4_t> OP##_u32(uint32x4_t a, uint32x4_t b) noexcept \
-        {                                                                   \
-            return ::OP##_u32(a, b);                                        \
-        }                                                                   \
-        inline RT<int32x4_t> OP##_s32(int32x4_t a, int32x4_t b) noexcept    \
-        {                                                                   \
-            return ::OP##_s32(a, b);                                        \
-        }                                                                   \
+#define WRAP_BINARY_INT_EXCLUDING_64(OP, RT)                                               \
+    namespace wrap                                                                         \
+    {                                                                                      \
+        inline RT<uint8x16_t> XSIMD_CALLCONV OP##_u8(uint8x16_t a, uint8x16_t b) noexcept  \
+        {                                                                                  \
+            return ::OP##_u8(a, b);                                                        \
+        }                                                                                  \
+        inline RT<int8x16_t> XSIMD_CALLCONV OP##_s8(int8x16_t a, int8x16_t b) noexcept     \
+        {                                                                                  \
+            return ::OP##_s8(a, b);                                                        \
+        }                                                                                  \
+        inline RT<uint16x8_t> XSIMD_CALLCONV OP##_u16(uint16x8_t a, uint16x8_t b) noexcept \
+        {                                                                                  \
+            return ::OP##_u16(a, b);                                                       \
+        }                                                                                  \
+        inline RT<int16x8_t> XSIMD_CALLCONV OP##_s16(int16x8_t a, int16x8_t b) noexcept    \
+        {                                                                                  \
+            return ::OP##_s16(a, b);                                                       \
+        }                                                                                  \
+        inline RT<uint32x4_t> XSIMD_CALLCONV OP##_u32(uint32x4_t a, uint32x4_t b) noexcept \
+        {                                                                                  \
+            return ::OP##_u32(a, b);                                                       \
+        }                                                                                  \
+        inline RT<int32x4_t> XSIMD_CALLCONV OP##_s32(int32x4_t a, int32x4_t b) noexcept    \
+        {                                                                                  \
+            return ::OP##_s32(a, b);                                                       \
+        }                                                                                  \
     }
 
-#define WRAP_BINARY_INT(OP, RT)                                             \
-    WRAP_BINARY_INT_EXCLUDING_64(OP, RT)                                    \
-    namespace wrap                                                          \
-    {                                                                       \
-        inline RT<uint64x2_t> OP##_u64(uint64x2_t a, uint64x2_t b) noexcept \
-        {                                                                   \
-            return ::OP##_u64(a, b);                                        \
-        }                                                                   \
-        inline RT<int64x2_t> OP##_s64(int64x2_t a, int64x2_t b) noexcept    \
-        {                                                                   \
-            return ::OP##_s64(a, b);                                        \
-        }                                                                   \
+#define WRAP_BINARY_INT(OP, RT)                                                            \
+    WRAP_BINARY_INT_EXCLUDING_64(OP, RT)                                                   \
+    namespace wrap                                                                         \
+    {                                                                                      \
+        inline RT<uint64x2_t> XSIMD_CALLCONV OP##_u64(uint64x2_t a, uint64x2_t b) noexcept \
+        {                                                                                  \
+            return ::OP##_u64(a, b);                                                       \
+        }                                                                                  \
+        inline RT<int64x2_t> XSIMD_CALLCONV OP##_s64(int64x2_t a, int64x2_t b) noexcept    \
+        {                                                                                  \
+            return ::OP##_s64(a, b);                                                       \
+        }                                                                                  \
     }
 
-#define WRAP_BINARY_FLOAT(OP, RT)                                              \
-    namespace wrap                                                             \
-    {                                                                          \
-        inline RT<float32x4_t> OP##_f32(float32x4_t a, float32x4_t b) noexcept \
-        {                                                                      \
-            return ::OP##_f32(a, b);                                           \
-        }                                                                      \
+#define WRAP_BINARY_FLOAT(OP, RT)                                                             \
+    namespace wrap                                                                            \
+    {                                                                                         \
+        inline RT<float32x4_t> XSIMD_CALLCONV OP##_f32(float32x4_t a, float32x4_t b) noexcept \
+        {                                                                                     \
+            return ::OP##_f32(a, b);                                                          \
+        }                                                                                     \
     }
 
-#define WRAP_UNARY_INT_EXCLUDING_64(OP)                   \
-    namespace wrap                                        \
-    {                                                     \
-        inline uint8x16_t OP##_u8(uint8x16_t a) noexcept  \
-        {                                                 \
-            return ::OP##_u8(a);                          \
-        }                                                 \
-        inline int8x16_t OP##_s8(int8x16_t a) noexcept    \
-        {                                                 \
-            return ::OP##_s8(a);                          \
-        }                                                 \
-        inline uint16x8_t OP##_u16(uint16x8_t a) noexcept \
-        {                                                 \
-            return ::OP##_u16(a);                         \
-        }                                                 \
-        inline int16x8_t OP##_s16(int16x8_t a) noexcept   \
-        {                                                 \
-            return ::OP##_s16(a);                         \
-        }                                                 \
-        inline uint32x4_t OP##_u32(uint32x4_t a) noexcept \
-        {                                                 \
-            return ::OP##_u32(a);                         \
-        }                                                 \
-        inline int32x4_t OP##_s32(int32x4_t a) noexcept   \
-        {                                                 \
-            return ::OP##_s32(a);                         \
-        }                                                 \
+#define WRAP_UNARY_INT_EXCLUDING_64(OP)                                  \
+    namespace wrap                                                       \
+    {                                                                    \
+        inline uint8x16_t XSIMD_CALLCONV OP##_u8(uint8x16_t a) noexcept  \
+        {                                                                \
+            return ::OP##_u8(a);                                         \
+        }                                                                \
+        inline int8x16_t XSIMD_CALLCONV OP##_s8(int8x16_t a) noexcept    \
+        {                                                                \
+            return ::OP##_s8(a);                                         \
+        }                                                                \
+        inline uint16x8_t XSIMD_CALLCONV OP##_u16(uint16x8_t a) noexcept \
+        {                                                                \
+            return ::OP##_u16(a);                                        \
+        }                                                                \
+        inline int16x8_t XSIMD_CALLCONV OP##_s16(int16x8_t a) noexcept   \
+        {                                                                \
+            return ::OP##_s16(a);                                        \
+        }                                                                \
+        inline uint32x4_t XSIMD_CALLCONV OP##_u32(uint32x4_t a) noexcept \
+        {                                                                \
+            return ::OP##_u32(a);                                        \
+        }                                                                \
+        inline int32x4_t XSIMD_CALLCONV OP##_s32(int32x4_t a) noexcept   \
+        {                                                                \
+            return ::OP##_s32(a);                                        \
+        }                                                                \
     }
 
-#define WRAP_UNARY_INT(OP)                                \
-    WRAP_UNARY_INT_EXCLUDING_64(OP)                       \
-    namespace wrap                                        \
-    {                                                     \
-        inline uint64x2_t OP##_u64(uint64x2_t a) noexcept \
-        {                                                 \
-            return ::OP##_u64(a);                         \
-        }                                                 \
-        inline int64x2_t OP##_s64(int64x2_t a) noexcept   \
-        {                                                 \
-            return ::OP##_s64(a);                         \
-        }                                                 \
+#define WRAP_UNARY_INT(OP)                                               \
+    WRAP_UNARY_INT_EXCLUDING_64(OP)                                      \
+    namespace wrap                                                       \
+    {                                                                    \
+        inline uint64x2_t XSIMD_CALLCONV OP##_u64(uint64x2_t a) noexcept \
+        {                                                                \
+            return ::OP##_u64(a);                                        \
+        }                                                                \
+        inline int64x2_t XSIMD_CALLCONV OP##_s64(int64x2_t a) noexcept   \
+        {                                                                \
+            return ::OP##_s64(a);                                        \
+        }                                                                \
     }
 
-#define WRAP_UNARY_FLOAT(OP)                                \
-    namespace wrap                                          \
-    {                                                       \
-        inline float32x4_t OP##_f32(float32x4_t a) noexcept \
-        {                                                   \
-            return ::OP##_f32(a);                           \
-        }                                                   \
+#define WRAP_UNARY_FLOAT(OP)                                               \
+    namespace wrap                                                         \
+    {                                                                      \
+        inline float32x4_t XSIMD_CALLCONV OP##_f32(float32x4_t a) noexcept \
+        {                                                                  \
+            return ::OP##_f32(a);                                          \
+        }                                                                  \
     }
 
 // Dummy identity caster to ease coding
-inline uint8x16_t vreinterpretq_u8_u8(uint8x16_t arg) noexcept { return arg; }
-inline int8x16_t vreinterpretq_s8_s8(int8x16_t arg) noexcept { return arg; }
-inline uint16x8_t vreinterpretq_u16_u16(uint16x8_t arg) noexcept { return arg; }
-inline int16x8_t vreinterpretq_s16_s16(int16x8_t arg) noexcept { return arg; }
-inline uint32x4_t vreinterpretq_u32_u32(uint32x4_t arg) noexcept { return arg; }
-inline int32x4_t vreinterpretq_s32_s32(int32x4_t arg) noexcept { return arg; }
-inline uint64x2_t vreinterpretq_u64_u64(uint64x2_t arg) noexcept { return arg; }
-inline int64x2_t vreinterpretq_s64_s64(int64x2_t arg) noexcept { return arg; }
-inline float32x4_t vreinterpretq_f32_f32(float32x4_t arg) noexcept { return arg; }
+inline uint8x16_t XSIMD_CALLCONV vreinterpretq_u8_u8(uint8x16_t arg) noexcept { return arg; }
+inline int8x16_t XSIMD_CALLCONV vreinterpretq_s8_s8(int8x16_t arg) noexcept { return arg; }
+inline uint16x8_t XSIMD_CALLCONV vreinterpretq_u16_u16(uint16x8_t arg) noexcept { return arg; }
+inline int16x8_t XSIMD_CALLCONV vreinterpretq_s16_s16(int16x8_t arg) noexcept { return arg; }
+inline uint32x4_t XSIMD_CALLCONV vreinterpretq_u32_u32(uint32x4_t arg) noexcept { return arg; }
+inline int32x4_t XSIMD_CALLCONV vreinterpretq_s32_s32(int32x4_t arg) noexcept { return arg; }
+inline uint64x2_t XSIMD_CALLCONV vreinterpretq_u64_u64(uint64x2_t arg) noexcept { return arg; }
+inline int64x2_t XSIMD_CALLCONV vreinterpretq_s64_s64(int64x2_t arg) noexcept { return arg; }
+inline float32x4_t XSIMD_CALLCONV vreinterpretq_f32_f32(float32x4_t arg) noexcept { return arg; }
 
 namespace xsimd
 {

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -32,17 +32,17 @@ namespace xsimd
 
         // fwd
         template <class A, class T, size_t I>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I>, requires_arch<generic>) noexcept;
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> XSIMD_CREF self, T val, index<I>, requires_arch<generic>) noexcept;
 
         // abs
         template <class A>
-        inline batch<double, A> abs(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV abs(batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             __m128d sign_mask = _mm_set1_pd(-0.f); // -0.f = 1 << 31
             return _mm_andnot_pd(sign_mask, self);
         }
         template <class A>
-        inline batch<float, A> abs(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV abs(batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             __m128 sign_mask = _mm_set1_ps(-0.f); // -0.f = 1 << 31
             return _mm_andnot_ps(sign_mask, self);
@@ -50,7 +50,7 @@ namespace xsimd
 
         // add
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> add(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV add(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -69,123 +69,123 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<float, A> add(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV add(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_add_ps(self, other);
         }
 
         template <class A>
-        inline batch<double, A> add(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV add(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_add_pd(self, other);
         }
 
         // all
         template <class A>
-        inline bool all(batch_bool<float, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_ps(self) == 0x0F;
         }
         template <class A>
-        inline bool all(batch_bool<double, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_pd(self) == 0x03;
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline bool all(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV all(batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_epi8(self) == 0xFFFF;
         }
 
         // any
         template <class A>
-        inline bool any(batch_bool<float, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_ps(self) != 0;
         }
         template <class A>
-        inline bool any(batch_bool<double, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_pd(self) != 0;
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline bool any(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline bool XSIMD_CALLCONV any(batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_epi8(self) != 0;
         }
 
         // bitwise_and
         template <class A>
-        inline batch<float, A> bitwise_and(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_and(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_ps(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_and(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_and(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_and(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_and(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_si128(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_and(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_si128(self, other);
         }
 
         template <class A>
-        batch<double, A> inline bitwise_and(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_and(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_pd(self, other);
         }
 
         template <class A>
-        inline batch_bool<double, A> bitwise_and(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_and(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_and_pd(self, other);
         }
 
         // bitwise_andnot
         template <class A>
-        inline batch<float, A> bitwise_andnot(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_andnot(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_ps(self, other);
         }
 
         template <class A>
-        inline batch_bool<float, A> bitwise_andnot(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_andnot(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_andnot(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_si128(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_si128(self, other);
         }
 
         template <class A>
-        inline batch<double, A> bitwise_andnot(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_andnot(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_pd(self, other);
         }
 
         template <class A>
-        inline batch_bool<double, A> bitwise_andnot(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_andnot_pd(self, other);
         }
 
         // bitwise_lshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& self, int32_t other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_lshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -205,73 +205,73 @@ namespace xsimd
 
         // bitwise_not
         template <class A>
-        inline batch<float, A> bitwise_not(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_not(batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_ps(self, _mm_castsi128_ps(_mm_set1_epi32(-1)));
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_not(batch_bool<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_not(batch_bool<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_ps(self, _mm_castsi128_ps(_mm_set1_epi32(-1)));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_not(batch<T, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_not(batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_si128(self, _mm_set1_epi32(-1));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_not(batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_si128(self, _mm_set1_epi32(-1));
         }
         template <class A>
-        inline batch<double, A> bitwise_not(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_not(batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_pd(self, _mm_castsi128_pd(_mm_set1_epi32(-1)));
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_not(batch_bool<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_not(batch_bool<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_pd(self, _mm_castsi128_pd(_mm_set1_epi32(-1)));
         }
 
         // bitwise_or
         template <class A>
-        inline batch<float, A> bitwise_or(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_or(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_ps(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_or(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_or(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_or(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_or(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_si128(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV bitwise_or(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_si128(self, other);
         }
 
         template <class A>
-        inline batch<double, A> bitwise_or(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_or(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_pd(self, other);
         }
 
         template <class A>
-        inline batch_bool<double, A> bitwise_or(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_or(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_or_pd(self, other);
         }
 
         // bitwise_rshift
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& self, int32_t other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_rshift(batch<T, A> XSIMD_CREF self, int32_t other, requires_arch<sse2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -323,103 +323,103 @@ namespace xsimd
 
         // bitwise_xor
         template <class A>
-        inline batch<float, A> bitwise_xor(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_xor(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_ps(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> bitwise_xor(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bitwise_xor(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_si128(self, other);
         }
         template <class A>
-        inline batch<double, A> bitwise_xor(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_xor(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_pd(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> bitwise_xor(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bitwise_xor(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_pd(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_xor(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_xor(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_xor_si128(self, other);
         }
 
         // bitwise_cast
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<float, A> bitwise_cast(batch<T, A> const& self, batch<float, A> const&, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_ps(self);
         }
         template <class A, class T, class Tp, class = typename std::enable_if<std::is_integral<typename std::common_type<T, Tp>::type>::value, void>::type>
-        inline batch<Tp, A> bitwise_cast(batch<T, A> const& self, batch<Tp, A> const&, requires_arch<sse2>) noexcept
+        inline batch<Tp, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<Tp, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return batch<Tp, A>(self.data);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<float, A> const& self, batch<T, A> const&, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castps_si128(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<double, A> bitwise_cast(batch<T, A> const& self, batch<double, A> const&, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<T, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_pd(self);
         }
         template <class A>
-        inline batch<double, A> bitwise_cast(batch<float, A> const& self, batch<double, A> const&, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV bitwise_cast(batch<float, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castps_pd(self);
         }
         template <class A>
-        inline batch<float, A> bitwise_cast(batch<double, A> const& self, batch<float, A> const&, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castpd_ps(self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> bitwise_cast(batch<double, A> const& self, batch<T, A> const&, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch<double, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF, requires_arch<sse2>) noexcept
         {
             return _mm_castpd_si128(self);
         }
 
         // bool_cast
         template <class A>
-        batch_bool<int32_t, A> inline bool_cast(batch_bool<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<int32_t, A> XSIMD_CALLCONV bool_cast(batch_bool<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_castps_si128(self);
         }
         template <class A>
-        batch_bool<float, A> inline bool_cast(batch_bool<int32_t, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV bool_cast(batch_bool<int32_t, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_ps(self);
         }
         template <class A>
-        batch_bool<int64_t, A> inline bool_cast(batch_bool<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<int64_t, A> XSIMD_CALLCONV bool_cast(batch_bool<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_castpd_si128(self);
         }
         template <class A>
-        batch_bool<double, A> inline bool_cast(batch_bool<int64_t, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV bool_cast(batch_bool<int64_t, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_pd(self);
         }
 
         // broadcast
         template <class A>
-        batch<float, A> inline broadcast(float val, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV broadcast(float val, requires_arch<sse2>) noexcept
         {
             return _mm_set1_ps(val);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> broadcast(T val, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV broadcast(T val, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -437,7 +437,7 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<double, A> broadcast(double val, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV broadcast(double val, requires_arch<sse2>) noexcept
         {
             return _mm_set1_pd(val);
         }
@@ -448,23 +448,23 @@ namespace xsimd
             // Override these methods in SSE-based archs, no need to override store_aligned / store_unaligned
             // complex_low
             template <class A>
-            inline batch<float, A> complex_low(batch<std::complex<float>, A> const& self, requires_arch<sse2>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_low(batch<std::complex<float>, A> const& self, requires_arch<sse2>) noexcept
             {
                 return _mm_unpacklo_ps(self.real(), self.imag());
             }
             // complex_high
             template <class A>
-            inline batch<float, A> complex_high(batch<std::complex<float>, A> const& self, requires_arch<sse2>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV complex_high(batch<std::complex<float>, A> const& self, requires_arch<sse2>) noexcept
             {
                 return _mm_unpackhi_ps(self.real(), self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_low(batch<std::complex<double>, A> const& self, requires_arch<sse2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_low(batch<std::complex<double>, A> const& self, requires_arch<sse2>) noexcept
             {
                 return _mm_unpacklo_pd(self.real(), self.imag());
             }
             template <class A>
-            inline batch<double, A> complex_high(batch<std::complex<double>, A> const& self, requires_arch<sse2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV complex_high(batch<std::complex<double>, A> const& self, requires_arch<sse2>) noexcept
             {
                 return _mm_unpackhi_pd(self.real(), self.imag());
             }
@@ -472,12 +472,12 @@ namespace xsimd
 
         // div
         template <class A>
-        inline batch<float, A> div(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV div(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_div_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> div(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV div(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_div_pd(self, other);
         }
@@ -486,13 +486,13 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<float, A> fast_cast(batch<int32_t, A> const& self, batch<float, A> const&, requires_arch<sse2>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<int32_t, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 return _mm_cvtepi32_ps(self);
             }
 
             template <class A>
-            inline batch<float, A> fast_cast(batch<uint32_t, A> const& v, batch<float, A> const&, requires_arch<sse2>) noexcept
+            inline batch<float, A> XSIMD_CALLCONV fast_cast(batch<uint32_t, A> XSIMD_CREF v, batch<float, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 // see https://stackoverflow.com/questions/34066228/how-to-perform-uint32-float-conversion-with-sse
                 __m128i msk_lo = _mm_set1_epi32(0xFFFF);
@@ -507,7 +507,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> fast_cast(batch<uint64_t, A> const& x, batch<double, A> const&, requires_arch<sse2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<uint64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 // adapted to sse2
@@ -520,7 +520,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> fast_cast(batch<int64_t, A> const& x, batch<double, A> const&, requires_arch<sse2>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<int64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 // adapted to sse2
@@ -534,13 +534,13 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<int32_t, A> fast_cast(batch<float, A> const& self, batch<int32_t, A> const&, requires_arch<sse2>) noexcept
+            inline batch<int32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> XSIMD_CREF self, batch<int32_t, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 return _mm_cvttps_epi32(self);
             }
 
             template <class A>
-            inline batch<uint32_t, A> fast_cast(batch<float, A> const& self, batch<uint32_t, A> const&, requires_arch<sse2>) noexcept
+            inline batch<uint32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> XSIMD_CREF self, batch<uint32_t, A> XSIMD_CREF, requires_arch<sse2>) noexcept
             {
                 __m128 mask = _mm_cmpge_ps(self, _mm_set1_ps(1u << 31));
                 __m128 lhs = _mm_castsi128_ps(_mm_cvttps_epi32(self));
@@ -554,17 +554,17 @@ namespace xsimd
 
         // eq
         template <class A>
-        inline batch_bool<float, A> eq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV eq(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpeq_ps(self, other);
         }
         template <class A>
-        inline batch_bool<float, A> eq(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV eq(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_ps(_mm_cmpeq_epi32(_mm_castps_si128(self), _mm_castps_si128(other)));
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -588,24 +588,24 @@ namespace xsimd
             }
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return eq(batch<T, A>(self.data), batch<T, A>(other.data));
         }
         template <class A>
-        inline batch_bool<double, A> eq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV eq(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpeq_pd(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> eq(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV eq(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_castsi128_pd(_mm_cmpeq_epi32(_mm_castpd_si128(self), _mm_castpd_si128(other)));
         }
 
         // from_mask
         template <class A>
-        inline batch_bool<float, A> from_mask(batch_bool<float, A> const&, uint64_t mask, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV from_mask(batch_bool<float, A> XSIMD_CREF, uint64_t mask, requires_arch<sse2>) noexcept
         {
             alignas(A::alignment()) static const uint32_t lut[][4] = {
                 { 0x00000000, 0x00000000, 0x00000000, 0x00000000 },
@@ -629,7 +629,7 @@ namespace xsimd
             return _mm_castsi128_ps(_mm_load_si128((const __m128i*)lut[mask]));
         }
         template <class A>
-        inline batch_bool<double, A> from_mask(batch_bool<double, A> const&, uint64_t mask, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV from_mask(batch_bool<double, A> XSIMD_CREF, uint64_t mask, requires_arch<sse2>) noexcept
         {
             alignas(A::alignment()) static const uint64_t lut[][4] = {
                 { 0x0000000000000000ul, 0x0000000000000000ul },
@@ -641,7 +641,7 @@ namespace xsimd
             return _mm_castsi128_pd(_mm_load_si128((const __m128i*)lut[mask]));
         }
         template <class T, class A, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> from_mask(batch_bool<T, A> const&, uint64_t mask, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV from_mask(batch_bool<T, A> XSIMD_CREF, uint64_t mask, requires_arch<sse2>) noexcept
         {
             alignas(A::alignment()) static const uint64_t lut64[] = {
                 0x0000000000000000,
@@ -696,24 +696,24 @@ namespace xsimd
 
         // ge
         template <class A>
-        inline batch_bool<float, A> ge(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV ge(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpge_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> ge(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV ge(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpge_pd(self, other);
         }
 
         // gt
         template <class A>
-        inline batch_bool<float, A> gt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV gt(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpgt_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -736,14 +736,14 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch_bool<double, A> gt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV gt(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpgt_pd(self, other);
         }
 
         // hadd
         template <class A>
-        inline float hadd(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline float XSIMD_CALLCONV hadd(batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             __m128 tmp0 = _mm_add_ps(self, _mm_movehl_ps(self, self));
             __m128 tmp1 = _mm_add_ss(tmp0, _mm_shuffle_ps(tmp0, tmp0, 1));
@@ -753,7 +753,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-            inline T hadd_default(batch<T, A> const& self, requires_arch<sse2>) noexcept
+            inline T XSIMD_CALLCONV hadd_default(batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
             {
                 alignas(A::alignment()) T buffer[batch<T, A>::size];
                 self.store_aligned(buffer);
@@ -766,7 +766,7 @@ namespace xsimd
             }
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline T hadd(batch<T, A> const& self, requires_arch<sse2>) noexcept
+        inline T XSIMD_CALLCONV hadd(batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -797,14 +797,14 @@ namespace xsimd
             }
         }
         template <class A>
-        inline double hadd(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline double XSIMD_CALLCONV hadd(batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_cvtsd_f64(_mm_add_sd(self, _mm_unpackhi_pd(self, self)));
         }
 
         // haddp
         template <class A>
-        inline batch<float, A> haddp(batch<float, A> const* row, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV haddp(batch<float, A> const* row, requires_arch<sse2>) noexcept
         {
             __m128 tmp0 = _mm_unpacklo_ps(row[0], row[1]);
             __m128 tmp1 = _mm_unpackhi_ps(row[0], row[1]);
@@ -817,7 +817,7 @@ namespace xsimd
             return _mm_add_ps(tmp0, tmp2);
         }
         template <class A>
-        inline batch<double, A> haddp(batch<double, A> const* row, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV haddp(batch<double, A> const* row, requires_arch<sse2>) noexcept
         {
             return _mm_add_pd(_mm_unpacklo_pd(row[0], row[1]),
                               _mm_unpackhi_pd(row[0], row[1]));
@@ -825,7 +825,7 @@ namespace xsimd
 
         // insert
         template <class A, class T, size_t I, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I> pos, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> XSIMD_CREF self, T val, index<I> pos, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -838,46 +838,46 @@ namespace xsimd
 
         // isnan
         template <class A>
-        inline batch_bool<float, A> isnan(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV isnan(batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_cmpunord_ps(self, self);
         }
         template <class A>
-        inline batch_bool<double, A> isnan(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV isnan(batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_cmpunord_pd(self, self);
         }
 
         // load_aligned
         template <class A>
-        inline batch<float, A> load_aligned(float const* mem, convert<float>, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_aligned(float const* mem, convert<float>, requires_arch<sse2>) noexcept
         {
             return _mm_load_ps(mem);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_aligned(T const* mem, convert<T>, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_aligned(T const* mem, convert<T>, requires_arch<sse2>) noexcept
         {
             return _mm_load_si128((__m128i const*)mem);
         }
         template <class A>
-        inline batch<double, A> load_aligned(double const* mem, convert<double>, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_aligned(double const* mem, convert<double>, requires_arch<sse2>) noexcept
         {
             return _mm_load_pd(mem);
         }
 
         // load_unaligned
         template <class A>
-        inline batch<float, A> load_unaligned(float const* mem, convert<float>, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV load_unaligned(float const* mem, convert<float>, requires_arch<sse2>) noexcept
         {
             return _mm_loadu_ps(mem);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_unaligned(T const* mem, convert<T>, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_unaligned(T const* mem, convert<T>, requires_arch<sse2>) noexcept
         {
             return _mm_loadu_si128((__m128i const*)mem);
         }
         template <class A>
-        inline batch<double, A> load_unaligned(double const* mem, convert<double>, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV load_unaligned(double const* mem, convert<double>, requires_arch<sse2>) noexcept
         {
             return _mm_loadu_pd(mem);
         }
@@ -887,12 +887,12 @@ namespace xsimd
         {
             // Redefine these methods in the SSE-based archs if required
             template <class A>
-            inline batch<std::complex<float>, A> load_complex(batch<float, A> const& hi, batch<float, A> const& lo, requires_arch<sse2>) noexcept
+            inline batch<std::complex<float>, A> XSIMD_CALLCONV load_complex(batch<float, A> XSIMD_CREF hi, batch<float, A> XSIMD_CREF lo, requires_arch<sse2>) noexcept
             {
                 return { _mm_shuffle_ps(hi, lo, _MM_SHUFFLE(2, 0, 2, 0)), _mm_shuffle_ps(hi, lo, _MM_SHUFFLE(3, 1, 3, 1)) };
             }
             template <class A>
-            inline batch<std::complex<double>, A> load_complex(batch<double, A> const& hi, batch<double, A> const& lo, requires_arch<sse2>) noexcept
+            inline batch<std::complex<double>, A> XSIMD_CALLCONV load_complex(batch<double, A> XSIMD_CREF hi, batch<double, A> XSIMD_CREF lo, requires_arch<sse2>) noexcept
             {
                 return { _mm_shuffle_pd(hi, lo, _MM_SHUFFLE2(0, 0)), _mm_shuffle_pd(hi, lo, _MM_SHUFFLE2(1, 1)) };
             }
@@ -900,24 +900,24 @@ namespace xsimd
 
         // le
         template <class A>
-        inline batch_bool<float, A> le(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV le(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmple_ps(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> le(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV le(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmple_pd(self, other);
         }
 
         // lt
         template <class A>
-        inline batch_bool<float, A> lt(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV lt(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmplt_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -974,7 +974,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch_bool<double, A> lt(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV lt(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmplt_pd(self, other);
         }
@@ -984,7 +984,7 @@ namespace xsimd
          */
         namespace detail
         {
-            inline int mask_lut(int mask)
+            inline int XSIMD_CALLCONV mask_lut(int mask) noexcept
             {
                 // clang-format off
                 static const int mask_lut[256] = {
@@ -1012,7 +1012,7 @@ namespace xsimd
 
         // mask
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline uint64_t mask(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1033,85 +1033,85 @@ namespace xsimd
             }
         }
         template <class A>
-        inline uint64_t mask(batch_bool<float, A> const& self, requires_arch<sse2>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_ps(self);
         }
 
         template <class A>
-        inline uint64_t mask(batch_bool<double, A> const& self, requires_arch<sse2>) noexcept
+        inline uint64_t XSIMD_CALLCONV mask(batch_bool<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_movemask_pd(self);
         }
 
         // max
         template <class A>
-        inline batch<float, A> max(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV max(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_max_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return select(self > other, self, other);
         }
         template <class A>
-        inline batch<double, A> max(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV max(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_max_pd(self, other);
         }
 
         // min
         template <class A>
-        inline batch<float, A> min(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV min(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_min_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return select(self <= other, self, other);
         }
         template <class A>
-        inline batch<double, A> min(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV min(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_min_pd(self, other);
         }
 
         // mul
         template <class A>
-        inline batch<float, A> mul(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV mul(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_mul_ps(self, other);
         }
         template <class A>
-        inline batch<double, A> mul(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV mul(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_mul_pd(self, other);
         }
 
         // nearbyint_as_int
         template <class A>
-        inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& self,
-                                                  requires_arch<sse2>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV nearbyint_as_int(batch<float, A> XSIMD_CREF self,
+                                                                 requires_arch<sse2>) noexcept
         {
             return _mm_cvtps_epi32(self);
         }
 
         // neg
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> neg(batch<T, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV neg(batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return 0 - self;
         }
         template <class A>
-        inline batch<float, A> neg(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV neg(batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_ps(self, _mm_castsi128_ps(_mm_set1_epi32(0x80000000)));
         }
 
         template <class A>
-        inline batch<double, A> neg(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV neg(batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_xor_pd(
                 self, _mm_castsi128_pd(_mm_setr_epi32(0, 0x80000000, 0, 0x80000000)));
@@ -1119,109 +1119,109 @@ namespace xsimd
 
         // neq
         template <class A>
-        inline batch_bool<float, A> neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV neq(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpneq_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return ~(self == other);
         }
         template <class A>
-        inline batch_bool<float, A> neq(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV neq(batch_bool<float, A> XSIMD_CREF self, batch_bool<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpneq_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> neq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV neq(batch_bool<T, A> XSIMD_CREF self, batch_bool<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return ~(self == other);
         }
 
         template <class A>
-        inline batch_bool<double, A> neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV neq(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpneq_pd(self, other);
         }
         template <class A>
-        inline batch_bool<double, A> neq(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV neq(batch_bool<double, A> XSIMD_CREF self, batch_bool<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_cmpneq_pd(self, other);
         }
 
         // reciprocal
         template <class A>
-        inline batch<float, A> reciprocal(batch<float, A> const& self,
-                                          kernel::requires_arch<sse2>)
+        inline batch<float, A> XSIMD_CALLCONV reciprocal(batch<float, A> XSIMD_CREF self,
+                                                         kernel::requires_arch<sse2>)
         {
             return _mm_rcp_ps(self);
         }
 
         // rsqrt
         template <class A>
-        inline batch<float, A> rsqrt(batch<float, A> const& val, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV rsqrt(batch<float, A> XSIMD_CREF val, requires_arch<sse2>) noexcept
         {
             return _mm_rsqrt_ps(val);
         }
         template <class A>
-        inline batch<double, A> rsqrt(batch<double, A> const& val, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV rsqrt(batch<double, A> XSIMD_CREF val, requires_arch<sse2>) noexcept
         {
             return _mm_cvtps_pd(_mm_rsqrt_ps(_mm_cvtpd_ps(val)));
         }
 
         // select
         template <class A>
-        inline batch<float, A> select(batch_bool<float, A> const& cond, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool<float, A> XSIMD_CREF cond, batch<float, A> XSIMD_CREF true_br, batch<float, A> XSIMD_CREF false_br, requires_arch<sse2>) noexcept
         {
             return _mm_or_ps(_mm_and_ps(cond, true_br), _mm_andnot_ps(cond, false_br));
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> XSIMD_CREF cond, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<sse2>) noexcept
         {
             return _mm_or_si128(_mm_and_si128(cond, true_br), _mm_andnot_si128(cond, false_br));
         }
         template <class A, class T, bool... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<sse2>) noexcept
         {
             return select(batch_bool<T, A> { Values... }, true_br, false_br, sse2 {});
         }
         template <class A>
-        inline batch<double, A> select(batch_bool<double, A> const& cond, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool<double, A> XSIMD_CREF cond, batch<double, A> XSIMD_CREF true_br, batch<double, A> XSIMD_CREF false_br, requires_arch<sse2>) noexcept
         {
             return _mm_or_pd(_mm_and_pd(cond, true_br), _mm_andnot_pd(cond, false_br));
         }
 
         // sqrt
         template <class A>
-        inline batch<float, A> sqrt(batch<float, A> const& val, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sqrt(batch<float, A> XSIMD_CREF val, requires_arch<sse2>) noexcept
         {
             return _mm_sqrt_ps(val);
         }
         template <class A>
-        inline batch<double, A> sqrt(batch<double, A> const& val, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sqrt(batch<double, A> XSIMD_CREF val, requires_arch<sse2>) noexcept
         {
             return _mm_sqrt_pd(val);
         }
 
         // slide_left
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_left(batch<T, A> const& x, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_left(batch<T, A> XSIMD_CREF x, requires_arch<sse2>) noexcept
         {
             return _mm_slli_si128(x, N);
         }
 
         // slide_right
         template <size_t N, class A, class T>
-        inline batch<T, A> slide_right(batch<T, A> const& x, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV slide_right(batch<T, A> XSIMD_CREF x, requires_arch<sse2>) noexcept
         {
             return _mm_srli_si128(x, N);
         }
 
         // sadd
         template <class A>
-        inline batch<float, A> sadd(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sadd(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_add_ps(self, other); // no saturated arithmetic on floating point numbers
         }
@@ -1229,7 +1229,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-            inline batch<T, A> sadd_default(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV sadd_default(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
             {
                 if (std::is_signed<T>::value)
                 {
@@ -1248,7 +1248,7 @@ namespace xsimd
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sadd(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sadd(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1276,62 +1276,62 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<double, A> sadd(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sadd(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_add_pd(self, other); // no saturated arithmetic on floating point numbers
         }
 
         // set
         template <class A, class... Values>
-        inline batch<float, A> set(batch<float, A> const&, requires_arch<sse2>, Values... values) noexcept
+        inline batch<float, A> XSIMD_CALLCONV set(batch<float, A> XSIMD_CREF, requires_arch<sse2>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch<float, A>::size, "consistent init");
             return _mm_setr_ps(values...);
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<sse2>, T v0, T v1) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<sse2>, T v0, T v1) noexcept
         {
             return _mm_set_epi64x(v1, v0);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<sse2>, T v0, T v1, T v2, T v3) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<sse2>, T v0, T v1, T v2, T v3) noexcept
         {
             return _mm_setr_epi32(v0, v1, v2, v3);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<sse2>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<sse2>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7) noexcept
         {
             return _mm_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<sse2>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
+        inline batch<T, A> XSIMD_CALLCONV set(batch<T, A> XSIMD_CREF, requires_arch<sse2>, T v0, T v1, T v2, T v3, T v4, T v5, T v6, T v7, T v8, T v9, T v10, T v11, T v12, T v13, T v14, T v15) noexcept
         {
             return _mm_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
         }
 
         template <class A, class... Values>
-        inline batch<double, A> set(batch<double, A> const&, requires_arch<sse2>, Values... values) noexcept
+        inline batch<double, A> XSIMD_CALLCONV set(batch<double, A> XSIMD_CREF, requires_arch<sse2>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch<double, A>::size, "consistent init");
             return _mm_setr_pd(values...);
         }
 
         template <class A, class T, class... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<sse2>, Values... values) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV set(batch_bool<T, A> XSIMD_CREF, requires_arch<sse2>, Values... values) noexcept
         {
             return set(batch<T, A>(), A {}, static_cast<T>(values ? -1LL : 0LL)...).data;
         }
 
         template <class A, class... Values>
-        inline batch_bool<float, A> set(batch_bool<float, A> const&, requires_arch<sse2>, Values... values) noexcept
+        inline batch_bool<float, A> XSIMD_CALLCONV set(batch_bool<float, A> XSIMD_CREF, requires_arch<sse2>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch_bool<float, A>::size, "consistent init");
             return _mm_castsi128_ps(set(batch<int32_t, A>(), A {}, static_cast<int32_t>(values ? -1LL : 0LL)...).data);
         }
 
         template <class A, class... Values>
-        inline batch_bool<double, A> set(batch_bool<double, A> const&, requires_arch<sse2>, Values... values) noexcept
+        inline batch_bool<double, A> XSIMD_CALLCONV set(batch_bool<double, A> XSIMD_CREF, requires_arch<sse2>, Values... values) noexcept
         {
             static_assert(sizeof...(Values) == batch_bool<double, A>::size, "consistent init");
             return _mm_castsi128_pd(set(batch<int64_t, A>(), A {}, static_cast<int64_t>(values ? -1LL : 0LL)...).data);
@@ -1339,7 +1339,7 @@ namespace xsimd
 
         // ssub
         template <class A>
-        inline batch<float, A> ssub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ssub(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_sub_ps(self, other); // no saturated arithmetic on floating point numbers
         }
@@ -1347,7 +1347,7 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-            inline batch<T, A> ssub_default(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV ssub_default(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
             {
                 if (std::is_signed<T>::value)
                 {
@@ -1362,7 +1362,7 @@ namespace xsimd
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> ssub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV ssub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -1391,63 +1391,63 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> ssub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ssub(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_sub_pd(self, other); // no saturated arithmetic on floating point numbers
         }
 
         // store_aligned
         template <class A>
-        inline void store_aligned(float* mem, batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(float* mem, batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_store_ps(mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch<T, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_store_si128((__m128i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_aligned(T* mem, batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(T* mem, batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_store_si128((__m128i*)mem, self);
         }
         template <class A>
-        inline void store_aligned(double* mem, batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_aligned(double* mem, batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_store_pd(mem, self);
         }
 
         // store_unaligned
         template <class A>
-        inline void store_unaligned(float* mem, batch<float, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(float* mem, batch<float, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_storeu_ps(mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch<T, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_storeu_si128((__m128i*)mem, self);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline void store_unaligned(T* mem, batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(T* mem, batch_bool<T, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_storeu_si128((__m128i*)mem, self);
         }
         template <class A>
-        inline void store_unaligned(double* mem, batch<double, A> const& self, requires_arch<sse2>) noexcept
+        inline void XSIMD_CALLCONV store_unaligned(double* mem, batch<double, A> XSIMD_CREF self, requires_arch<sse2>) noexcept
         {
             return _mm_storeu_pd(mem, self);
         }
 
         // sub
         template <class A>
-        inline batch<float, A> sub(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV sub(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_sub_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> sub(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV sub(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1465,7 +1465,7 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<double, A> sub(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV sub(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_sub_pd(self, other);
         }
@@ -1474,64 +1474,64 @@ namespace xsimd
 
         namespace detail
         {
-            constexpr uint32_t shuffle(uint32_t w, uint32_t x, uint32_t y, uint32_t z)
+            constexpr uint32_t XSIMD_CALLCONV shuffle(uint32_t w, uint32_t x, uint32_t y, uint32_t z)
             {
                 return (z << 6) | (y << 4) | (x << 2) | w;
             }
-            constexpr uint32_t shuffle(uint32_t x, uint32_t y)
+            constexpr uint32_t XSIMD_CALLCONV shuffle(uint32_t x, uint32_t y)
             {
                 return (y << 1) | x;
             }
         }
 
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3>
-        inline batch<float, A> swizzle(batch<float, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3>, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV swizzle(batch<float, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3>, requires_arch<sse2>) noexcept
         {
             constexpr uint32_t index = detail::shuffle(V0, V1, V2, V3);
             return _mm_shuffle_ps(self, self, index);
         }
 
         template <class A, uint64_t V0, uint64_t V1>
-        inline batch<double, A> swizzle(batch<double, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1>, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV swizzle(batch<double, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1>, requires_arch<sse2>) noexcept
         {
             constexpr uint32_t index = detail::shuffle(V0, V1);
             return _mm_shuffle_pd(self, self, index);
         }
 
         template <class A, uint64_t V0, uint64_t V1>
-        inline batch<uint64_t, A> swizzle(batch<uint64_t, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1>, requires_arch<sse2>) noexcept
+        inline batch<uint64_t, A> XSIMD_CALLCONV swizzle(batch<uint64_t, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1>, requires_arch<sse2>) noexcept
         {
             constexpr uint32_t index = detail::shuffle(2 * V0, 2 * V0 + 1, 2 * V1, 2 * V1 + 1);
             return _mm_shuffle_epi32(self, index);
         }
 
         template <class A, uint64_t V0, uint64_t V1>
-        inline batch<int64_t, A> swizzle(batch<int64_t, A> const& self, batch_constant<batch<uint64_t, A>, V0, V1> mask, requires_arch<sse2>) noexcept
+        inline batch<int64_t, A> XSIMD_CALLCONV swizzle(batch<int64_t, A> XSIMD_CREF self, batch_constant<batch<uint64_t, A>, V0, V1> mask, requires_arch<sse2>) noexcept
         {
             return bitwise_cast<batch<int64_t, A>>(swizzle(bitwise_cast<batch<uint64_t, A>>(self), mask, sse2 {}));
         }
 
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3>
-        inline batch<uint32_t, A> swizzle(batch<uint32_t, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3>, requires_arch<sse2>) noexcept
+        inline batch<uint32_t, A> XSIMD_CALLCONV swizzle(batch<uint32_t, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3>, requires_arch<sse2>) noexcept
         {
             constexpr uint32_t index = detail::shuffle(V0, V1, V2, V3);
             return _mm_shuffle_epi32(self, index);
         }
 
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3>
-        inline batch<int32_t, A> swizzle(batch<int32_t, A> const& self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3> mask, requires_arch<sse2>) noexcept
+        inline batch<int32_t, A> XSIMD_CALLCONV swizzle(batch<int32_t, A> XSIMD_CREF self, batch_constant<batch<uint32_t, A>, V0, V1, V2, V3> mask, requires_arch<sse2>) noexcept
         {
             return bitwise_cast<batch<int32_t, A>>(swizzle(bitwise_cast<batch<uint32_t, A>>(self), mask, sse2 {}));
         }
 
         // zip_hi
         template <class A>
-        inline batch<float, A> zip_hi(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_hi(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_unpackhi_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_hi(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_hi(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1549,19 +1549,19 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<double, A> zip_hi(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_hi(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_unpackhi_pd(self, other);
         }
 
         // zip_lo
         template <class A>
-        inline batch<float, A> zip_lo(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV zip_lo(batch<float, A> XSIMD_CREF self, batch<float, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_unpacklo_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> zip_lo(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV zip_lo(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             switch (sizeof(T))
             {
@@ -1579,7 +1579,7 @@ namespace xsimd
             }
         }
         template <class A>
-        inline batch<double, A> zip_lo(batch<double, A> const& self, batch<double, A> const& other, requires_arch<sse2>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV zip_lo(batch<double, A> XSIMD_CREF self, batch<double, A> XSIMD_CREF other, requires_arch<sse2>) noexcept
         {
             return _mm_unpacklo_pd(self, other);
         }

--- a/include/xsimd/arch/xsimd_sse3.hpp
+++ b/include/xsimd/arch/xsimd_sse3.hpp
@@ -24,21 +24,21 @@ namespace xsimd
 
         // load_unaligned
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> load_unaligned(T const* mem, convert<T>, requires_arch<sse3>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV load_unaligned(T const* mem, convert<T>, requires_arch<sse3>) noexcept
         {
             return _mm_lddqu_si128((__m128i const*)mem);
         }
 
         // hadd
         template <class A>
-        inline float hadd(batch<float, A> const& self, requires_arch<sse3>) noexcept
+        inline float XSIMD_CALLCONV hadd(batch<float, A> XSIMD_CREF self, requires_arch<sse3>) noexcept
         {
             __m128 tmp0 = _mm_hadd_ps(self, self);
             __m128 tmp1 = _mm_hadd_ps(tmp0, tmp0);
             return _mm_cvtss_f32(tmp1);
         }
         template <class A>
-        inline double hadd(batch<double, A> const& self, requires_arch<sse3>) noexcept
+        inline double XSIMD_CALLCONV hadd(batch<double, A> XSIMD_CREF self, requires_arch<sse3>) noexcept
         {
             __m128d tmp0 = _mm_hadd_pd(self, self);
             return _mm_cvtsd_f64(tmp0);
@@ -46,13 +46,13 @@ namespace xsimd
 
         // haddp
         template <class A>
-        inline batch<float, A> haddp(batch<float, A> const* row, requires_arch<sse3>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV haddp(batch<float, A> const* row, requires_arch<sse3>) noexcept
         {
             return _mm_hadd_ps(_mm_hadd_ps(row[0], row[1]),
                                _mm_hadd_ps(row[2], row[3]));
         }
         template <class A>
-        inline batch<double, A> haddp(batch<double, A> const* row, requires_arch<sse3>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV haddp(batch<double, A> const* row, requires_arch<sse3>) noexcept
         {
             return _mm_hadd_pd(row[0], row[1]);
         }

--- a/include/xsimd/arch/xsimd_sse4_1.hpp
+++ b/include/xsimd/arch/xsimd_sse4_1.hpp
@@ -24,18 +24,18 @@ namespace xsimd
         using namespace types;
         // any
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline bool any(batch<T, A> const& self, requires_arch<sse4_1>) noexcept
+        inline bool XSIMD_CALLCONV any(batch<T, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return !_mm_testz_si128(self, self);
         }
         // ceil
         template <class A>
-        inline batch<float, A> ceil(batch<float, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV ceil(batch<float, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_ceil_ps(self);
         }
         template <class A>
-        inline batch<double, A> ceil(batch<double, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV ceil(batch<double, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_ceil_pd(self);
         }
@@ -44,7 +44,7 @@ namespace xsimd
         namespace detail
         {
             template <class A>
-            inline batch<double, A> fast_cast(batch<int64_t, A> const& x, batch<double, A> const&, requires_arch<sse4_1>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<int64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<sse4_1>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 __m128i xH = _mm_srai_epi32(x, 16);
@@ -56,7 +56,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<double, A> fast_cast(batch<uint64_t, A> const& x, batch<double, A> const&, requires_arch<sse4_1>) noexcept
+            inline batch<double, A> XSIMD_CALLCONV fast_cast(batch<uint64_t, A> XSIMD_CREF x, batch<double, A> XSIMD_CREF, requires_arch<sse4_1>) noexcept
             {
                 // from https://stackoverflow.com/questions/41144668/how-to-efficiently-perform-double-int64-conversions-with-sse-avx
                 __m128i xH = _mm_srli_epi64(x, 32);
@@ -67,7 +67,7 @@ namespace xsimd
             }
 
             template <class A>
-            inline batch<uint32_t, A> fast_cast(batch<float, A> const& self, batch<uint32_t, A> const&, requires_arch<sse4_1>) noexcept
+            inline batch<uint32_t, A> XSIMD_CALLCONV fast_cast(batch<float, A> XSIMD_CREF self, batch<uint32_t, A> XSIMD_CREF, requires_arch<sse4_1>) noexcept
             {
                 return _mm_castps_si128(
                     _mm_blendv_ps(_mm_castsi128_ps(_mm_cvttps_epi32(self)),
@@ -80,7 +80,7 @@ namespace xsimd
 
         // eq
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse4_1>) noexcept
+        inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse4_1>) noexcept
         {
             switch (sizeof(T))
             {
@@ -93,19 +93,19 @@ namespace xsimd
 
         // floor
         template <class A>
-        inline batch<float, A> floor(batch<float, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV floor(batch<float, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_floor_ps(self);
         }
         template <class A>
-        inline batch<double, A> floor(batch<double, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV floor(batch<double, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_floor_pd(self);
         }
 
         // insert
         template <class A, class T, size_t I, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> insert(batch<T, A> const& self, T val, index<I> pos, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> XSIMD_CREF self, T val, index<I> pos, requires_arch<sse4_1>) noexcept
         {
             switch (sizeof(T))
             {
@@ -124,7 +124,7 @@ namespace xsimd
 
         // max
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse4_1>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -158,7 +158,7 @@ namespace xsimd
 
         // min
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> min(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse4_1>) noexcept
         {
             if (std::is_signed<T>::value)
             {
@@ -192,7 +192,7 @@ namespace xsimd
 
         // mul
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV mul(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, requires_arch<sse4_1>) noexcept
         {
             switch (sizeof(T))
             {
@@ -220,12 +220,12 @@ namespace xsimd
 
         // nearbyint
         template <class A>
-        inline batch<float, A> nearbyint(batch<float, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV nearbyint(batch<float, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_round_ps(self, _MM_FROUND_TO_NEAREST_INT);
         }
         template <class A>
-        inline batch<double, A> nearbyint(batch<double, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV nearbyint(batch<double, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_round_pd(self, _MM_FROUND_TO_NEAREST_INT);
         }
@@ -234,30 +234,30 @@ namespace xsimd
         namespace detail
         {
             template <class T>
-            inline constexpr T interleave(T const& cond) noexcept
+            inline constexpr T XSIMD_CALLCONV interleave(T const& cond) noexcept
             {
                 return (((cond * 0x0101010101010101ULL & 0x8040201008040201ULL) * 0x0102040810204081ULL >> 49) & 0x5555) | (((cond * 0x0101010101010101ULL & 0x8040201008040201ULL) * 0x0102040810204081ULL >> 48) & 0xAAAA);
             }
         }
 
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> XSIMD_CREF cond, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             return _mm_blendv_epi8(false_br, true_br, cond);
         }
         template <class A>
-        inline batch<float, A> select(batch_bool<float, A> const& cond, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool<float, A> XSIMD_CREF cond, batch<float, A> XSIMD_CREF true_br, batch<float, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             return _mm_blendv_ps(false_br, true_br, cond);
         }
         template <class A>
-        inline batch<double, A> select(batch_bool<double, A> const& cond, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool<double, A> XSIMD_CREF cond, batch<double, A> XSIMD_CREF true_br, batch<double, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             return _mm_blendv_pd(false_br, true_br, cond);
         }
 
         template <class A, class T, bool... Values, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const&, batch<T, A> XSIMD_CREF true_br, batch<T, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             constexpr int mask = batch_bool_constant<batch<T, A>, Values...>::mask();
             switch (sizeof(T))
@@ -280,13 +280,13 @@ namespace xsimd
             }
         }
         template <class A, bool... Values>
-        inline batch<float, A> select(batch_bool_constant<batch<float, A>, Values...> const&, batch<float, A> const& true_br, batch<float, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV select(batch_bool_constant<batch<float, A>, Values...> const&, batch<float, A> XSIMD_CREF true_br, batch<float, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             constexpr int mask = batch_bool_constant<batch<float, A>, Values...>::mask();
             return _mm_blend_ps(false_br, true_br, mask);
         }
         template <class A, bool... Values>
-        inline batch<double, A> select(batch_bool_constant<batch<double, A>, Values...> const&, batch<double, A> const& true_br, batch<double, A> const& false_br, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV select(batch_bool_constant<batch<double, A>, Values...> const&, batch<double, A> XSIMD_CREF true_br, batch<double, A> XSIMD_CREF false_br, requires_arch<sse4_1>) noexcept
         {
             constexpr int mask = batch_bool_constant<batch<double, A>, Values...>::mask();
             return _mm_blend_pd(false_br, true_br, mask);
@@ -294,12 +294,12 @@ namespace xsimd
 
         // trunc
         template <class A>
-        inline batch<float, A> trunc(batch<float, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<float, A> XSIMD_CALLCONV trunc(batch<float, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_round_ps(self, _MM_FROUND_TO_ZERO);
         }
         template <class A>
-        inline batch<double, A> trunc(batch<double, A> const& self, requires_arch<sse4_1>) noexcept
+        inline batch<double, A> XSIMD_CALLCONV trunc(batch<double, A> XSIMD_CREF self, requires_arch<sse4_1>) noexcept
         {
             return _mm_round_pd(self, _MM_FROUND_TO_ZERO);
         }

--- a/include/xsimd/arch/xsimd_sse4_2.hpp
+++ b/include/xsimd/arch/xsimd_sse4_2.hpp
@@ -25,12 +25,12 @@ namespace xsimd
 
         // lt
         template <class A>
-        inline batch_bool<int64_t, A> lt(batch<int64_t, A> const& self, batch<int64_t, A> const& other, requires_arch<sse4_2>) noexcept
+        inline batch_bool<int64_t, A> XSIMD_CALLCONV lt(batch<int64_t, A> XSIMD_CREF self, batch<int64_t, A> XSIMD_CREF other, requires_arch<sse4_2>) noexcept
         {
             return _mm_cmpgt_epi64(other, self);
         }
         template <class A>
-        inline batch_bool<uint64_t, A> lt(batch<uint64_t, A> const& self, batch<uint64_t, A> const& other, requires_arch<sse4_2>) noexcept
+        inline batch_bool<uint64_t, A> XSIMD_CALLCONV lt(batch<uint64_t, A> XSIMD_CREF self, batch<uint64_t, A> XSIMD_CREF other, requires_arch<sse4_2>) noexcept
         {
             auto xself = _mm_xor_si128(self, _mm_set1_epi64x(std::numeric_limits<int64_t>::lowest()));
             auto xother = _mm_xor_si128(other, _mm_set1_epi64x(std::numeric_limits<int64_t>::lowest()));

--- a/include/xsimd/arch/xsimd_ssse3.hpp
+++ b/include/xsimd/arch/xsimd_ssse3.hpp
@@ -27,7 +27,7 @@ namespace xsimd
 
         // abs
         template <class A, class T, typename std::enable_if<std::is_integral<T>::value && std::is_signed<T>::value, void>::type>
-        inline batch<T, A> abs(batch<T, A> const& self, requires_arch<ssse3>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> XSIMD_CREF self, requires_arch<ssse3>) noexcept
         {
             switch (sizeof(T))
             {
@@ -50,13 +50,13 @@ namespace xsimd
         {
 
             template <class T, class A>
-            inline batch<T, A> extract_pair(batch<T, A> const&, batch<T, A> const& other, std::size_t, ::xsimd::detail::index_sequence<>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV extract_pair(batch<T, A> XSIMD_CREF, batch<T, A> XSIMD_CREF other, std::size_t, ::xsimd::detail::index_sequence<>) noexcept
             {
                 return other;
             }
 
             template <class T, class A, std::size_t I, std::size_t... Is>
-            inline batch<T, A> extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, ::xsimd::detail::index_sequence<I, Is...>) noexcept
+            inline batch<T, A> XSIMD_CALLCONV extract_pair(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, std::size_t i, ::xsimd::detail::index_sequence<I, Is...>) noexcept
             {
                 if (i == I)
                 {
@@ -68,7 +68,7 @@ namespace xsimd
         }
 
         template <class A, class T, class _ = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline batch<T, A> extract_pair(batch<T, A> const& self, batch<T, A> const& other, std::size_t i, requires_arch<ssse3>) noexcept
+        inline batch<T, A> XSIMD_CALLCONV extract_pair(batch<T, A> XSIMD_CREF self, batch<T, A> XSIMD_CREF other, std::size_t i, requires_arch<ssse3>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
             assert(0 <= i && i < size && "index in bounds");
@@ -77,7 +77,7 @@ namespace xsimd
 
         // hadd
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
-        inline T hadd(batch<T, A> const& self, requires_arch<ssse3>) noexcept
+        inline T XSIMD_CALLCONV hadd(batch<T, A> XSIMD_CREF self, requires_arch<ssse3>) noexcept
         {
             switch (sizeof(T))
             {
@@ -101,7 +101,7 @@ namespace xsimd
 
         // swizzle
         template <class A, uint16_t V0, uint16_t V1, uint16_t V2, uint16_t V3, uint16_t V4, uint16_t V5, uint16_t V6, uint16_t V7>
-        inline batch<uint16_t, A> swizzle(batch<uint16_t, A> const& self, batch_constant<batch<uint16_t, A>, V0, V1, V2, V3, V4, V5, V6, V7>, requires_arch<ssse3>) noexcept
+        inline batch<uint16_t, A> XSIMD_CALLCONV swizzle(batch<uint16_t, A> XSIMD_CREF self, batch_constant<batch<uint16_t, A>, V0, V1, V2, V3, V4, V5, V6, V7>, requires_arch<ssse3>) noexcept
         {
             constexpr batch_constant<batch<uint8_t, A>, 2 * V0, 2 * V0 + 1, 2 * V1, 2 * V1 + 1, 2 * V2, 2 * V2 + 1, 2 * V3, 2 * V3 + 1,
                                      2 * V4, 2 * V4 + 1, 2 * V5, 2 * V5 + 1, 2 * V6, 2 * V6 + 1, 2 * V7, 2 * V7 + 1>
@@ -110,21 +110,21 @@ namespace xsimd
         }
 
         template <class A, uint16_t V0, uint16_t V1, uint16_t V2, uint16_t V3, uint16_t V4, uint16_t V5, uint16_t V6, uint16_t V7>
-        inline batch<int16_t, A> swizzle(batch<int16_t, A> const& self, batch_constant<batch<uint16_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<ssse3>) noexcept
+        inline batch<int16_t, A> XSIMD_CALLCONV swizzle(batch<int16_t, A> XSIMD_CREF self, batch_constant<batch<uint16_t, A>, V0, V1, V2, V3, V4, V5, V6, V7> mask, requires_arch<ssse3>) noexcept
         {
             return bitwise_cast<int16_t>(swizzle(bitwise_cast<uint16_t>(self), mask, ssse3 {}));
         }
 
         template <class A, uint8_t V0, uint8_t V1, uint8_t V2, uint8_t V3, uint8_t V4, uint8_t V5, uint8_t V6, uint8_t V7,
                   uint8_t V8, uint8_t V9, uint8_t V10, uint8_t V11, uint8_t V12, uint8_t V13, uint8_t V14, uint8_t V15>
-        inline batch<uint8_t, A> swizzle(batch<uint8_t, A> const& self, batch_constant<batch<uint8_t, A>, V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15> mask, requires_arch<ssse3>) noexcept
+        inline batch<uint8_t, A> XSIMD_CALLCONV swizzle(batch<uint8_t, A> XSIMD_CREF self, batch_constant<batch<uint8_t, A>, V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15> mask, requires_arch<ssse3>) noexcept
         {
             return _mm_shuffle_epi8(self, (batch<uint8_t, A>)mask);
         }
 
         template <class A, uint8_t V0, uint8_t V1, uint8_t V2, uint8_t V3, uint8_t V4, uint8_t V5, uint8_t V6, uint8_t V7,
                   uint8_t V8, uint8_t V9, uint8_t V10, uint8_t V11, uint8_t V12, uint8_t V13, uint8_t V14, uint8_t V15>
-        inline batch<int8_t, A> swizzle(batch<int8_t, A> const& self, batch_constant<batch<uint8_t, A>, V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15> mask, requires_arch<ssse3>) noexcept
+        inline batch<int8_t, A> XSIMD_CALLCONV swizzle(batch<int8_t, A> XSIMD_CREF self, batch_constant<batch<uint8_t, A>, V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15> mask, requires_arch<ssse3>) noexcept
         {
             return bitwise_cast<int8_t>(swizzle(bitwise_cast<uint8_t>(self), mask, ssse3 {}));
         }

--- a/include/xsimd/stl/algorithms.hpp
+++ b/include/xsimd/stl/algorithms.hpp
@@ -22,7 +22,7 @@
 namespace xsimd
 {
     template <class Arch = default_arch, class I1, class I2, class O1, class UF>
-    void transform(I1 first, I2 last, O1 out_first, UF&& f) noexcept
+    void XSIMD_CALLCONV transform(I1 first, I2 last, O1 out_first, UF&& f) noexcept
     {
         using value_type = typename std::decay<decltype(*first)>::type;
         using batch_type = batch<value_type, Arch>;
@@ -76,7 +76,7 @@ namespace xsimd
     }
 
     template <class Arch = default_arch, class I1, class I2, class I3, class O1, class UF>
-    void transform(I1 first_1, I2 last_1, I3 first_2, O1 out_first, UF&& f) noexcept
+    void XSIMD_CALLCONV transform(I1 first_1, I2 last_1, I3 first_2, O1 out_first, UF&& f) noexcept
     {
         using value_type = typename std::decay<decltype(*first_1)>::type;
         using batch_type = batch<value_type, Arch>;
@@ -143,7 +143,7 @@ namespace xsimd
     }
 
     template <class Arch = default_arch, class Iterator1, class Iterator2, class Init, class BinaryFunction = detail::plus>
-    Init reduce(Iterator1 first, Iterator2 last, Init init, BinaryFunction&& binfun = detail::plus {}) noexcept
+    Init XSIMD_CALLCONV reduce(Iterator1 first, Iterator2 last, Init init, BinaryFunction&& binfun = detail::plus {}) noexcept
     {
         using value_type = typename std::decay<decltype(*first)>::type;
         using batch_type = batch<value_type, Arch>;

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -54,7 +54,7 @@ namespace xsimd
      * @return the absolute values of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> abs(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV abs(batch<T, A> const& x) noexcept
     {
         return kernel::abs<A>(x, A {});
     }
@@ -67,7 +67,7 @@ namespace xsimd
      * @return the absolute values of \c z.
      */
     template <class T, class A>
-    inline batch<T, A> abs(batch<std::complex<T>, A> const& z) noexcept
+    inline batch<T, A> XSIMD_CALLCONV abs(batch<std::complex<T>, A> const& z) noexcept
     {
         return kernel::abs<A>(z, A {});
     }
@@ -81,7 +81,7 @@ namespace xsimd
      * @return the sum of \c x and \c y
      */
     template <class T, class Tp>
-    inline auto add(T const& x, Tp const& y) noexcept -> decltype(x + y)
+    inline auto XSIMD_CALLCONV add(T const& x, Tp const& y) noexcept -> decltype(x + y)
     {
         return x + y;
     }
@@ -94,7 +94,7 @@ namespace xsimd
      * @return the arc cosine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> acos(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV acos(batch<T, A> const& x) noexcept
     {
         return kernel::acos<A>(x, A {});
     }
@@ -107,7 +107,7 @@ namespace xsimd
      * @return the inverse hyperbolic cosine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> acosh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV acosh(batch<T, A> const& x) noexcept
     {
         return kernel::acosh<A>(x, A {});
     }
@@ -120,7 +120,7 @@ namespace xsimd
      * @return the argument of \c z.
      */
     template <class T, class A>
-    inline real_batch_type_t<batch<T, A>> arg(batch<T, A> const& z) noexcept
+    inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV arg(batch<T, A> const& z) noexcept
     {
         return kernel::arg<A>(z, A {});
     }
@@ -133,7 +133,7 @@ namespace xsimd
      * @return the arc sine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> asin(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV asin(batch<T, A> const& x) noexcept
     {
         return kernel::asin<A>(x, A {});
     }
@@ -146,7 +146,7 @@ namespace xsimd
      * @return the inverse hyperbolic sine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> asinh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV asinh(batch<T, A> const& x) noexcept
     {
         return kernel::asinh<A>(x, A {});
     }
@@ -159,7 +159,7 @@ namespace xsimd
      * @return the arc tangent of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> atan(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV atan(batch<T, A> const& x) noexcept
     {
         return kernel::atan<A>(x, A {});
     }
@@ -174,7 +174,7 @@ namespace xsimd
      * @return the arc tangent of \c x/y.
      */
     template <class T, class A>
-    inline batch<T, A> atan2(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV atan2(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::atan2<A>(x, y, A {});
     }
@@ -187,7 +187,7 @@ namespace xsimd
      * @return the inverse hyperbolic tangent of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> atanh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV atanh(batch<T, A> const& x) noexcept
     {
         return kernel::atanh<A>(x, A {});
     }
@@ -200,7 +200,7 @@ namespace xsimd
      * @return \c x casted to \c T_out
      */
     template <class T_out, class T_in, class A>
-    inline batch<T_out, A> batch_cast(batch<T_in, A> const& x) noexcept
+    inline batch<T_out, A> XSIMD_CALLCONV batch_cast(batch<T_in, A> const& x) noexcept
     {
         return kernel::batch_cast<A>(x, batch<T_out, A> {}, A {});
     }
@@ -213,7 +213,7 @@ namespace xsimd
      * @return bit of sign of \c x
      */
     template <class T, class A>
-    inline batch<T, A> bitofsign(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV bitofsign(batch<T, A> const& x) noexcept
     {
         return kernel::bitofsign<A>(x, A {});
     }
@@ -227,7 +227,7 @@ namespace xsimd
      * @return the result of the bitwise and.
      */
     template <class T, class Tp>
-    inline auto bitwise_and(T const& x, Tp const& y) noexcept -> decltype(x & y)
+    inline auto XSIMD_CALLCONV bitwise_and(T const& x, Tp const& y) noexcept -> decltype(x & y)
     {
         return x & y;
     }
@@ -241,7 +241,7 @@ namespace xsimd
      * @return the result of the bitwise and not.
      */
     template <class T, class A>
-    inline batch<T, A> bitwise_andnot(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV bitwise_andnot(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::bitwise_andnot<A>(x, y, A {});
     }
@@ -255,7 +255,7 @@ namespace xsimd
      * @return the result of the bitwise and not.
      */
     template <class T, class A>
-    inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& x, batch_bool<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV bitwise_andnot(batch_bool<T, A> const& x, batch_bool<T, A> const& y) noexcept
     {
         return kernel::bitwise_andnot<A>(x, y, A {});
     }
@@ -268,7 +268,7 @@ namespace xsimd
      * @return \c x reinterpreted as \c T_out
      */
     template <class B, class T, class A>
-    inline B bitwise_cast(batch<T, A> const& x) noexcept
+    inline B XSIMD_CALLCONV bitwise_cast(batch<T, A> const& x) noexcept
     {
         return kernel::bitwise_cast<A>(x, B {}, A {});
     }
@@ -281,7 +281,7 @@ namespace xsimd
      * @return the result of the bitwise not.
      */
     template <class T, class A>
-    inline batch<T, A> bitwise_not(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV bitwise_not(batch<T, A> const& x) noexcept
     {
         return kernel::bitwise_not<A>(x, A {});
     }
@@ -295,7 +295,7 @@ namespace xsimd
      * @return the result of the bitwise or.
      */
     template <class T, class Tp>
-    inline auto bitwise_or(T const& x, Tp const& y) noexcept -> decltype(x | y)
+    inline auto XSIMD_CALLCONV bitwise_or(T const& x, Tp const& y) noexcept -> decltype(x | y)
     {
         return x | y;
     }
@@ -309,29 +309,29 @@ namespace xsimd
      * @return the result of the bitwise xor.
      */
     template <class T, class Tp>
-    inline auto bitwise_xor(T const& x, Tp const& y) noexcept -> decltype(x ^ y)
+    inline auto XSIMD_CALLCONV bitwise_xor(T const& x, Tp const& y) noexcept -> decltype(x ^ y)
     {
         return x ^ y;
     }
 
     // FIXME: check if these need to be exposed, or removed (?)
     template <class A>
-    inline batch_bool<float, A> bool_cast(batch_bool<int32_t, A> const& x) noexcept
+    inline batch_bool<float, A> XSIMD_CALLCONV bool_cast(batch_bool<int32_t, A> const& x) noexcept
     {
         return kernel::bool_cast<A>(x, A {});
     }
     template <class A>
-    inline batch_bool<int32_t, A> bool_cast(batch_bool<float, A> const& x) noexcept
+    inline batch_bool<int32_t, A> XSIMD_CALLCONV bool_cast(batch_bool<float, A> const& x) noexcept
     {
         return kernel::bool_cast<A>(x, A {});
     }
     template <class A>
-    inline batch_bool<double, A> bool_cast(batch_bool<int64_t, A> const& x) noexcept
+    inline batch_bool<double, A> XSIMD_CALLCONV bool_cast(batch_bool<int64_t, A> const& x) noexcept
     {
         return kernel::bool_cast<A>(x, A {});
     }
     template <class A>
-    inline batch_bool<int64_t, A> bool_cast(batch_bool<double, A> const& x) noexcept
+    inline batch_bool<int64_t, A> XSIMD_CALLCONV bool_cast(batch_bool<double, A> const& x) noexcept
     {
         return kernel::bool_cast<A>(x, A {});
     }
@@ -344,7 +344,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class T, class A = default_arch>
-    inline batch<T, A> broadcast(T v) noexcept
+    inline batch<T, A> XSIMD_CALLCONV broadcast(T v) noexcept
     {
         return kernel::broadcast<A>(v, A {});
     }
@@ -358,7 +358,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class To, class A = default_arch, class From>
-    inline simd_return_type<From, To> broadcast_as(From v) noexcept
+    inline simd_return_type<From, To> XSIMD_CALLCONV broadcast_as(From v) noexcept
     {
         using batch_value_type = typename simd_return_type<From, To>::value_type;
         using value_type = typename std::conditional<std::is_same<From, bool>::value,
@@ -375,7 +375,7 @@ namespace xsimd
      * @return the cubic root of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> cbrt(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV cbrt(batch<T, A> const& x) noexcept
     {
         return kernel::cbrt<A>(x, A {});
     }
@@ -389,7 +389,7 @@ namespace xsimd
      * @return the batch of smallest integer values not less than \c x.
      */
     template <class T, class A>
-    inline batch<T, A> ceil(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV ceil(batch<T, A> const& x) noexcept
     {
         return kernel::ceil<A>(x, A {});
     }
@@ -404,7 +404,7 @@ namespace xsimd
      * @return the result of the clipping.
      */
     template <class A, class T>
-    inline batch<T, A> clip(batch<T, A> const& x, batch<T, A> const& lo, batch<T, A> const& hi) noexcept
+    inline batch<T, A> XSIMD_CALLCONV clip(batch<T, A> const& x, batch<T, A> const& lo, batch<T, A> const& hi) noexcept
     {
         return kernel::clip(x, lo, hi, A {});
     }
@@ -417,7 +417,7 @@ namespace xsimd
      * @return the argument of \c z.
      */
     template <class A, class T>
-    inline complex_batch_type_t<batch<T, A>> conj(batch<T, A> const& z) noexcept
+    inline complex_batch_type_t<batch<T, A>> XSIMD_CALLCONV conj(batch<T, A> const& z) noexcept
     {
         return kernel::conj(z, A {});
     }
@@ -433,7 +433,7 @@ namespace xsimd
      * matches that of \c y.
      */
     template <class A, class T>
-    inline batch<T, A> copysign(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV copysign(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::copysign<A>(x, y, A {});
     }
@@ -446,7 +446,7 @@ namespace xsimd
      * @return the cosine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> cos(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV cos(batch<T, A> const& x) noexcept
     {
         return kernel::cos<A>(x, A {});
     }
@@ -459,7 +459,7 @@ namespace xsimd
      * @return the hyperbolic cosine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> cosh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV cosh(batch<T, A> const& x) noexcept
     {
         return kernel::cosh<A>(x, A {});
     }
@@ -473,7 +473,7 @@ namespace xsimd
      * @return the result of the division.
      */
     template <class T, class Tp>
-    inline auto div(T const& x, Tp const& y) noexcept -> decltype(x / y)
+    inline auto XSIMD_CALLCONV div(T const& x, Tp const& y) noexcept -> decltype(x / y)
     {
         return x / y;
     }
@@ -487,7 +487,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> eq(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV eq(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x == y;
     }
@@ -500,7 +500,7 @@ namespace xsimd
      * @return the natural exponential of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> exp(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV exp(batch<T, A> const& x) noexcept
     {
         return kernel::exp<A>(x, A {});
     }
@@ -513,7 +513,7 @@ namespace xsimd
      * @return the base 10 exponential of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> exp10(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV exp10(batch<T, A> const& x) noexcept
     {
         return kernel::exp10<A>(x, A {});
     }
@@ -526,7 +526,7 @@ namespace xsimd
      * @return the base 2 exponential of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> exp2(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV exp2(batch<T, A> const& x) noexcept
     {
         return kernel::exp2<A>(x, A {});
     }
@@ -539,7 +539,7 @@ namespace xsimd
      * @return the natural exponential of \c x, minus one.
      */
     template <class T, class A>
-    inline batch<T, A> expm1(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV expm1(batch<T, A> const& x) noexcept
     {
         return kernel::expm1<A>(x, A {});
     }
@@ -552,7 +552,7 @@ namespace xsimd
      * @return the error function of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> erf(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV erf(batch<T, A> const& x) noexcept
     {
         return kernel::erf<A>(x, A {});
     }
@@ -565,7 +565,7 @@ namespace xsimd
      * @return the error function of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> erfc(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV erfc(batch<T, A> const& x) noexcept
     {
         return kernel::erfc<A>(x, A {});
     }
@@ -579,7 +579,7 @@ namespace xsimd
      * @return the evaluation ofpolynomial with coefficient \c Coefs on point \c x.
      */
     template <class T, class A, uint64_t... Coefs>
-    inline batch<T, A> estrin(const batch<T, A>& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV estrin(const batch<T, A>& x) noexcept
     {
         return kernel::estrin<T, A, Coefs...>(x);
     }
@@ -595,7 +595,7 @@ namespace xsimd
      * @return.
      */
     template <class T, class A>
-    inline batch<T, A> extract_pair(batch<T, A> const& x, batch<T, A> const& y, std::size_t i) noexcept
+    inline batch<T, A> XSIMD_CALLCONV extract_pair(batch<T, A> const& x, batch<T, A> const& y, std::size_t i) noexcept
     {
         return kernel::extract_pair<A>(x, y, i, A {});
     }
@@ -608,7 +608,7 @@ namespace xsimd
      * @return the asbolute values of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> fabs(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fabs(batch<T, A> const& x) noexcept
     {
         return kernel::abs<A>(x, A {});
     }
@@ -623,7 +623,7 @@ namespace xsimd
      * @return the positive difference.
      */
     template <class T, class A>
-    inline batch<T, A> fdim(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fdim(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::fdim<A>(x, y, A {});
     }
@@ -637,7 +637,7 @@ namespace xsimd
      * @return the batch of largest integer values not greater than \c x.
      */
     template <class T, class A>
-    inline batch<T, A> floor(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV floor(batch<T, A> const& x) noexcept
     {
         return kernel::floor<A>(x, A {});
     }
@@ -652,7 +652,7 @@ namespace xsimd
      * @return the result of the fused multiply-add operation.
      */
     template <class T, class A>
-    inline batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
     {
         return kernel::fma<A>(x, y, z, A {});
     }
@@ -666,7 +666,7 @@ namespace xsimd
      * @return a batch of the larger values.
      */
     template <class T, class A>
-    inline batch<T, A> fmax(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fmax(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::max<A>(x, y, A {});
     }
@@ -680,7 +680,7 @@ namespace xsimd
      * @return a batch of the larger values.
      */
     template <class T, class A>
-    inline batch<T, A> fmin(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fmin(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::min<A>(x, y, A {});
     }
@@ -694,7 +694,7 @@ namespace xsimd
      * @return the result of the modulo.
      */
     template <class T, class A>
-    inline batch<T, A> fmod(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fmod(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::fmod<A>(x, y, A {});
     }
@@ -709,7 +709,7 @@ namespace xsimd
      * @return the result of the fused multiply-sub operation.
      */
     template <class T, class A>
-    inline batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
     {
         return kernel::fms<A>(x, y, z, A {});
     }
@@ -724,7 +724,7 @@ namespace xsimd
      * @return the result of the fused negated multiply-add operation.
      */
     template <class T, class A>
-    inline batch<T, A> fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
     {
         return kernel::fnma<A>(x, y, z, A {});
     }
@@ -739,7 +739,7 @@ namespace xsimd
      * @return the result of the fused negated multiply-sub operation.
      */
     template <class T, class A>
-    inline batch<T, A> fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
+    inline batch<T, A> XSIMD_CALLCONV fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z) noexcept
     {
         return kernel::fnms<A>(x, y, z, A {});
     }
@@ -753,7 +753,7 @@ namespace xsimd
      * @return the normalized fraction of x
      */
     template <class T, class A>
-    inline batch<T, A> frexp(const batch<T, A>& x, batch<as_integer_t<T>, A>& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV frexp(const batch<T, A>& x, batch<as_integer_t<T>, A>& y) noexcept
     {
         return kernel::frexp<A>(x, y, A {});
     }
@@ -768,7 +768,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> ge(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV ge(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x >= y;
     }
@@ -783,7 +783,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> gt(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV gt(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x > y;
     }
@@ -796,7 +796,7 @@ namespace xsimd
      * @return the result of the reduction.
      */
     template <class T, class A>
-    inline T hadd(batch<T, A> const& x) noexcept
+    inline T XSIMD_CALLCONV hadd(batch<T, A> const& x) noexcept
     {
         return kernel::hadd<A>(x, A {});
     }
@@ -811,7 +811,7 @@ namespace xsimd
      * @return the result of the reduction.
      */
     template <class T, class A>
-    inline batch<T, A> haddp(batch<T, A> const* row) noexcept
+    inline batch<T, A> XSIMD_CALLCONV haddp(batch<T, A> const* row) noexcept
     {
         return kernel::haddp<A>(row, A {});
     }
@@ -825,7 +825,7 @@ namespace xsimd
      * @return the evaluation ofpolynomial with coefficient \c Coefs on point \c x.
      */
     template <class T, class A, uint64_t... Coefs>
-    inline batch<T, A> horner(const batch<T, A>& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV horner(const batch<T, A>& x) noexcept
     {
         return kernel::horner<T, A, Coefs...>(x);
     }
@@ -840,7 +840,7 @@ namespace xsimd
      * @return the square root of the sum of the squares of \c x and \c y.
      */
     template <class T, class A>
-    inline batch<T, A> hypot(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV hypot(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::hypot<A>(x, y, A {});
     }
@@ -853,7 +853,7 @@ namespace xsimd
      * @return the argument of \c x.
      */
     template <class T, class A>
-    inline real_batch_type_t<batch<T, A>> imag(batch<T, A> const& x) noexcept
+    inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV imag(batch<T, A> const& x) noexcept
     {
         return kernel::imag<A>(x, A {});
     }
@@ -865,7 +865,7 @@ namespace xsimd
      * @return a batch of positive infinity
      */
     template <class B>
-    B infinity()
+    B XSIMD_CALLCONV infinity()
     {
         using T = typename B::value_type;
         return B(std::numeric_limits<T>::infinity());
@@ -881,7 +881,7 @@ namespace xsimd
      * @return copy of \c x with position \c pos set to \c val
      */
     template <class T, class A, size_t I>
-    inline batch<T, A> insert(batch<T, A> const& x, T val, index<I> pos) noexcept
+    inline batch<T, A> XSIMD_CALLCONV insert(batch<T, A> const& x, T val, index<I> pos) noexcept
     {
         return kernel::insert<A>(x, val, pos, A {});
     }
@@ -894,7 +894,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> is_even(batch<T, A> const& x) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV is_even(batch<T, A> const& x) noexcept
     {
         return kernel::is_even<A>(x, A {});
     }
@@ -907,7 +907,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> is_flint(batch<T, A> const& x) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV is_flint(batch<T, A> const& x) noexcept
     {
         return kernel::is_flint<A>(x, A {});
     }
@@ -920,7 +920,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> is_odd(batch<T, A> const& x) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV is_odd(batch<T, A> const& x) noexcept
     {
         return kernel::is_odd<A>(x, A {});
     }
@@ -933,7 +933,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> isinf(batch<T, A> const& x) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV isinf(batch<T, A> const& x) noexcept
     {
         return kernel::isinf<A>(x, A {});
     }
@@ -946,7 +946,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> isfinite(batch<T, A> const& x) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV isfinite(batch<T, A> const& x) noexcept
     {
         return kernel::isfinite<A>(x, A {});
     }
@@ -959,7 +959,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline typename batch<T, A>::batch_bool_type isnan(batch<T, A> const& x) noexcept
+    inline typename batch<T, A>::batch_bool_type XSIMD_CALLCONV isnan(batch<T, A> const& x) noexcept
     {
         return kernel::isnan<A>(x, A {});
     }
@@ -973,7 +973,7 @@ namespace xsimd
      * @return the natural logarithm of the gamma function of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& y) noexcept
     {
         return kernel::ldexp<A>(x, y, A {});
     }
@@ -987,7 +987,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> le(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV le(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x <= y;
     }
@@ -1000,7 +1000,7 @@ namespace xsimd
      * @return the natural logarithm of the gamma function of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> lgamma(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV lgamma(batch<T, A> const& x) noexcept
     {
         return kernel::lgamma<A>(x, A {});
     }
@@ -1014,14 +1014,14 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class To, class A = default_arch, class From>
-    inline simd_return_type<From, To> load_as(From const* ptr, aligned_mode) noexcept
+    inline simd_return_type<From, To> XSIMD_CALLCONV load_as(From const* ptr, aligned_mode) noexcept
     {
         using batch_value_type = typename simd_return_type<From, To>::value_type;
         return kernel::load_aligned<A>(ptr, kernel::convert<batch_value_type> {}, A {});
     }
 
     template <class To, class A = default_arch>
-    inline simd_return_type<bool, To> load_as(bool const* ptr, aligned_mode) noexcept
+    inline simd_return_type<bool, To> XSIMD_CALLCONV load_as(bool const* ptr, aligned_mode) noexcept
     {
         return simd_return_type<bool, To>::load_aligned(ptr);
     }
@@ -1035,7 +1035,7 @@ namespace xsimd
 
 #if XSIMD_ENABLE_XTL_COMPLEX
     template <class To, class A = default_arch, class From, bool i3ec>
-    inline simd_return_type<xtl::xcomplex<From, From, i3ec>, To> load_as(xtl::xcomplex<From, From, i3ec> const* ptr, aligned_mode) noexcept
+    inline simd_return_type<xtl::xcomplex<From, From, i3ec>, To> XSIMD_CALLCONV load_as(xtl::xcomplex<From, From, i3ec> const* ptr, aligned_mode) noexcept
     {
         return load_as<To>(reinterpret_cast<std::complex<From> const*>(ptr), aligned_mode());
     }
@@ -1050,20 +1050,20 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class To, class A = default_arch, class From>
-    inline simd_return_type<From, To> load_as(From const* ptr, unaligned_mode) noexcept
+    inline simd_return_type<From, To> XSIMD_CALLCONV load_as(From const* ptr, unaligned_mode) noexcept
     {
         using batch_value_type = typename simd_return_type<From, To>::value_type;
         return kernel::load_unaligned<A>(ptr, kernel::convert<batch_value_type> {}, A {});
     }
 
     template <class To, class A = default_arch>
-    inline simd_return_type<bool, To> load_as(bool const* ptr, unaligned_mode) noexcept
+    inline simd_return_type<bool, To> XSIMD_CALLCONV load_as(bool const* ptr, unaligned_mode) noexcept
     {
         return simd_return_type<bool, To>::load_unaligned(ptr);
     }
 
     template <class To, class A = default_arch, class From>
-    inline simd_return_type<std::complex<From>, To> load_as(std::complex<From> const* ptr, unaligned_mode) noexcept
+    inline simd_return_type<std::complex<From>, To> XSIMD_CALLCONV load_as(std::complex<From> const* ptr, unaligned_mode) noexcept
     {
         using batch_value_type = typename simd_return_type<std::complex<From>, To>::value_type;
         return kernel::load_complex_unaligned<A>(ptr, kernel::convert<batch_value_type> {}, A {});
@@ -1071,7 +1071,7 @@ namespace xsimd
 
 #if XSIMD_ENABLE_XTL_COMPLEX
     template <class To, class A = default_arch, class From, bool i3ec>
-    inline simd_return_type<xtl::xcomplex<From, From, i3ec>, To> load_as(xtl::xcomplex<From, From, i3ec> const* ptr, unaligned_mode) noexcept
+    inline simd_return_type<xtl::xcomplex<From, From, i3ec>, To> XSIMD_CALLCONV load_as(xtl::xcomplex<From, From, i3ec> const* ptr, unaligned_mode) noexcept
     {
         return load_as<To>(reinterpret_cast<std::complex<From> const*>(ptr), unaligned_mode());
     }
@@ -1086,7 +1086,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class A = default_arch, class From>
-    inline batch<From, A> load(From const* ptr, aligned_mode = {}) noexcept
+    inline batch<From, A> XSIMD_CALLCONV load(From const* ptr, aligned_mode = {}) noexcept
     {
         return load_as<From, A>(ptr, aligned_mode {});
     }
@@ -1100,7 +1100,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class A = default_arch, class From>
-    inline batch<From, A> load(From const* ptr, unaligned_mode) noexcept
+    inline batch<From, A> XSIMD_CALLCONV load(From const* ptr, unaligned_mode) noexcept
     {
         return load_as<From, A>(ptr, unaligned_mode {});
     }
@@ -1114,7 +1114,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class A = default_arch, class From>
-    inline batch<From, A> load_aligned(From const* ptr) noexcept
+    inline batch<From, A> XSIMD_CALLCONV load_aligned(From const* ptr) noexcept
     {
         return load_as<From, A>(ptr, aligned_mode {});
     }
@@ -1128,7 +1128,7 @@ namespace xsimd
      * @return a new batch instance
      */
     template <class A = default_arch, class From>
-    inline batch<From, A> load_unaligned(From const* ptr) noexcept
+    inline batch<From, A> XSIMD_CALLCONV load_unaligned(From const* ptr) noexcept
     {
         return load_as<From, A>(ptr, unaligned_mode {});
     }
@@ -1141,7 +1141,7 @@ namespace xsimd
      * @return the natural logarithm of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> log(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV log(batch<T, A> const& x) noexcept
     {
         return kernel::log<A>(x, A {});
     }
@@ -1153,7 +1153,7 @@ namespace xsimd
      * @return the base 2 logarithm of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> log2(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV log2(batch<T, A> const& x) noexcept
     {
         return kernel::log2<A>(x, A {});
     }
@@ -1165,7 +1165,7 @@ namespace xsimd
      * @return the base 10 logarithm of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> log10(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV log10(batch<T, A> const& x) noexcept
     {
         return kernel::log10<A>(x, A {});
     }
@@ -1177,7 +1177,7 @@ namespace xsimd
      * @return the natural logarithm of one plus \c x.
      */
     template <class T, class A>
-    inline batch<T, A> log1p(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV log1p(batch<T, A> const& x) noexcept
     {
         return kernel::log1p<A>(x, A {});
     }
@@ -1191,7 +1191,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> lt(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV lt(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x < y;
     }
@@ -1205,7 +1205,7 @@ namespace xsimd
      * @return a batch of the larger values.
      */
     template <class T, class A>
-    inline batch<T, A> max(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV max(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::max<A>(x, y, A {});
     }
@@ -1219,7 +1219,7 @@ namespace xsimd
      * @return a batch of the smaller values.
      */
     template <class T, class A>
-    inline batch<T, A> min(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV min(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::min<A>(x, y, A {});
     }
@@ -1231,7 +1231,7 @@ namespace xsimd
      * @return a batch of positive infinity
      */
     template <class B>
-    inline B minusinfinity() noexcept
+    inline B XSIMD_CALLCONV minusinfinity() noexcept
     {
         using T = typename B::value_type;
         return B(-std::numeric_limits<T>::infinity());
@@ -1246,7 +1246,7 @@ namespace xsimd
      * @return the result of the modulo.
      */
     template <class T, class Tp>
-    inline auto mod(T const& x, Tp const& y) noexcept -> decltype(x % y)
+    inline auto XSIMD_CALLCONV mod(T const& x, Tp const& y) noexcept -> decltype(x % y)
     {
         return x % y;
     }
@@ -1261,7 +1261,7 @@ namespace xsimd
      * @return the result of the product.
      */
     template <class T, class Tp>
-    inline auto mul(T const& x, Tp const& y) noexcept -> decltype(x * y)
+    inline auto XSIMD_CALLCONV mul(T const& x, Tp const& y) noexcept -> decltype(x * y)
     {
         return x * y;
     }
@@ -1275,7 +1275,7 @@ namespace xsimd
      * @return the result of the product.
      */
     template <class T, class A>
-    inline batch<T, A> mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    inline batch<T, A> XSIMD_CALLCONV mul_real(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
     {
         return kernel::mul_real<A>(a, b, A {});
     }
@@ -1289,7 +1289,7 @@ namespace xsimd
      * @return the result of the product.
      */
     template <class T, class A>
-    inline batch<T, A> mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
+    inline batch<T, A> XSIMD_CALLCONV mul_imag(const batch<std::complex<T>, A>& a, const batch<std::complex<T>, A>& b) noexcept
     {
         return kernel::mul_imag<A>(a, b, A {});
     }
@@ -1303,7 +1303,7 @@ namespace xsimd
      * @return the batch of nearest integer values.
      */
     template <class T, class A>
-    inline batch<T, A> nearbyint(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV nearbyint(batch<T, A> const& x) noexcept
     {
         return kernel::nearbyint<A>(x, A {});
     }
@@ -1317,7 +1317,7 @@ namespace xsimd
      * @return the batch of nearest integer values.
      */
     template <class T, class A>
-    inline batch<as_integer_t<T>, A>
+    inline batch<as_integer_t<T>, A> XSIMD_CALLCONV
     nearbyint_as_int(batch<T, A> const& x) noexcept
     {
         return kernel::nearbyint_as_int(x, A {});
@@ -1332,7 +1332,7 @@ namespace xsimd
      * @return a boolean batch.
      */
     template <class T, class A>
-    inline batch_bool<T, A> neq(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV neq(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return x != y;
     }
@@ -1345,7 +1345,7 @@ namespace xsimd
      * @return the opposite of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> neg(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV neg(batch<T, A> const& x) noexcept
     {
         return -x;
     }
@@ -1360,7 +1360,7 @@ namespace xsimd
      * @return \c x raised to the power \c y.
      */
     template <class T, class A>
-    inline batch<T, A> nextafter(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV nextafter(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::nextafter<A>(x, y, A {});
     }
@@ -1373,7 +1373,7 @@ namespace xsimd
      * @return the norm of \c x.
      */
     template <class A, class T>
-    inline real_batch_type_t<batch<T, A>> norm(batch<T, A> const& x) noexcept
+    inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV norm(batch<T, A> const& x) noexcept
     {
         return kernel::norm(x, A {});
     }
@@ -1387,7 +1387,7 @@ namespace xsimd
      * @return \c r exp(i * \c theta).
      */
     template <class T, class A>
-    inline complex_batch_type_t<batch<T, A>> polar(batch<T, A> const& r, batch<T, A> const& theta = batch<T, A> {}) noexcept
+    inline complex_batch_type_t<batch<T, A>> XSIMD_CALLCONV polar(batch<T, A> const& r, batch<T, A> const& theta = batch<T, A> {}) noexcept
     {
         return kernel::polar<A>(r, theta, A {});
     }
@@ -1400,7 +1400,7 @@ namespace xsimd
      * @return \c x.
      */
     template <class T, class A>
-    inline batch<T, A> pos(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV pos(batch<T, A> const& x) noexcept
     {
         return +x;
     }
@@ -1415,7 +1415,7 @@ namespace xsimd
      * @return \c x raised to the power \c y.
      */
     template <class T, class A>
-    inline batch<T, A> pow(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV pow(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::pow<A>(x, y, A {});
     }
@@ -1430,7 +1430,7 @@ namespace xsimd
      * @return \c x raised to the power \c y.
      */
     template <class T, class ITy, class A, class = typename std::enable_if<std::is_integral<ITy>::value, void>::type>
-    inline batch<T, A> pow(batch<T, A> const& x, ITy y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV pow(batch<T, A> const& x, ITy y) noexcept
     {
         return kernel::ipow<A>(x, y, A {});
     }
@@ -1443,7 +1443,7 @@ namespace xsimd
      * @return the projection of \c z.
      */
     template <class A, class T>
-    inline complex_batch_type_t<batch<T, A>> proj(batch<T, A> const& z) noexcept
+    inline complex_batch_type_t<batch<T, A>> XSIMD_CALLCONV proj(batch<T, A> const& z) noexcept
     {
         return kernel::proj(z, A {});
     }
@@ -1458,7 +1458,7 @@ namespace xsimd
      * @return the reciprocal.
      */
     template <class T, class A, class = typename std::enable_if<std::is_floating_point<T>::value, void>::type>
-    inline batch<T, A> reciprocal(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV reciprocal(batch<T, A> const& x) noexcept
     {
         return kernel::reciprocal(x, A {});
     }
@@ -1471,7 +1471,7 @@ namespace xsimd
      * @return the argument of \c z.
      */
     template <class T, class A>
-    inline real_batch_type_t<batch<T, A>> real(batch<T, A> const& z) noexcept
+    inline real_batch_type_t<batch<T, A>> XSIMD_CALLCONV real(batch<T, A> const& z) noexcept
     {
         return kernel::real<A>(z, A {});
     }
@@ -1485,7 +1485,7 @@ namespace xsimd
      * @return the result of the addition.
      */
     template <class T, class A>
-    inline batch<T, A> remainder(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV remainder(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::remainder<A>(x, y, A {});
     }
@@ -1499,7 +1499,7 @@ namespace xsimd
      * @return the batch of rounded values.
      */
     template <class T, class A>
-    inline batch<T, A> rint(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV rint(batch<T, A> const& x) noexcept
     {
         return nearbyint(x);
     }
@@ -1514,7 +1514,7 @@ namespace xsimd
      * @return the batch of nearest integer values.
      */
     template <class T, class A>
-    inline batch<T, A> round(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV round(batch<T, A> const& x) noexcept
     {
         return kernel::round<A>(x, A {});
     }
@@ -1531,7 +1531,7 @@ namespace xsimd
      * @return the inverse square root of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> rsqrt(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV rsqrt(batch<T, A> const& x) noexcept
     {
         return kernel::rsqrt<A>(x, A {});
     }
@@ -1547,7 +1547,7 @@ namespace xsimd
      * @return the result of the saturated addition.
      */
     template <class T, class Tp>
-    inline auto sadd(T const& x, Tp const& y) noexcept -> decltype(x + y)
+    inline auto XSIMD_CALLCONV sadd(T const& x, Tp const& y) noexcept -> decltype(x + y)
     {
         using B = decltype(x + y);
         using A = typename B::arch_type;
@@ -1569,7 +1569,7 @@ namespace xsimd
      * @return the result of the selection.
      */
     template <class T, class A>
-    inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br) noexcept
+    inline batch<T, A> XSIMD_CALLCONV select(batch_bool<T, A> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br) noexcept
     {
         return kernel::select<A>(cond, true_br, false_br, A {});
     }
@@ -1589,7 +1589,7 @@ namespace xsimd
      * @return the result of the selection.
      */
     template <class T, class A>
-    inline batch<std::complex<T>, A> select(batch_bool<T, A> const& cond, batch<std::complex<T>, A> const& true_br, batch<std::complex<T>, A> const& false_br) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV select(batch_bool<T, A> const& cond, batch<std::complex<T>, A> const& true_br, batch<std::complex<T>, A> const& false_br) noexcept
     {
         return kernel::select<A>(cond, true_br, false_br, A {});
     }
@@ -1609,7 +1609,7 @@ namespace xsimd
      * @return the result of the selection.
      */
     template <class T, class A, bool... Values>
-    inline batch<T, A> select(batch_bool_constant<batch<T, A>, Values...> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br) noexcept
+    inline batch<T, A> XSIMD_CALLCONV select(batch_bool_constant<batch<T, A>, Values...> const& cond, batch<T, A> const& true_br, batch<T, A> const& false_br) noexcept
     {
         return kernel::select<A>(cond, true_br, false_br, A {});
     }
@@ -1622,7 +1622,7 @@ namespace xsimd
      * @return -1 for each negative element, -1 or +1 for each null element and +1 for each element
      */
     template <class T, class A>
-    inline batch<T, A> sign(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV sign(batch<T, A> const& x) noexcept
     {
         return kernel::sign<A>(x, A {});
     }
@@ -1635,7 +1635,7 @@ namespace xsimd
      * @return -1 for each negative element, -1 or +1 for each null element and +1 for each element
      */
     template <class T, class A>
-    inline batch<T, A> signnz(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV signnz(batch<T, A> const& x) noexcept
     {
         return kernel::signnz<A>(x, A {});
     }
@@ -1648,7 +1648,7 @@ namespace xsimd
      * @return the sine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> sin(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV sin(batch<T, A> const& x) noexcept
     {
         return kernel::sin<A>(x, A {});
     }
@@ -1661,7 +1661,7 @@ namespace xsimd
      * @return the hyperbolic sine of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> sinh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV sinh(batch<T, A> const& x) noexcept
     {
         return kernel::sinh<A>(x, A {});
     }
@@ -1675,7 +1675,7 @@ namespace xsimd
      * @return a pair containing the sine then the cosine of  batch \c x
      */
     template <class T, class A>
-    inline std::pair<batch<T, A>, batch<T, A>> sincos(batch<T, A> const& x) noexcept
+    inline std::pair<batch<T, A>, batch<T, A>> XSIMD_CALLCONV sincos(batch<T, A> const& x) noexcept
     {
         return kernel::sincos<A>(x, A {});
     }
@@ -1691,7 +1691,7 @@ namespace xsimd
      * @return slided batch.
      */
     template <size_t N, class T, class A>
-    inline batch<T, A> slide_left(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV slide_left(batch<T, A> const& x) noexcept
     {
         static_assert(std::is_integral<T>::value, "can only slide batch of integers");
         return kernel::slide_left<N, A>(x, A {});
@@ -1708,7 +1708,7 @@ namespace xsimd
      * @return slided batch.
      */
     template <size_t N, class T, class A>
-    inline batch<T, A> slide_right(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV slide_right(batch<T, A> const& x) noexcept
     {
         static_assert(std::is_integral<T>::value, "can only slide batch of integers");
         return kernel::slide_right<N, A>(x, A {});
@@ -1722,7 +1722,7 @@ namespace xsimd
      * @return the square root of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> sqrt(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV sqrt(batch<T, A> const& x) noexcept
     {
         return kernel::sqrt<A>(x, A {});
     }
@@ -1737,7 +1737,7 @@ namespace xsimd
      * @return the result of the saturated difference.
      */
     template <class T, class Tp>
-    inline auto ssub(T const& x, Tp const& y) noexcept -> decltype(x - y)
+    inline auto XSIMD_CALLCONV ssub(T const& x, Tp const& y) noexcept -> decltype(x - y)
     {
         using B = decltype(x + y);
         using A = typename B::arch_type;
@@ -1753,26 +1753,26 @@ namespace xsimd
      * @param src the batch to copy
      */
     template <class To, class A = default_arch, class From>
-    inline void store_as(To* dst, batch<From, A> const& src, aligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(To* dst, batch<From, A> const& src, aligned_mode) noexcept
     {
         kernel::store_aligned(dst, src, A {});
     }
 
     template <class A = default_arch, class From>
-    inline void store_as(bool* dst, batch_bool<From, A> const& src, aligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(bool* dst, batch_bool<From, A> const& src, aligned_mode) noexcept
     {
         kernel::store(src, dst, A {});
     }
 
     template <class To, class A = default_arch, class From>
-    inline void store_as(std::complex<To>* dst, batch<std::complex<From>, A> const& src, aligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(std::complex<To>* dst, batch<std::complex<From>, A> const& src, aligned_mode) noexcept
     {
         kernel::store_complex_aligned(dst, src, A {});
     }
 
 #if XSIMD_ENABLE_XTL_COMPLEX
     template <class To, class A = default_arch, class From, bool i3ec>
-    inline void store_as(xtl::xcomplex<To, To, i3ec>* dst, batch<std::complex<From>, A> const& src, aligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(xtl::xcomplex<To, To, i3ec>* dst, batch<std::complex<From>, A> const& src, aligned_mode) noexcept
     {
         store_as(reinterpret_cast<std::complex<To>*>(dst), src, aligned_mode());
     }
@@ -1787,26 +1787,26 @@ namespace xsimd
      * @param src the batch to copy
      */
     template <class To, class A = default_arch, class From>
-    inline void store_as(To* dst, batch<From, A> const& src, unaligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(To* dst, batch<From, A> const& src, unaligned_mode) noexcept
     {
         kernel::store_unaligned(dst, src, A {});
     }
 
     template <class A = default_arch, class From>
-    inline void store_as(bool* dst, batch_bool<From, A> const& src, unaligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(bool* dst, batch_bool<From, A> const& src, unaligned_mode) noexcept
     {
         kernel::store(src, dst, A {});
     }
 
     template <class To, class A = default_arch, class From>
-    inline void store_as(std::complex<To>* dst, batch<std::complex<From>, A> const& src, unaligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(std::complex<To>* dst, batch<std::complex<From>, A> const& src, unaligned_mode) noexcept
     {
         kernel::store_complex_unaligned(dst, src, A {});
     }
 
 #if XSIMD_ENABLE_XTL_COMPLEX
     template <class To, class A = default_arch, class From, bool i3ec>
-    inline void store_as(xtl::xcomplex<To, To, i3ec>* dst, batch<std::complex<From>, A> const& src, unaligned_mode) noexcept
+    inline void XSIMD_CALLCONV store_as(xtl::xcomplex<To, To, i3ec>* dst, batch<std::complex<From>, A> const& src, unaligned_mode) noexcept
     {
         store_as(reinterpret_cast<std::complex<To>*>(dst), src, unaligned_mode());
     }
@@ -1821,7 +1821,7 @@ namespace xsimd
      * @param val the batch to copy from
      */
     template <class A, class T>
-    inline void store(T* mem, batch<T, A> const& val, aligned_mode = {}) noexcept
+    inline void XSIMD_CALLCONV store(T* mem, batch<T, A> const& val, aligned_mode = {}) noexcept
     {
         store_as<T, A>(mem, val, aligned_mode {});
     }
@@ -1835,7 +1835,7 @@ namespace xsimd
      * @param val the batch to copy from
      */
     template <class A, class T>
-    inline void store(T* mem, batch<T, A> const& val, unaligned_mode) noexcept
+    inline void XSIMD_CALLCONV store(T* mem, batch<T, A> const& val, unaligned_mode) noexcept
     {
         store_as<T, A>(mem, val, unaligned_mode {});
     }
@@ -1849,7 +1849,7 @@ namespace xsimd
      * @param val the batch to copy from
      */
     template <class A, class T>
-    inline void store_aligned(T* mem, batch<T, A> const& val) noexcept
+    inline void XSIMD_CALLCONV store_aligned(T* mem, batch<T, A> const& val) noexcept
     {
         store_as<T, A>(mem, val, aligned_mode {});
     }
@@ -1863,7 +1863,7 @@ namespace xsimd
      * @param val the batch to copy
      */
     template <class A, class T>
-    inline void store_unaligned(T* mem, batch<T, A> const& val) noexcept
+    inline void XSIMD_CALLCONV store_unaligned(T* mem, batch<T, A> const& val) noexcept
     {
         store_as<T, A>(mem, val, unaligned_mode {});
     }
@@ -1878,7 +1878,7 @@ namespace xsimd
      * @return the difference between \c x and \c y
      */
     template <class T, class Tp>
-    inline auto sub(T const& x, Tp const& y) noexcept -> decltype(x - y)
+    inline auto XSIMD_CALLCONV sub(T const& x, Tp const& y) noexcept -> decltype(x - y)
     {
         return x - y;
     }
@@ -1893,14 +1893,14 @@ namespace xsimd
      * @return swizzled batch
      */
     template <class T, class A, class Vt, Vt... Values>
-    inline typename std::enable_if<std::is_arithmetic<T>::value, batch<T, A>>::type
+    inline typename std::enable_if<std::is_arithmetic<T>::value, batch<T, A>>::type XSIMD_CALLCONV
     swizzle(batch<T, A> const& x, batch_constant<batch<Vt, A>, Values...> mask) noexcept
     {
         static_assert(sizeof(T) == sizeof(Vt), "consistent mask");
         return kernel::swizzle<A>(x, mask, A {});
     }
     template <class T, class A, class Vt, Vt... Values>
-    inline batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& x, batch_constant<batch<Vt, A>, Values...> mask) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV swizzle(batch<std::complex<T>, A> const& x, batch_constant<batch<Vt, A>, Values...> mask) noexcept
     {
         static_assert(sizeof(T) == sizeof(Vt), "consistent mask");
         return kernel::swizzle<A>(x, mask, A {});
@@ -1914,7 +1914,7 @@ namespace xsimd
      * @return the tangent of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> tan(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV tan(batch<T, A> const& x) noexcept
     {
         return kernel::tan<A>(x, A {});
     }
@@ -1927,7 +1927,7 @@ namespace xsimd
      * @return the hyperbolic tangent of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> tanh(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV tanh(batch<T, A> const& x) noexcept
     {
         return kernel::tanh<A>(x, A {});
     }
@@ -1940,7 +1940,7 @@ namespace xsimd
      * @return the gamma function of \c x.
      */
     template <class T, class A>
-    inline batch<T, A> tgamma(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV tgamma(batch<T, A> const& x) noexcept
     {
         return kernel::tgamma<A>(x, A {});
     }
@@ -1954,7 +1954,7 @@ namespace xsimd
      * @return \c i converted to a value of an floating point type of the same size as \c T
      */
     template <class T, class A>
-    inline batch<as_float_t<T>, A> to_float(batch<T, A> const& i) noexcept
+    inline batch<as_float_t<T>, A> XSIMD_CALLCONV to_float(batch<T, A> const& i) noexcept
     {
         return batch_cast<as_float_t<T>>(i);
     }
@@ -1968,7 +1968,7 @@ namespace xsimd
      * @return \c x converted to a value of an integer type of the same size as \c T
      */
     template <class T, class A>
-    inline batch<as_integer_t<T>, A> to_int(batch<T, A> const& x) noexcept
+    inline batch<as_integer_t<T>, A> XSIMD_CALLCONV to_int(batch<T, A> const& x) noexcept
     {
         return batch_cast<as_integer_t<T>>(x);
     }
@@ -1982,7 +1982,7 @@ namespace xsimd
      * @return the batch of nearest integer values not greater in magnitude than \c x.
      */
     template <class T, class A>
-    inline batch<T, A> trunc(batch<T, A> const& x) noexcept
+    inline batch<T, A> XSIMD_CALLCONV trunc(batch<T, A> const& x) noexcept
     {
         return kernel::trunc<A>(x, A {});
     }
@@ -1997,7 +1997,7 @@ namespace xsimd
      * @return a batch of the high part of shuffled values.
      */
     template <class T, class A>
-    inline batch<T, A> zip_hi(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV zip_hi(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::zip_hi<A>(x, y, A {});
     }
@@ -2012,21 +2012,21 @@ namespace xsimd
      * @return a batch of the low part of shuffled values.
      */
     template <class T, class A>
-    inline batch<T, A> zip_lo(batch<T, A> const& x, batch<T, A> const& y) noexcept
+    inline batch<T, A> XSIMD_CALLCONV zip_lo(batch<T, A> const& x, batch<T, A> const& y) noexcept
     {
         return kernel::zip_lo<A>(x, y, A {});
     }
 
     // bitwise_cast
     template <class A, class T, typename std::enable_if<std::is_integral<T>::value, int>::type = 3>
-    inline batch<T, A> bitwise_cast(batch_bool<T, A> const& self) noexcept
+    inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch_bool<T, A> const& self) noexcept
     {
         T z(0);
         return select(self, batch<T, A>(T(~z)), batch<T, A>(z));
     }
 
     template <class A, class T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 3>
-    inline batch<T, A> bitwise_cast(batch_bool<T, A> const& self) noexcept
+    inline batch<T, A> XSIMD_CALLCONV bitwise_cast(batch_bool<T, A> const& self) noexcept
     {
         T z0(0), z1(0);
         using int_type = as_unsigned_integer_t<T>;
@@ -2044,7 +2044,7 @@ namespace xsimd
      * @return a boolean scalar.
      */
     template <class T, class A>
-    inline bool all(batch_bool<T, A> const& x) noexcept
+    inline bool XSIMD_CALLCONV all(batch_bool<T, A> const& x) noexcept
     {
         return kernel::all<A>(x, A {});
     }
@@ -2058,7 +2058,7 @@ namespace xsimd
      * @return a boolean scalar.
      */
     template <class T, class A>
-    inline bool any(batch_bool<T, A> const& x) noexcept
+    inline bool XSIMD_CALLCONV any(batch_bool<T, A> const& x) noexcept
     {
         return kernel::any<A>(x, A {});
     }
@@ -2072,7 +2072,7 @@ namespace xsimd
      * @return a boolean scalar.
      */
     template <class T, class A>
-    inline bool none(batch_bool<T, A> const& x) noexcept
+    inline bool XSIMD_CALLCONV none(batch_bool<T, A> const& x) noexcept
     {
         return !xsimd::any(x);
     }
@@ -2086,7 +2086,7 @@ namespace xsimd
      * @return a reference to \c o
      */
     template <class T, class A>
-    inline std::ostream& operator<<(std::ostream& o, batch<T, A> const& x) noexcept
+    inline std::ostream& XSIMD_CALLCONV operator<<(std::ostream& o, batch<T, A> const& x) noexcept
     {
         constexpr auto size = batch<T, A>::size;
         alignas(A::alignment()) T buffer[size];
@@ -2106,7 +2106,7 @@ namespace xsimd
      * @return a reference to \c o
      */
     template <class T, class A>
-    inline std::ostream& operator<<(std::ostream& o, batch_bool<T, A> const& x) noexcept
+    inline std::ostream& XSIMD_CALLCONV operator<<(std::ostream& o, batch_bool<T, A> const& x) noexcept
     {
         constexpr auto size = batch_bool<T, A>::size;
         alignas(A::alignment()) bool buffer[size];

--- a/include/xsimd/types/xsimd_avx512f_register.hpp
+++ b/include/xsimd/types/xsimd_avx512f_register.hpp
@@ -13,6 +13,7 @@
 #define XSIMD_AVX512F_REGISTER_HPP
 
 #include "./xsimd_generic_arch.hpp"
+#include "./xsimd_register.hpp" // XSIMD_DECLARE_SIMD_REGISTER
 
 namespace xsimd
 {
@@ -44,8 +45,8 @@ namespace xsimd
                 std::conditional<(sizeof(T) == 4), __mmask16, __mmask8>>::type::type;
             register_type data;
             simd_avx512_bool_register() = default;
-            simd_avx512_bool_register(register_type r) { data = r; }
-            operator register_type() const noexcept { return data; }
+            simd_avx512_bool_register(register_type r) noexcept { data = r; }
+            XSIMD_FORCEINLINE XSIMD_CALLCONV operator register_type() const noexcept { return data; }
         };
         template <class T>
         struct get_bool_simd_register<T, avx512f>

--- a/include/xsimd/types/xsimd_avx_register.hpp
+++ b/include/xsimd/types/xsimd_avx_register.hpp
@@ -13,6 +13,7 @@
 #define XSIMD_AVX_REGISTER_HPP
 
 #include "./xsimd_generic_arch.hpp"
+#include "./xsimd_register.hpp" // XSIMD_DECLARE_SIMD_REGISTER
 
 namespace xsimd
 {

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -51,159 +51,159 @@ namespace xsimd
         batch(register_type reg) noexcept;
 
         template <class U>
-        XSIMD_NO_DISCARD static batch broadcast(U val) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV broadcast(U val) noexcept;
 
         // memory operators
         template <class U>
-        void store_aligned(U* mem) const noexcept;
+        void XSIMD_CALLCONV store_aligned(U* mem) const noexcept;
         template <class U>
-        void store_unaligned(U* mem) const noexcept;
+        void XSIMD_CALLCONV store_unaligned(U* mem) const noexcept;
         template <class U>
-        void store(U* mem, aligned_mode) const noexcept;
+        void XSIMD_CALLCONV store(U* mem, aligned_mode) const noexcept;
         template <class U>
-        void store(U* mem, unaligned_mode) const noexcept;
+        void XSIMD_CALLCONV store(U* mem, unaligned_mode) const noexcept;
 
         template <class U>
-        XSIMD_NO_DISCARD static batch load_aligned(U const* mem) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_aligned(U const* mem) noexcept;
         template <class U>
-        XSIMD_NO_DISCARD static batch load_unaligned(U const* mem) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_unaligned(U const* mem) noexcept;
         template <class U>
-        XSIMD_NO_DISCARD static batch load(U const* mem, aligned_mode) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load(U const* mem, aligned_mode) noexcept;
         template <class U>
-        XSIMD_NO_DISCARD static batch load(U const* mem, unaligned_mode) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load(U const* mem, unaligned_mode) noexcept;
 
         template <class U, class V>
-        XSIMD_NO_DISCARD static batch gather(U const* src, batch<V, arch_type> const& index) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV gather(U const* src, batch<V, arch_type> const& index) noexcept;
         template <class U, class V>
-        void scatter(U* dst, batch<V, arch_type> const& index) const noexcept;
+        void XSIMD_CALLCONV scatter(U* dst, batch<V, arch_type> const& index) const noexcept;
 
-        T get(std::size_t i) const noexcept;
+        T XSIMD_CALLCONV get(std::size_t i) const noexcept;
 
         // comparison operators
-        inline batch_bool_type operator==(batch const& other) const noexcept;
-        inline batch_bool_type operator!=(batch const& other) const noexcept;
-        inline batch_bool_type operator>=(batch const& other) const noexcept;
-        inline batch_bool_type operator<=(batch const& other) const noexcept;
-        inline batch_bool_type operator>(batch const& other) const noexcept;
-        inline batch_bool_type operator<(batch const& other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator==(batch XSIMD_CREF other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator!=(batch XSIMD_CREF other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator>=(batch XSIMD_CREF other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator<=(batch XSIMD_CREF other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator>(batch XSIMD_CREF other) const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator<(batch XSIMD_CREF other) const noexcept;
 
         // Update operators
-        inline batch& operator+=(batch const& other) noexcept;
-        inline batch& operator-=(batch const& other) noexcept;
-        inline batch& operator*=(batch const& other) noexcept;
-        inline batch& operator/=(batch const& other) noexcept;
-        inline batch& operator%=(batch const& other) noexcept;
-        inline batch& operator&=(batch const& other) noexcept;
-        inline batch& operator|=(batch const& other) noexcept;
-        inline batch& operator^=(batch const& other) noexcept;
-        inline batch& operator>>=(int32_t other) noexcept;
-        inline batch& operator>>=(batch const& other) noexcept;
-        inline batch& operator<<=(int32_t other) noexcept;
-        inline batch& operator<<=(batch const& other) noexcept;
+        inline batch& XSIMD_CALLCONV operator+=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator-=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator*=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator/=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator%=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator&=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator|=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator^=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator>>=(int32_t other) noexcept;
+        inline batch& XSIMD_CALLCONV operator>>=(batch XSIMD_CREF other) noexcept;
+        inline batch& XSIMD_CALLCONV operator<<=(int32_t other) noexcept;
+        inline batch& XSIMD_CALLCONV operator<<=(batch XSIMD_CREF other) noexcept;
 
         // incr/decr operators
-        inline batch& operator++() noexcept;
-        inline batch& operator--() noexcept;
-        inline batch operator++(int) noexcept;
-        inline batch operator--(int) noexcept;
+        inline batch& XSIMD_CALLCONV operator++() noexcept;
+        inline batch& XSIMD_CALLCONV operator--() noexcept;
+        inline batch XSIMD_CALLCONV operator++(int) noexcept;
+        inline batch XSIMD_CALLCONV operator--(int) noexcept;
 
         // unary operators
-        inline batch_bool_type operator!() const noexcept;
-        inline batch operator~() const noexcept;
-        inline batch operator-() const noexcept;
-        inline batch operator+() const noexcept;
+        inline batch_bool_type XSIMD_CALLCONV operator!() const noexcept;
+        inline batch XSIMD_CALLCONV operator~() const noexcept;
+        inline batch XSIMD_CALLCONV operator-() const noexcept;
+        inline batch XSIMD_CALLCONV operator+() const noexcept;
 
         // arithmetic operators. They are defined as friend to enable automatic
         // conversion of parameters from scalar to batch. Inline implementation
         // is required to avoid warnings.
 
         /** Shorthand for xsimd::add() */
-        friend batch operator+(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator+(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) += other;
         }
 
         /** Shorthand for xsimd::sub() */
-        friend batch operator-(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator-(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) -= other;
         }
 
         /** Shorthand for xsimd::mul() */
-        friend batch operator*(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator*(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) *= other;
         }
 
         /** Shorthand for xsimd::div() */
-        friend batch operator/(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator/(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) /= other;
         }
 
         /** Shorthand for xsimd::mod() */
-        friend batch operator%(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator%(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) %= other;
         }
 
         /** Shorthand for xsimd::bitwise_and() */
-        friend batch operator&(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator&(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) &= other;
         }
 
         /** Shorthand for xsimd::bitwise_or() */
-        friend batch operator|(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator|(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) |= other;
         }
 
         /** Shorthand for xsimd::bitwise_xor() */
-        friend batch operator^(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator^(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) ^= other;
         }
 
         /** Shorthand for xsimd::bitwise_rshift() */
-        friend batch operator>>(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator>>(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) >>= other;
         }
 
         /** Shorthand for xsimd::bitwise_lshift() */
-        friend batch operator<<(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator<<(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self) <<= other;
         }
 
         /** Shorthand for xsimd::bitwise_rshift() */
-        friend batch operator>>(batch const& self, int32_t other) noexcept
+        friend batch XSIMD_CALLCONV operator>>(batch XSIMD_CREF self, int32_t other) noexcept
         {
             return batch(self) >>= other;
         }
 
         /** Shorthand for xsimd::bitwise_lshift() */
-        friend batch operator<<(batch const& self, int32_t other) noexcept
+        friend batch XSIMD_CALLCONV operator<<(batch XSIMD_CREF self, int32_t other) noexcept
         {
             return batch(self) <<= other;
         }
 
         /** Shorthand for xsimd::logical_and() */
-        friend batch operator&&(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator&&(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self).logical_and(other);
         }
 
         /** Shorthand for xsimd::logical_or() */
-        friend batch operator||(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator||(batch XSIMD_CREF self, batch XSIMD_CREF other) noexcept
         {
             return batch(self).logical_or(other);
         }
 
     private:
-        batch logical_and(batch const& other) const noexcept;
-        batch logical_or(batch const& other) const noexcept;
+        batch XSIMD_CALLCONV logical_and(batch XSIMD_CREF other) const noexcept;
+        batch XSIMD_CALLCONV logical_or(batch XSIMD_CREF other) const noexcept;
     };
 
     template <class T, class A>
@@ -242,41 +242,41 @@ namespace xsimd
         batch_bool(Tp const*) = delete;
 
         // memory operators
-        void store_aligned(bool* mem) const noexcept;
-        void store_unaligned(bool* mem) const noexcept;
-        XSIMD_NO_DISCARD static batch_bool load_aligned(bool const* mem) noexcept;
-        XSIMD_NO_DISCARD static batch_bool load_unaligned(bool const* mem) noexcept;
+        void XSIMD_CALLCONV store_aligned(bool* mem) const noexcept;
+        void XSIMD_CALLCONV store_unaligned(bool* mem) const noexcept;
+        XSIMD_NO_DISCARD static batch_bool XSIMD_CALLCONV load_aligned(bool const* mem) noexcept;
+        XSIMD_NO_DISCARD static batch_bool XSIMD_CALLCONV load_unaligned(bool const* mem) noexcept;
 
-        bool get(std::size_t i) const noexcept;
+        bool XSIMD_CALLCONV get(std::size_t i) const noexcept;
 
         // mask operations
-        uint64_t mask() const noexcept;
-        static batch_bool from_mask(uint64_t mask) noexcept;
+        uint64_t XSIMD_CALLCONV mask() const noexcept;
+        static batch_bool XSIMD_CALLCONV from_mask(uint64_t mask) noexcept;
 
         // comparison operators
-        batch_bool operator==(batch_bool const& other) const noexcept;
-        batch_bool operator!=(batch_bool const& other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator==(batch_bool XSIMD_CREF other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator!=(batch_bool XSIMD_CREF other) const noexcept;
 
         // logical operators
-        batch_bool operator~() const noexcept;
-        batch_bool operator!() const noexcept;
-        batch_bool operator&(batch_bool const& other) const noexcept;
-        batch_bool operator|(batch_bool const& other) const noexcept;
-        batch_bool operator^(batch_bool const& other) const noexcept;
-        batch_bool operator&&(batch_bool const& other) const noexcept;
-        batch_bool operator||(batch_bool const& other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator~() const noexcept;
+        batch_bool XSIMD_CALLCONV operator!() const noexcept;
+        batch_bool XSIMD_CALLCONV operator&(batch_bool XSIMD_CREF other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator|(batch_bool XSIMD_CREF other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator^(batch_bool XSIMD_CREF other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator&&(batch_bool XSIMD_CREF other) const noexcept;
+        batch_bool XSIMD_CALLCONV operator||(batch_bool XSIMD_CREF other) const noexcept;
 
         // update operators
-        batch_bool& operator&=(batch_bool const& other) const noexcept { return (*this) = (*this) & other; }
-        batch_bool& operator|=(batch_bool const& other) const noexcept { return (*this) = (*this) | other; }
-        batch_bool& operator^=(batch_bool const& other) const noexcept { return (*this) = (*this) ^ other; }
+        batch_bool& XSIMD_CALLCONV operator&=(batch_bool XSIMD_CREF other) const noexcept { return (*this) = (*this) & other; }
+        batch_bool& XSIMD_CALLCONV operator|=(batch_bool XSIMD_CREF other) const noexcept { return (*this) = (*this) | other; }
+        batch_bool& XSIMD_CALLCONV operator^=(batch_bool XSIMD_CREF other) const noexcept { return (*this) = (*this) ^ other; }
 
     private:
         template <class U, class... V, size_t I, size_t... Is>
-        static register_type make_register(detail::index_sequence<I, Is...>, U u, V... v) noexcept;
+        static register_type XSIMD_CALLCONV make_register(detail::index_sequence<I, Is...>, U u, V... v) noexcept;
 
         template <class... V>
-        static register_type make_register(detail::index_sequence<>, V... v) noexcept;
+        static register_type XSIMD_CALLCONV make_register(detail::index_sequence<>, V... v) noexcept;
     };
 
     template <class T, class A>
@@ -313,29 +313,29 @@ namespace xsimd
         explicit batch(batch_bool_type const& b) noexcept;
 
         // memory operators
-        XSIMD_NO_DISCARD static batch load_aligned(const T* real_src, const T* imag_src = nullptr) noexcept;
-        XSIMD_NO_DISCARD static batch load_unaligned(const T* real_src, const T* imag_src = nullptr) noexcept;
-        void store_aligned(T* real_dst, T* imag_dst) const noexcept;
-        void store_unaligned(T* real_dst, T* imag_dst) const noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_aligned(const T* real_src, const T* imag_src = nullptr) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_unaligned(const T* real_src, const T* imag_src = nullptr) noexcept;
+        void XSIMD_CALLCONV store_aligned(T* real_dst, T* imag_dst) const noexcept;
+        void XSIMD_CALLCONV store_unaligned(T* real_dst, T* imag_dst) const noexcept;
 
-        XSIMD_NO_DISCARD static batch load_aligned(const value_type* src) noexcept;
-        XSIMD_NO_DISCARD static batch load_unaligned(const value_type* src) noexcept;
-        void store_aligned(value_type* dst) const noexcept;
-        void store_unaligned(value_type* dst) const noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_aligned(const value_type* src) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_unaligned(const value_type* src) noexcept;
+        void XSIMD_CALLCONV store_aligned(value_type* dst) const noexcept;
+        void XSIMD_CALLCONV store_unaligned(value_type* dst) const noexcept;
 
         template <class U>
-        XSIMD_NO_DISCARD static batch load(U const* mem, aligned_mode) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load(U const* mem, aligned_mode) noexcept;
         template <class U>
-        XSIMD_NO_DISCARD static batch load(U const* mem, unaligned_mode) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load(U const* mem, unaligned_mode) noexcept;
         template <class U>
-        void store(U* mem, aligned_mode) const noexcept;
+        void XSIMD_CALLCONV store(U* mem, aligned_mode) const noexcept;
         template <class U>
-        void store(U* mem, unaligned_mode) const noexcept;
+        void XSIMD_CALLCONV store(U* mem, unaligned_mode) const noexcept;
 
-        real_batch real() const noexcept;
-        real_batch imag() const noexcept;
+        real_batch XSIMD_CALLCONV real() const noexcept;
+        real_batch XSIMD_CALLCONV imag() const noexcept;
 
-        value_type get(std::size_t i) const noexcept;
+        value_type XSIMD_CALLCONV get(std::size_t i) const noexcept;
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
         // xtl-related methods
@@ -345,60 +345,60 @@ namespace xsimd
         batch(xtl::xcomplex<T, T, i3ec> val0, xtl::xcomplex<T, T, i3ec> val1, Ts... vals) noexcept;
 
         template <bool i3ec>
-        XSIMD_NO_DISCARD static batch load_aligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_aligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept;
         template <bool i3ec>
-        XSIMD_NO_DISCARD static batch load_unaligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept;
+        XSIMD_NO_DISCARD static batch XSIMD_CALLCONV load_unaligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept;
         template <bool i3ec>
-        void store_aligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept;
+        void XSIMD_CALLCONV store_aligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept;
         template <bool i3ec>
-        void store_unaligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept;
+        void XSIMD_CALLCONV store_unaligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept;
 #endif
 
         // comparison operators
-        batch_bool<T, A> operator==(batch const& other) const noexcept;
-        batch_bool<T, A> operator!=(batch const& other) const noexcept;
+        batch_bool<T, A> XSIMD_CALLCONV operator==(batch const& other) const noexcept;
+        batch_bool<T, A> XSIMD_CALLCONV operator!=(batch const& other) const noexcept;
 
         // Update operators
-        batch& operator+=(batch const& other) noexcept;
-        batch& operator-=(batch const& other) noexcept;
-        batch& operator*=(batch const& other) noexcept;
-        batch& operator/=(batch const& other) noexcept;
+        batch& XSIMD_CALLCONV operator+=(batch const& other) noexcept;
+        batch& XSIMD_CALLCONV operator-=(batch const& other) noexcept;
+        batch& XSIMD_CALLCONV operator*=(batch const& other) noexcept;
+        batch& XSIMD_CALLCONV operator/=(batch const& other) noexcept;
 
         // incr/decr operators
-        batch& operator++() noexcept;
-        batch& operator--() noexcept;
-        batch operator++(int) noexcept;
-        batch operator--(int) noexcept;
+        batch& XSIMD_CALLCONV operator++() noexcept;
+        batch& XSIMD_CALLCONV operator--() noexcept;
+        batch XSIMD_CALLCONV operator++(int) noexcept;
+        batch XSIMD_CALLCONV operator--(int) noexcept;
 
         // unary operators
-        batch_bool_type operator!() const noexcept;
-        batch operator~() const noexcept;
-        batch operator-() const noexcept;
-        batch operator+() const noexcept;
+        batch_bool_type XSIMD_CALLCONV operator!() const noexcept;
+        batch XSIMD_CALLCONV operator~() const noexcept;
+        batch XSIMD_CALLCONV operator-() const noexcept;
+        batch XSIMD_CALLCONV operator+() const noexcept;
 
         // arithmetic operators. They are defined as friend to enable automatic
         // conversion of parameters from scalar to batch
 
         /** Shorthand for xsimd::add() */
-        friend batch operator+(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator+(batch const& self, batch const& other) noexcept
         {
             return batch(self) += other;
         }
 
         /** Shorthand for xsimd::sub() */
-        friend batch operator-(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator-(batch const& self, batch const& other) noexcept
         {
             return batch(self) -= other;
         }
 
         /** Shorthand for xsimd::mul() */
-        friend batch operator*(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator*(batch const& self, batch const& other) noexcept
         {
             return batch(self) *= other;
         }
 
         /** Shorthand for xsimd::div() */
-        friend batch operator/(batch const& self, batch const& other) noexcept
+        friend batch XSIMD_CALLCONV operator/(batch const& self, batch const& other) noexcept
         {
             return batch(self) /= other;
         }
@@ -474,7 +474,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    XSIMD_NO_DISCARD inline batch<T, A> batch<T, A>::broadcast(U val) noexcept
+    XSIMD_NO_DISCARD XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::broadcast(U val) noexcept
     {
         return batch(static_cast<T>(val));
     }
@@ -489,7 +489,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline void batch<T, A>::store_aligned(U* mem) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch<T, A>::store_aligned(U* mem) const noexcept
     {
         kernel::store_aligned<A>(mem, *this, A {});
     }
@@ -500,7 +500,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline void batch<T, A>::store_unaligned(U* mem) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch<T, A>::store_unaligned(U* mem) const noexcept
     {
         kernel::store_unaligned<A>(mem, *this, A {});
     }
@@ -510,7 +510,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline void batch<T, A>::store(U* mem, aligned_mode) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch<T, A>::store(U* mem, aligned_mode) const noexcept
     {
         return store_aligned(mem);
     }
@@ -520,7 +520,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline void batch<T, A>::store(U* mem, unaligned_mode) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch<T, A>::store(U* mem, unaligned_mode) const noexcept
     {
         return store_unaligned(mem);
     }
@@ -531,7 +531,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline batch<T, A> batch<T, A>::load_aligned(U const* mem) noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::load_aligned(U const* mem) noexcept
     {
         return kernel::load_aligned<A>(mem, kernel::convert<T> {}, A {});
     }
@@ -542,7 +542,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline batch<T, A> batch<T, A>::load_unaligned(U const* mem) noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::load_unaligned(U const* mem) noexcept
     {
         return kernel::load_unaligned<A>(mem, kernel::convert<T> {}, A {});
     }
@@ -552,7 +552,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline batch<T, A> batch<T, A>::load(U const* mem, aligned_mode) noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::load(U const* mem, aligned_mode) noexcept
     {
         return load_aligned(mem);
     }
@@ -562,7 +562,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U>
-    inline batch<T, A> batch<T, A>::load(U const* mem, unaligned_mode) noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::load(U const* mem, unaligned_mode) noexcept
     {
         return load_unaligned(mem);
     }
@@ -575,7 +575,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <typename U, typename V>
-    inline batch<T, A> batch<T, A>::gather(U const* src, batch<V, A> const& index) noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::gather(U const* src, batch<V, A> const& index) noexcept
     {
         static_assert(std::is_convertible<T, U>::value, "Can't convert from src to this batch's type!");
         return kernel::gather(batch {}, src, index, A {});
@@ -589,7 +589,7 @@ namespace xsimd
      */
     template <class T, class A>
     template <class U, class V>
-    inline void batch<T, A>::scatter(U* dst, batch<V, A> const& index) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch<T, A>::scatter(U* dst, batch<V, A> const& index) const noexcept
     {
         static_assert(std::is_convertible<T, U>::value, "Can't convert from this batch's type to dst!");
         kernel::scatter<A>(*this, dst, index, A {});
@@ -601,7 +601,7 @@ namespace xsimd
      * \c warning This is very inefficient and should only be used for debugging purpose.
      */
     template <class T, class A>
-    inline T batch<T, A>::get(std::size_t i) const noexcept
+    XSIMD_FORCEINLINE T XSIMD_CALLCONV batch<T, A>::get(std::size_t i) const noexcept
     {
         return kernel::get(*this, i, A {});
     }
@@ -614,7 +614,7 @@ namespace xsimd
      * Shorthand for xsimd::eq()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator==(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator==(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::eq<A>(*this, other, A {});
     }
@@ -623,7 +623,7 @@ namespace xsimd
      * Shorthand for xsimd::neq()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator!=(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator!=(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::neq<A>(*this, other, A {});
     }
@@ -632,7 +632,7 @@ namespace xsimd
      * Shorthand for xsimd::ge()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator>=(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator>=(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::ge<A>(*this, other, A {});
     }
@@ -641,7 +641,7 @@ namespace xsimd
      * Shorthand for xsimd::le()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator<=(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator<=(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::le<A>(*this, other, A {});
     }
@@ -650,7 +650,7 @@ namespace xsimd
      * Shorthand for xsimd::gt()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator>(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator>(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::gt<A>(*this, other, A {});
     }
@@ -659,7 +659,7 @@ namespace xsimd
      * Shorthand for xsimd::lt()
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator<(batch<T, A> const& other) const noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator<(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::lt<A>(*this, other, A {});
     }
@@ -669,73 +669,73 @@ namespace xsimd
      **************************/
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator+=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator+=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::add<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator-=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator-=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::sub<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator*=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator*=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::mul<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator/=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator/=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::div<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator%=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator%=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::mod<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator&=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator&=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::bitwise_and<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator|=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator|=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::bitwise_or<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator^=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator^=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::bitwise_xor<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator>>=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator>>=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::bitwise_rshift<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator<<=(batch<T, A> const& other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator<<=(batch<T, A> XSIMD_CREF other) noexcept
     {
         return *this = kernel::bitwise_lshift<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator>>=(int32_t other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator>>=(int32_t other) noexcept
     {
         return *this = kernel::bitwise_rshift<A>(*this, other, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A>& batch<T, A>::operator<<=(int32_t other) noexcept
+    inline batch<T, A>& XSIMD_CALLCONV batch<T, A>::operator<<=(int32_t other) noexcept
     {
         return *this = kernel::bitwise_lshift<A>(*this, other, A {});
     }
@@ -777,25 +777,25 @@ namespace xsimd
      *************************/
 
     template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator!() const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch<T, A>::operator!() const noexcept
     {
         return kernel::eq<A>(*this, batch(0), A {});
     }
 
     template <class T, class A>
-    inline batch<T, A> batch<T, A>::operator~() const noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::operator~() const noexcept
     {
         return kernel::bitwise_not<A>(*this, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A> batch<T, A>::operator-() const noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::operator-() const noexcept
     {
         return kernel::neg<A>(*this, A {});
     }
 
     template <class T, class A>
-    inline batch<T, A> batch<T, A>::operator+() const noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::operator+() const noexcept
     {
         return *this;
     }
@@ -805,13 +805,13 @@ namespace xsimd
      ************************/
 
     template <class T, class A>
-    inline batch<T, A> batch<T, A>::logical_and(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::logical_and(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::logical_and<A>(*this, other, A());
     }
 
     template <class T, class A>
-    inline batch<T, A> batch<T, A>::logical_or(batch<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch<T, A> XSIMD_CALLCONV batch<T, A>::logical_or(batch<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::logical_or<A>(*this, other, A());
     }
@@ -839,19 +839,19 @@ namespace xsimd
      *******************************/
 
     template <class T, class A>
-    inline void batch_bool<T, A>::store_aligned(bool* mem) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch_bool<T, A>::store_aligned(bool* mem) const noexcept
     {
         kernel::store(*this, mem, A {});
     }
 
     template <class T, class A>
-    inline void batch_bool<T, A>::store_unaligned(bool* mem) const noexcept
+    XSIMD_FORCEINLINE void XSIMD_CALLCONV batch_bool<T, A>::store_unaligned(bool* mem) const noexcept
     {
         store_aligned(mem);
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::load_aligned(bool const* mem) noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::load_aligned(bool const* mem) noexcept
     {
         batch_type ref(0);
         alignas(A::alignment()) T buffer[size];
@@ -861,7 +861,7 @@ namespace xsimd
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::load_unaligned(bool const* mem) noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::load_unaligned(bool const* mem) noexcept
     {
         return load_aligned(mem);
     }
@@ -872,7 +872,7 @@ namespace xsimd
      * @return bit mask
      */
     template <class T, class A>
-    inline uint64_t batch_bool<T, A>::mask() const noexcept
+    XSIMD_FORCEINLINE uint64_t XSIMD_CALLCONV batch_bool<T, A>::mask() const noexcept
     {
         return kernel::mask(*this, A {});
     }
@@ -883,13 +883,13 @@ namespace xsimd
      * @return bit mask
      */
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::from_mask(uint64_t mask) noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::from_mask(uint64_t mask) noexcept
     {
         return kernel::from_mask(batch_bool<T, A>(), mask, A {});
     }
 
     template <class T, class A>
-    inline bool batch_bool<T, A>::get(std::size_t i) const noexcept
+    XSIMD_FORCEINLINE bool XSIMD_CALLCONV batch_bool<T, A>::get(std::size_t i) const noexcept
     {
         return kernel::get(*this, i, A {});
     }
@@ -899,13 +899,13 @@ namespace xsimd
      ***********************************/
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator==(batch_bool<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator==(batch_bool<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::eq<A>(*this, other, A {}).data;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator!=(batch_bool<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator!=(batch_bool<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::neq<A>(*this, other, A {}).data;
     }
@@ -915,43 +915,43 @@ namespace xsimd
      ********************************/
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator~() const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator~() const noexcept
     {
         return kernel::bitwise_not<A>(*this, A {}).data;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator!() const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator!() const noexcept
     {
         return operator==(batch_bool(false));
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator&(batch_bool<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator&(batch_bool<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::bitwise_and<A>(*this, other, A {}).data;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator|(batch_bool<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator|(batch_bool<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::bitwise_or<A>(*this, other, A {}).data;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator^(batch_bool<T, A> const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator^(batch_bool<T, A> XSIMD_CREF other) const noexcept
     {
         return kernel::bitwise_xor<A>(*this, other, A {}).data;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator&&(batch_bool const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator&&(batch_bool XSIMD_CREF other) const noexcept
     {
         return operator&(other);
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch_bool<T, A>::operator||(batch_bool const& other) const noexcept
+    XSIMD_FORCEINLINE batch_bool<T, A> XSIMD_CALLCONV batch_bool<T, A>::operator||(batch_bool XSIMD_CREF other) const noexcept
     {
         return operator|(other);
     }
@@ -968,14 +968,14 @@ namespace xsimd
 
     template <class T, class A>
     template <class U, class... V, size_t I, size_t... Is>
-    inline auto batch_bool<T, A>::make_register(detail::index_sequence<I, Is...>, U u, V... v) noexcept -> register_type
+    XSIMD_FORCEINLINE auto XSIMD_CALLCONV batch_bool<T, A>::make_register(detail::index_sequence<I, Is...>, U u, V... v) noexcept -> register_type
     {
         return make_register(detail::index_sequence<Is...>(), u, u, v...);
     }
 
     template <class T, class A>
     template <class... V>
-    inline auto batch_bool<T, A>::make_register(detail::index_sequence<>, V... v) noexcept -> register_type
+    XSIMD_FORCEINLINE auto XSIMD_CALLCONV batch_bool<T, A>::make_register(detail::index_sequence<>, V... v) noexcept -> register_type
     {
         return kernel::set<A>(batch_bool<T, A>(), A {}, v...).data;
     }
@@ -1032,49 +1032,49 @@ namespace xsimd
      ***********************************/
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_aligned(const T* real_src, const T* imag_src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_aligned(const T* real_src, const T* imag_src) noexcept
     {
         return { batch<T, A>::load_aligned(real_src), imag_src ? batch<T, A>::load_aligned(imag_src) : batch<T, A>(0) };
     }
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_unaligned(const T* real_src, const T* imag_src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_unaligned(const T* real_src, const T* imag_src) noexcept
     {
         return { batch<T, A>::load_unaligned(real_src), imag_src ? batch<T, A>::load_unaligned(imag_src) : batch<T, A>(0) };
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_aligned(const value_type* src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_aligned(const value_type* src) noexcept
     {
         return kernel::load_complex_aligned<A>(src, kernel::convert<value_type> {}, A {});
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_unaligned(const value_type* src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_unaligned(const value_type* src) noexcept
     {
         return kernel::load_complex_unaligned<A>(src, kernel::convert<value_type> {}, A {});
     }
 
     template <class T, class A>
-    inline void batch<std::complex<T>, A>::store_aligned(value_type* dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_aligned(value_type* dst) const noexcept
     {
         return kernel::store_complex_aligned(dst, *this, A {});
     }
 
     template <class T, class A>
-    inline void batch<std::complex<T>, A>::store_unaligned(value_type* dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_unaligned(value_type* dst) const noexcept
     {
         return kernel::store_complex_unaligned(dst, *this, A {});
     }
 
     template <class T, class A>
-    inline void batch<std::complex<T>, A>::store_aligned(T* real_dst, T* imag_dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_aligned(T* real_dst, T* imag_dst) const noexcept
     {
         m_real.store_aligned(real_dst);
         m_imag.store_aligned(imag_dst);
     }
 
     template <class T, class A>
-    inline void batch<std::complex<T>, A>::store_unaligned(T* real_dst, T* imag_dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_unaligned(T* real_dst, T* imag_dst) const noexcept
     {
         m_real.store_unaligned(real_dst);
         m_imag.store_unaligned(imag_dst);
@@ -1082,46 +1082,46 @@ namespace xsimd
 
     template <class T, class A>
     template <class U>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load(U const* mem, aligned_mode) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load(U const* mem, aligned_mode) noexcept
     {
         return load_aligned(mem);
     }
 
     template <class T, class A>
     template <class U>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load(U const* mem, unaligned_mode) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load(U const* mem, unaligned_mode) noexcept
     {
         return load_unaligned(mem);
     }
 
     template <class T, class A>
     template <class U>
-    inline void batch<std::complex<T>, A>::store(U* mem, aligned_mode) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store(U* mem, aligned_mode) const noexcept
     {
         return store_aligned(mem);
     }
 
     template <class T, class A>
     template <class U>
-    inline void batch<std::complex<T>, A>::store(U* mem, unaligned_mode) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store(U* mem, unaligned_mode) const noexcept
     {
         return store_unaligned(mem);
     }
 
     template <class T, class A>
-    inline auto batch<std::complex<T>, A>::real() const noexcept -> real_batch
+    inline auto XSIMD_CALLCONV batch<std::complex<T>, A>::real() const noexcept -> real_batch
     {
         return m_real;
     }
 
     template <class T, class A>
-    inline auto batch<std::complex<T>, A>::imag() const noexcept -> real_batch
+    inline auto XSIMD_CALLCONV batch<std::complex<T>, A>::imag() const noexcept -> real_batch
     {
         return m_imag;
     }
 
     template <class T, class A>
-    inline auto batch<std::complex<T>, A>::get(std::size_t i) const noexcept -> value_type
+    inline auto XSIMD_CALLCONV batch<std::complex<T>, A>::get(std::size_t i) const noexcept -> value_type
     {
         return kernel::get(*this, i, A {});
     }
@@ -1154,28 +1154,28 @@ namespace xsimd
 
     template <class T, class A>
     template <bool i3ec>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_aligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_aligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept
     {
         return load_aligned(reinterpret_cast<std::complex<T> const*>(src));
     }
 
     template <class T, class A>
     template <bool i3ec>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::load_unaligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::load_unaligned(const xtl::xcomplex<T, T, i3ec>* src) noexcept
     {
         return load_unaligned(reinterpret_cast<std::complex<T> const*>(src));
     }
 
     template <class T, class A>
     template <bool i3ec>
-    inline void batch<std::complex<T>, A>::store_aligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_aligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept
     {
         store_aligned(reinterpret_cast<std::complex<T>*>(dst));
     }
 
     template <class T, class A>
     template <bool i3ec>
-    inline void batch<std::complex<T>, A>::store_unaligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept
+    inline void XSIMD_CALLCONV batch<std::complex<T>, A>::store_unaligned(xtl::xcomplex<T, T, i3ec>* dst) const noexcept
     {
         store_unaligned(reinterpret_cast<std::complex<T>*>(dst));
     }
@@ -1187,13 +1187,13 @@ namespace xsimd
      ***************************************/
 
     template <class T, class A>
-    inline batch_bool<T, A> batch<std::complex<T>, A>::operator==(batch const& other) const noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator==(batch const& other) const noexcept
     {
         return m_real == other.m_real && m_imag == other.m_imag;
     }
 
     template <class T, class A>
-    inline batch_bool<T, A> batch<std::complex<T>, A>::operator!=(batch const& other) const noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator!=(batch const& other) const noexcept
     {
         return m_real != other.m_real || m_imag != other.m_imag;
     }
@@ -1203,7 +1203,7 @@ namespace xsimd
      ***********************************/
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator+=(batch const& other) noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator+=(batch const& other) noexcept
     {
         m_real += other.m_real;
         m_imag += other.m_imag;
@@ -1211,7 +1211,7 @@ namespace xsimd
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator-=(batch const& other) noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator-=(batch const& other) noexcept
     {
         m_real -= other.m_real;
         m_imag -= other.m_imag;
@@ -1219,7 +1219,7 @@ namespace xsimd
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator*=(batch const& other) noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator*=(batch const& other) noexcept
     {
         real_batch new_real = real() * other.real() - imag() * other.imag();
         real_batch new_imag = real() * other.imag() + imag() * other.real();
@@ -1229,7 +1229,7 @@ namespace xsimd
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator/=(batch const& other) noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator/=(batch const& other) noexcept
     {
         real_batch a = real();
         real_batch b = imag();
@@ -1246,19 +1246,19 @@ namespace xsimd
      **************************************/
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator++() noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator++() noexcept
     {
         return operator+=(1);
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A>& batch<std::complex<T>, A>::operator--() noexcept
+    inline batch<std::complex<T>, A>& XSIMD_CALLCONV batch<std::complex<T>, A>::operator--() noexcept
     {
         return operator-=(1);
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::operator++(int) noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator++(int) noexcept
     {
         batch copy(*this);
         operator+=(1);
@@ -1278,25 +1278,25 @@ namespace xsimd
      **********************************/
 
     template <class T, class A>
-    inline batch_bool<T, A> batch<std::complex<T>, A>::operator!() const noexcept
+    inline batch_bool<T, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator!() const noexcept
     {
         return operator==(batch(0));
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::operator~() const noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator~() const noexcept
     {
         return { ~m_real, ~m_imag };
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::operator-() const noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator-() const noexcept
     {
         return { -m_real, -m_imag };
     }
 
     template <class T, class A>
-    inline batch<std::complex<T>, A> batch<std::complex<T>, A>::operator+() const noexcept
+    inline batch<std::complex<T>, A> XSIMD_CALLCONV batch<std::complex<T>, A>::operator+() const noexcept
     {
         return { +m_real, +m_imag };
     }

--- a/include/xsimd/types/xsimd_batch_constant.hpp
+++ b/include/xsimd/types/xsimd_batch_constant.hpp
@@ -35,20 +35,23 @@ namespace xsimd
 
         operator batch_bool<typename batch_type::value_type, arch_type>() const noexcept { return { Values... }; }
 
-        bool get(size_t i) const noexcept
+        constexpr bool XSIMD_CALLCONV get(size_t i) const noexcept
         {
-            return std::array<value_type, size> { { Values... } }[i];
+            constexpr auto vals = std::array<value_type, size> { { Values... } };
+            return vals[i];
         }
 
-        static constexpr int mask() noexcept
+        static constexpr int XSIMD_CALLCONV mask() noexcept
         {
             return mask_helper(0, static_cast<int>(Values)...);
         }
 
     private:
-        static constexpr int mask_helper(int acc) noexcept { return acc; }
+        XSIMD_FORCEINLINE
+        static constexpr int XSIMD_CALLCONV mask_helper(int acc) noexcept { return acc; }
+
         template <class... Tys>
-        static constexpr int mask_helper(int acc, int mask, Tys... masks) noexcept
+        static constexpr int XSIMD_CALLCONV mask_helper(int acc, int mask, Tys... masks) noexcept
         {
             return mask_helper(acc | mask, (masks << 1)...);
         }
@@ -73,20 +76,15 @@ namespace xsimd
         /**
          * @brief Generate a batch of @p batch_type from this @p batch_constant
          */
-        operator batch_type() const noexcept { return { Values... }; }
+        XSIMD_FORCEINLINE XSIMD_CALLCONV operator batch_type() const noexcept { return { Values... }; }
 
         /**
          * @brief Get the @p i th element of this @p batch_constant
          */
-        constexpr value_type get(size_t i) const noexcept
+        constexpr value_type XSIMD_CALLCONV get(size_t i) const noexcept
         {
-            return get(i, std::array<value_type, size> { Values... });
-        }
-
-    private:
-        constexpr value_type get(size_t i, std::array<value_type, size> const& values) const noexcept
-        {
-            return values[i];
+            constexpr auto vals = std::array<value_type, size> { Values... };
+            return vals[i];
         }
     };
 
@@ -128,13 +126,13 @@ namespace xsimd
      * @endcode
      */
     template <class batch_type, class G>
-    inline constexpr auto make_batch_constant() noexcept -> decltype(detail::make_batch_constant<batch_type, G>(detail::make_index_sequence<batch_type::size>()))
+    inline constexpr auto XSIMD_CALLCONV make_batch_constant() noexcept -> decltype(detail::make_batch_constant<batch_type, G>(detail::make_index_sequence<batch_type::size>()))
     {
         return detail::make_batch_constant<batch_type, G>(detail::make_index_sequence<batch_type::size>());
     }
 
     template <class batch_type, class G>
-    inline constexpr auto make_batch_bool_constant() noexcept
+    inline constexpr auto XSIMD_CALLCONV make_batch_bool_constant() noexcept
         -> decltype(detail::make_batch_bool_constant<batch_type, G>(
             detail::make_index_sequence<batch_type::size>()))
     {

--- a/include/xsimd/types/xsimd_register.hpp
+++ b/include/xsimd/types/xsimd_register.hpp
@@ -14,6 +14,8 @@
 
 #include <type_traits>
 
+#include "../config/xsimd_config.hpp"
+
 namespace xsimd
 {
     namespace types
@@ -32,17 +34,17 @@ namespace xsimd
                           "usage of simd_register with unsupported type");
         };
 
-#define XSIMD_DECLARE_SIMD_REGISTER(SCALAR_TYPE, ISA, VECTOR_TYPE) \
-    template <>                                                    \
-    struct simd_register<SCALAR_TYPE, ISA>                         \
-    {                                                              \
-        using register_type = VECTOR_TYPE;                         \
-        register_type data;                                        \
-        operator register_type() const noexcept { return data; }   \
-    };                                                             \
-    template <>                                                    \
-    struct has_simd_register<SCALAR_TYPE, ISA> : std::true_type    \
-    {                                                              \
+#define XSIMD_DECLARE_SIMD_REGISTER(SCALAR_TYPE, ISA, VECTOR_TYPE)                                \
+    template <>                                                                                   \
+    struct simd_register<SCALAR_TYPE, ISA>                                                        \
+    {                                                                                             \
+        using register_type = VECTOR_TYPE;                                                        \
+        register_type data;                                                                       \
+        XSIMD_FORCEINLINE XSIMD_CALLCONV operator register_type() const noexcept { return data; } \
+    };                                                                                            \
+    template <>                                                                                   \
+    struct has_simd_register<SCALAR_TYPE, ISA> : std::true_type                                   \
+    {                                                                                             \
     }
 
 #define XSIMD_DECLARE_SIMD_REGISTER_ALIAS(ISA, ISA_BASE)                          \

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -18,6 +18,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include "../config/xsimd_config.hpp"
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
 #include "xtl/xcomplex.hpp"
 #endif
@@ -320,13 +321,13 @@ namespace xsimd
 
         // Type-casted index sequence.
         template <class P, size_t... Is>
-        inline P indexes_from(index_sequence<Is...>) noexcept
+        inline P XSIMD_CALLCONV indexes_from(index_sequence<Is...>) noexcept
         {
             return { static_cast<typename P::value_type>(Is)... };
         }
 
         template <class P>
-        inline P make_sequence_as_batch() noexcept
+        inline P XSIMD_CALLCONV make_sequence_as_batch() noexcept
         {
             return indexes_from<P>(make_index_sequence<P::size>());
         }
@@ -339,20 +340,20 @@ namespace xsimd
     namespace detail
     {
         template <class T, class... Types, size_t I, size_t... Is>
-        inline const T& get_impl(const std::tuple<Types...>& t, std::is_same<T, T>, index_sequence<I, Is...>) noexcept
+        inline const T& XSIMD_CALLCONV get_impl(const std::tuple<Types...>& t, std::is_same<T, T>, index_sequence<I, Is...>) noexcept
         {
             return std::get<I>(t);
         }
 
         template <class T, class U, class... Types, size_t I, size_t... Is>
-        inline const T& get_impl(const std::tuple<Types...>& t, std::is_same<T, U>, index_sequence<I, Is...>) noexcept
+        inline const T& XSIMD_CALLCONV get_impl(const std::tuple<Types...>& t, std::is_same<T, U>, index_sequence<I, Is...>) noexcept
         {
             using tuple_elem = typename std::tuple_element<I + 1, std::tuple<Types...>>::type;
             return get_impl<T>(t, std::is_same<T, tuple_elem>(), index_sequence<Is...>());
         }
 
         template <class T, class... Types>
-        inline const T& get(const std::tuple<Types...>& t) noexcept
+        inline const T& XSIMD_CALLCONV get(const std::tuple<Types...>& t) noexcept
         {
             using tuple_elem = typename std::tuple_element<0, std::tuple<Types...>>::type;
             return get_impl<T>(t, std::is_same<T, tuple_elem>(), make_index_sequence<sizeof...(Types)>());
@@ -399,7 +400,7 @@ namespace xsimd
     {
         // std::array constructor from scalar value ("broadcast")
         template <typename T, std::size_t... Is>
-        inline constexpr std::array<T, sizeof...(Is)>
+        inline constexpr std::array<T, sizeof...(Is)> XSIMD_CALLCONV
         array_from_scalar_impl(const T& scalar, index_sequence<Is...>) noexcept
         {
             // You can safely ignore this silly ternary, the "scalar" is all
@@ -408,7 +409,7 @@ namespace xsimd
         }
 
         template <typename T, std::size_t N>
-        inline constexpr std::array<T, N>
+        inline constexpr std::array<T, N> XSIMD_CALLCONV
         array_from_scalar(const T& scalar) noexcept
         {
             return array_from_scalar_impl(scalar, make_index_sequence<N>());
@@ -416,14 +417,14 @@ namespace xsimd
 
         // std::array constructor from C-style pointer (handled as an array)
         template <typename T, std::size_t... Is>
-        inline constexpr std::array<T, sizeof...(Is)>
+        inline constexpr std::array<T, sizeof...(Is)> XSIMD_CALLCONV
         array_from_pointer_impl(const T* c_array, index_sequence<Is...>) noexcept
         {
             return std::array<T, sizeof...(Is)> { c_array[Is]... };
         }
 
         template <typename T, std::size_t N>
-        inline constexpr std::array<T, N>
+        inline constexpr std::array<T, N> XSIMD_CALLCONV
         array_from_pointer(const T* c_array) noexcept
         {
             return array_from_pointer_impl(c_array, make_index_sequence<N>());

--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -12,29 +12,6 @@
 #ifndef XSIMD_HPP
 #define XSIMD_HPP
 
-#if defined(__has_cpp_attribute)
-// if this check passes, then the compiler supports feature test macros
-#if __has_cpp_attribute(nodiscard) >= 201603L
-// if this check passes, then the compiler supports [[nodiscard]] without a message
-#define XSIMD_NO_DISCARD [[nodiscard]]
-#endif
-#endif
-
-#if !defined(XSIMD_NO_DISCARD) && __cplusplus >= 201703L
-// this means that the previous tests failed, but we are using C++17 or higher
-#define XSIMD_NO_DISCARD [[nodiscard]]
-#endif
-
-#if !defined(XSIMD_NO_DISCARD) && (defined(__GNUC__) || defined(__clang__))
-// this means that the previous checks failed, but we are using GCC or Clang
-#define XSIMD_NO_DISCARD __attribute__((warn_unused_result))
-#endif
-
-#if !defined(XSIMD_NO_DISCARD)
-// this means that all the previous checks failed, so we fallback to doing nothing
-#define XSIMD_NO_DISCARD
-#endif
-
 #include "config/xsimd_config.hpp"
 
 #include "arch/xsimd_scalar.hpp"


### PR DESCRIPTION
Hola. This PR is a spiritual successor to #646. I don't really intend it to be merged in (it's a massive diff), it's more that I've done the work to parameterize calling convention, pass by ref/value and forced inlines so they can be tested individually/together as desired, as these were all the variables discussed in that PR. 

The main changes are:

- added configurable `XSIMD_FORCEINLINE`, defaults to `__forceinline` on MSVC and `__attribute((always_inline))` on GCC/Clang. 
- added configurable `XSIMD_CREF`, defaults to `const&`.
- added configurable `XSIMD_CALLCONV`, defaults to `__vectorcall` when supported on MSVC, nothing otherwise.
- applied `XSIMD_FORCEINLINE` to most of `batch` and `batch_bool` (basically all functions that were just one-liner calls to things in the kernel namespace)
- replaced most (all?) instances of `batch<> const&` with `batch<> XSIMD_CREF`
- applied `XSIMD_CALLCONV` to pretty much every function in the lib

I've tried to be pretty comprehensive, but there might be a few bits I missed. I ran a small subset of the xsimd benchmarks in just about every permutation of the above on MSVC (e.g. `XSIMD_FORCEINLINE` set to `inline` vs `__forceinline` et cetera). You can find the results here:

https://docs.google.com/spreadsheets/d/1c2Y7-NI36g8zZGumO5m0DpK5QLRh8RBmsgWhAcYDuag/edit#gid=0

You'll note there's not a huge difference between all the different permuations in Release builds. but I only did the `add_fn()` test from `ops`, and ignored the double values altogether, so it wasn't super comprehensive.

If you (or @amyspark) want to test additional elements yourself (or test the library in other ways with the parameterized attributes), you can just override the attributes using #defines, e.g.:

```cpp
#define XSIMD_CALLCONV    __vectorcall
#define XSIMD_CREF        const&
#define XSIMD_FORCEINLINE inline

#include <xsimd/xsimd.hpp>
```

Disclaimer: I only changed what was necessary to get it to work on VS2022 for x64. I probably missed some ARM shenanigans so it might need extra work if you're testing there.

(I also drive-by moved `XSIMD_NODISCARD` to `xsimd_config.hpp` because it seems like it probably belongs there)