### PR TITLE
Fix find_package(xsimd) for xtl enabled xsimd

### DIFF
--- a/xsimdConfig.cmake.in
+++ b/xsimdConfig.cmake.in
@@ -18,6 +18,12 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET @PROJECT_NAME@)
+    set(@PROJECT_NAME@_ENABLE_XTL_COMPLEX @ENABLE_XTL_COMPLEX@)
+    if(@PROJECT_NAME@_ENABLE_XTL_COMPLEX)
+        include(CMakeFindDependencyMacro)
+        find_dependency(xtl)
+    endif()
+
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
     get_target_property(@PROJECT_NAME@_INCLUDE_DIRS @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
 endif()


### PR DESCRIPTION
If we enable xtl by -DENABLE_XTL_COMPLEX=ON, the xsimd CMake target
depends on the xtl CMake target. (See installed
xsimdTargets.cmake. You can find 'INTERFACE_LINK_LIBRARIES "xtl"' line
in the file.)

But installed xsimdConfig.cmake doesn't include
find_dependency(xtl). If we don't run find_dependency(xtl) in
xsimdConfig.cmake, the xtl CMake target isn't defined when users run
find_package(xsimd). If the xtl CMake target isn't defined, "xtl" in
'INTERFACE_LINK_LIBRARIES "xtl"' is processed as library name not
CMake target. If "xtl" is processed as library name, '-lxtl' is added
to link command line. It causes link error because 'libxtl.so' doesn't
exist.

How to reproduce:

  1. Install xsimd with -DENABLE_XTL_COMPLEX=ON:

         cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp/local -DENABLE_XTL_COMPLEX=ON
         cmake --build build --target install

  2. Create a test project:

     xsimd_test.cc:

         #include <xsimd/xsimd.hpp>

         int main(void) {
           return 0;
         }

     CMakeLists.txt:

          cmake_minimum_required(VERSION 3.1)
          project(xsimd_test)

          # Enable <PackageName_ROOT CMake variable for find_package().
          cmake_policy(SET CMP0074 NEW)

          find_package(xsimd REQUIRED)
          add_executable(xsimd_test xsimd_test.cc)
          target_link_libraries(xsimd_test xsimd)

  3. Build the test project:

          $ cmake -S . -B build -Dxsimd_ROOT=/tmp/local
          -- The C compiler identification is GNU 11.3.0
          -- The CXX compiler identification is GNU 11.3.0
          -- Detecting C compiler ABI info
          -- Detecting C compiler ABI info - done
          -- Check for working C compiler: /bin/cc - skipped
          -- Detecting C compile features
          -- Detecting C compile features - done
          -- Detecting CXX compiler ABI info
          -- Detecting CXX compiler ABI info - done
          -- Check for working CXX compiler: /bin/c++ - skipped
          -- Detecting CXX compile features
          -- Detecting CXX compile features - done
          -- Configuring done
          -- Generating done
          -- Build files have been written to: /tmp/abc/build
          $ cmake --build build --verbose
          /usr/bin/cmake -S/tmp/abc -B/tmp/abc/build --check-build-system CMakeFiles/Makefile.cmake 0
          /usr/bin/cmake -E cmake_progress_start /tmp/abc/build/CMakeFiles /tmp/abc/build//CMakeFiles/progress.marks
          /bin/gmake  -f CMakeFiles/Makefile2 all
          gmake[1]: Entering directory '/tmp/abc/build'
          /bin/gmake  -f CMakeFiles/xsimd_test.dir/build.make CMakeFiles/xsimd_test.dir/depend
          gmake[2]: Entering directory '/tmp/abc/build'
          cd /tmp/abc/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/abc /tmp/abc /tmp/abc/build /tmp/abc/build /tmp/abc/build/CMakeFiles/xsimd_test.dir/DependInfo.cmake --color=
          gmake[2]: Leaving directory '/tmp/abc/build'
          /bin/gmake  -f CMakeFiles/xsimd_test.dir/build.make CMakeFiles/xsimd_test.dir/build
          gmake[2]: Entering directory '/tmp/abc/build'
          [ 50%] Building CXX object CMakeFiles/xsimd_test.dir/xsimd_test.cc.o
          /bin/c++  -isystem /tmp/local/include  -MD -MT CMakeFiles/xsimd_test.dir/xsimd_test.cc.o -MF CMakeFiles/xsimd_test.dir/xsimd_test.cc.o.d -o CMakeFiles/xsimd_test.dir/xsimd_test.cc.o -c /tmp/abc/xsimd_test.cc
          [100%] Linking CXX executable xsimd_test
          /usr/bin/cmake -E cmake_link_script CMakeFiles/xsimd_test.dir/link.txt --verbose=1
          /bin/c++ -rdynamic CMakeFiles/xsimd_test.dir/xsimd_test.cc.o -o xsimd_test  -lxtl
          /bin/ld: cannot find -lxtl: No such file or directory
          collect2: error: ld returned 1 exit status
          gmake[2]: *** [CMakeFiles/xsimd_test.dir/build.make:97: xsimd_test] Error 1
          gmake[2]: Leaving directory '/tmp/abc/build'
          gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/xsimd_test.dir/all] Error 2
          gmake[1]: Leaving directory '/tmp/abc/build'
          gmake: *** [Makefile:91: all] Error 2