### PR TITLE
Ensure Neq confirms to IEEE 754.

### DIFF
--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1021,12 +1021,12 @@ namespace xsimd
         template <class A>
         inline batch_bool<float, A> neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx>) noexcept
         {
-            return _mm256_cmp_ps(self, other, _CMP_NEQ_OQ);
+            return _mm256_cmp_ps(self, other, _CMP_NEQ_UQ);
         }
         template <class A>
         inline batch_bool<double, A> neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx>) noexcept
         {
-            return _mm256_cmp_pd(self, other, _CMP_NEQ_OQ);
+            return _mm256_cmp_pd(self, other, _CMP_NEQ_UQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx>) noexcept

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -1236,12 +1236,12 @@ namespace xsimd
         template <class A>
         inline batch_bool<float, A> neq(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept
         {
-            return _mm512_cmp_ps_mask(self, other, _CMP_NEQ_OQ);
+            return _mm512_cmp_ps_mask(self, other, _CMP_NEQ_UQ);
         }
         template <class A>
         inline batch_bool<double, A> neq(batch<double, A> const& self, batch<double, A> const& other, requires_arch<avx512f>) noexcept
         {
-            return _mm512_cmp_pd_mask(self, other, _CMP_NEQ_OQ);
+            return _mm512_cmp_pd_mask(self, other, _CMP_NEQ_UQ);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512f>) noexcept

--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -1194,3 +1194,39 @@ TYPED_TEST(xsimd_api_all_types_functions, sub)
 {
     this->test_sub();
 }
+
+/*
+ * Functions that apply only to floating point types
+ */
+template <typename T>
+class xsimd_api_all_floating_point_types_functions : public ::testing::Test
+{
+    using value_type = typename scalar_type<T>::type;
+
+public:
+    void test_neq_nan()
+    {
+        value_type valNaN(std::numeric_limits<value_type>::signaling_NaN());
+        value_type val1(1.0);
+        EXPECT_EQ(extract(xsimd::neq(T(valNaN), T(val1))), valNaN != val1);
+    }
+};
+
+using AllFloatingPointTypes = ::testing::Types<
+    float, double,
+    std::complex<float>, std::complex<double>
+#ifndef XSIMD_NO_SUPPORTED_ARCHITECTURE
+    ,
+    xsimd::batch<float>, xsimd::batch<std::complex<float>>
+#if defined(XSIMD_WITH_NEON) && !defined(XSIMD_WITH_NEON64)
+    ,
+    xsimd::batch<double>, xsimd::batch<std::complex<double>>
+#endif
+#endif
+    >;
+
+TYPED_TEST_SUITE(xsimd_api_all_floating_point_types_functions, AllFloatingPointTypes);
+TYPED_TEST(xsimd_api_all_floating_point_types_functions, neq_nan)
+{
+    this->test_neq_nan();
+}


### PR DESCRIPTION
Fixes issue #805, where neq returns false for  x != Nan , where x is any valid floating point value. 