### PR TITLE
Fix potential ABI issue in SVE support

### DIFF
--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -28,7 +28,6 @@ namespace xsimd
         namespace detail
         {
             using xsimd::index;
-            using xsimd::detail::sve;
             using xsimd::types::detail::sve_vector_type;
 
             // predicate creation
@@ -90,20 +89,20 @@ namespace xsimd
         // TODO: gather
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> load_aligned(T const* src, convert<T>, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> load_aligned(T const* src, convert<T>, requires_arch<sve>) noexcept
         {
             return svld1(detail::sve_ptrue<T>(), reinterpret_cast<detail::sve_fix_char_t<T> const*>(src));
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<sve>) noexcept
         {
-            return load_aligned<A>(src, convert<T>(), detail::sve {});
+            return load_aligned<A>(src, convert<T>(), sve {});
         }
 
         // load_complex
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<std::complex<T>, A> load_complex_aligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<detail::sve>) noexcept
+        inline batch<std::complex<T>, A> load_complex_aligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
         {
             const T* buf = reinterpret_cast<const T*>(mem);
             const auto tmp = svld2(detail::sve_ptrue<T>(), buf);
@@ -113,9 +112,9 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<std::complex<T>, A> load_complex_unaligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<detail::sve>) noexcept
+        inline batch<std::complex<T>, A> load_complex_unaligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
         {
-            return load_complex_aligned<A>(mem, convert<std::complex<T>> {}, detail::sve {});
+            return load_complex_aligned<A>(mem, convert<std::complex<T>> {}, sve {});
         }
 
         /*********
@@ -125,20 +124,20 @@ namespace xsimd
         // TODO: scatter
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline void store_aligned(T* dst, batch<T, A> const& src, requires_arch<detail::sve>) noexcept
+        inline void store_aligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
         {
             svst1(detail::sve_ptrue<T>(), reinterpret_cast<detail::sve_fix_char_t<T>*>(dst), src);
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<detail::sve>) noexcept
+        inline void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
         {
-            store_aligned<A>(dst, src, detail::sve {});
+            store_aligned<A>(dst, src, sve {});
         }
 
         // store_complex
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline void store_complex_aligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<detail::sve>) noexcept
+        inline void store_complex_aligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
         {
             using v2type = typename std::conditional<(sizeof(T) == 4), svfloat32x2_t, svfloat64x2_t>::type;
             v2type tmp {};
@@ -149,9 +148,9 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline void store_complex_unaligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<detail::sve>) noexcept
+        inline void store_complex_unaligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
         {
-            store_complex_aligned(dst, src, detail::sve {});
+            store_complex_aligned(dst, src, sve {});
         }
 
         /********************
@@ -160,69 +159,69 @@ namespace xsimd
 
         // broadcast
         template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_u8(uint8_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_signed_t<T, 1> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_s8(int8_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_u16(uint16_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_signed_t<T, 2> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_s16(int16_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_u32(uint32_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_signed_t<T, 4> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_s32(int32_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_u64(uint64_t(arg));
         }
 
         template <class A, class T, detail::enable_sized_signed_t<T, 8> = 0>
-        inline batch<T, A> broadcast(T arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
         {
             return svdup_n_s64(int64_t(arg));
         }
 
         template <class A>
-        inline batch<float, A> broadcast(float arg, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> broadcast(float arg, requires_arch<sve>) noexcept
         {
             return svdup_n_f32(arg);
         }
 
         template <class A>
-        inline batch<double, A> broadcast(double arg, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> broadcast(double arg, requires_arch<sve>) noexcept
         {
             return svdup_n_f64(arg);
         }
 
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> broadcast(T val, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> broadcast(T val, requires_arch<sve>) noexcept
         {
-            return broadcast<detail::sve>(val, detail::sve {});
+            return broadcast<sve>(val, sve {});
         }
 
         /**************
@@ -231,100 +230,100 @@ namespace xsimd
 
         // add
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> add(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> add(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svadd_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // sadd
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> sadd(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> sadd(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svqadd(lhs, rhs);
         }
 
         // sub
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> sub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> sub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svsub_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // ssub
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> ssub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> ssub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svqsub(lhs, rhs);
         }
 
         // mul
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> mul(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> mul(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svmul_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // div
         template <class A, class T, typename std::enable_if<sizeof(T) >= 4, int>::type = 0>
-        inline batch<T, A> div(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> div(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svdiv_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // max
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> max(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> max(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svmax_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // min
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> min(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> min(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svmin_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // neg
         template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
-        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svreinterpret_u8(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s8(arg)));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
-        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svreinterpret_u16(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s16(arg)));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
-        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svreinterpret_u32(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s32(arg)));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
-        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svreinterpret_u64(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s64(arg)));
         }
 
         template <class A, class T, detail::sve_enable_signed_int_or_floating_point_t<T> = 0>
-        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svneg_x(detail::sve_ptrue<T>(), arg);
         }
 
         // abs
         template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
-        inline batch<T, A> abs(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return arg;
         }
 
         template <class A, class T, detail::sve_enable_signed_int_or_floating_point_t<T> = 0>
-        inline batch<T, A> abs(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svabs_x(detail::sve_ptrue<T>(), arg);
         }
@@ -335,13 +334,13 @@ namespace xsimd
 
         // bitwise_and
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_and(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_and(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svand_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_and(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_and(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u32(lhs);
             const auto rhs_bits = svreinterpret_u32(rhs);
@@ -350,7 +349,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> bitwise_and(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_and(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u64(lhs);
             const auto rhs_bits = svreinterpret_u64(rhs);
@@ -359,20 +358,20 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> bitwise_and(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svand_z(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_andnot
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_andnot(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_andnot(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svbic_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_andnot(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_andnot(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u32(lhs);
             const auto rhs_bits = svreinterpret_u32(rhs);
@@ -381,7 +380,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> bitwise_andnot(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_andnot(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u64(lhs);
             const auto rhs_bits = svreinterpret_u64(rhs);
@@ -390,20 +389,20 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svbic_z(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_or
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_or(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_or(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svorr_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_or(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_or(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u32(lhs);
             const auto rhs_bits = svreinterpret_u32(rhs);
@@ -412,7 +411,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> bitwise_or(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_or(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u64(lhs);
             const auto rhs_bits = svreinterpret_u64(rhs);
@@ -421,20 +420,20 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> bitwise_or(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svorr_z(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_xor
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_xor(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_xor(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return sveor_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_xor(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_xor(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u32(lhs);
             const auto rhs_bits = svreinterpret_u32(rhs);
@@ -443,7 +442,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> bitwise_xor(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_xor(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto lhs_bits = svreinterpret_u64(lhs);
             const auto rhs_bits = svreinterpret_u64(rhs);
@@ -452,20 +451,20 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_not
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_not(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_not(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svnot_x(detail::sve_ptrue<T>(), arg);
         }
 
         template <class A>
-        inline batch<float, A> bitwise_not(batch<float, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_not(batch<float, A> const& arg, requires_arch<sve>) noexcept
         {
             const auto arg_bits = svreinterpret_u32(arg);
             const auto result_bits = svnot_x(detail::sve_ptrue<float>(), arg_bits);
@@ -473,7 +472,7 @@ namespace xsimd
         }
 
         template <class A>
-        inline batch<double, A> bitwise_not(batch<double, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_not(batch<double, A> const& arg, requires_arch<sve>) noexcept
         {
             const auto arg_bits = svreinterpret_u64(arg);
             const auto result_bits = svnot_x(detail::sve_ptrue<double>(), arg_bits);
@@ -481,7 +480,7 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> bitwise_not(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svnot_z(detail::sve_ptrue<T>(), arg);
         }
@@ -525,7 +524,7 @@ namespace xsimd
 
         // bitwise_lshift
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& arg, int n, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_lshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
@@ -533,14 +532,14 @@ namespace xsimd
         }
 
         template <class A, class T, detail::enable_integral_t<T> = 0>
-        inline batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svlsl_x(detail::sve_ptrue<T>(), lhs, detail::sve_to_unsigned_batch<A, T>(rhs));
         }
 
         // bitwise_rshift
         template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
@@ -548,13 +547,13 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svlsr_x(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A, class T, detail::sve_enable_signed_int_t<T> = 0>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
@@ -562,7 +561,7 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_signed_int_t<T> = 0>
-        inline batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svasr_x(detail::sve_ptrue<T>(), lhs, detail::sve_to_unsigned_batch<A, T>(rhs));
         }
@@ -573,7 +572,7 @@ namespace xsimd
 
         // reduce_add
         template <class A, class T, class V = typename batch<T, A>::value_type, detail::sve_enable_all_t<T> = 0>
-        inline V reduce_add(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline V reduce_add(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             // sve integer reduction results are promoted to 64 bits
             return static_cast<V>(svaddv(detail::sve_ptrue<T>(), arg));
@@ -581,27 +580,27 @@ namespace xsimd
 
         // reduce_max
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline T reduce_max(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline T reduce_max(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svmaxv(detail::sve_ptrue<T>(), arg);
         }
 
         // reduce_min
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline T reduce_min(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline T reduce_min(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svminv(detail::sve_ptrue<T>(), arg);
         }
 
         // haddp
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> haddp(const batch<T, A>* row, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> haddp(const batch<T, A>* row, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
             T sums[size];
             for (std::size_t i = 0; i < size; ++i)
             {
-                sums[i] = reduce_add(row[i], detail::sve {});
+                sums[i] = reduce_add(row[i], sve {});
             }
             return svld1(detail::sve_ptrue<T>(), sums);
         }
@@ -612,13 +611,13 @@ namespace xsimd
 
         // eq
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> eq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> eq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmpeq(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> eq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> eq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             const auto neq_result = sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
             return svnot_z(detail::sve_ptrue<T>(), neq_result);
@@ -626,41 +625,41 @@ namespace xsimd
 
         // neq
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> neq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> neq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmpne(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> neq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> neq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // lt
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> lt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> lt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmplt(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // le
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> le(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> le(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmple(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // gt
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> gt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> gt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmpgt(detail::sve_ptrue<T>(), lhs, rhs);
         }
 
         // ge
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch_bool<T, A> ge(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> ge(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svcmpge(detail::sve_ptrue<T>(), lhs, rhs);
         }
@@ -671,7 +670,7 @@ namespace xsimd
 
         // swizzle
         template <class A, class T, class I, I... idx>
-        inline batch<T, A> swizzle(batch<T, A> const& arg, batch_constant<batch<I, A>, idx...>, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> swizzle(batch<T, A> const& arg, batch_constant<batch<I, A>, idx...>, requires_arch<sve>) noexcept
         {
             static_assert(batch<T, A>::size == sizeof...(idx), "invalid swizzle indices");
             const batch<I, A> indices { idx... };
@@ -681,10 +680,10 @@ namespace xsimd
         template <class A, class T, class I, I... idx>
         inline batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& self,
                                                  batch_constant<batch<I, A>, idx...>,
-                                                 requires_arch<detail::sve>) noexcept
+                                                 requires_arch<sve>) noexcept
         {
-            const auto real = swizzle(self.real(), batch_constant<batch<I, A>, idx...> {}, detail::sve {});
-            const auto imag = swizzle(self.imag(), batch_constant<batch<I, A>, idx...> {}, detail::sve {});
+            const auto real = swizzle(self.real(), batch_constant<batch<I, A>, idx...> {}, sve {});
+            const auto imag = swizzle(self.imag(), batch_constant<batch<I, A>, idx...> {}, sve {});
             return batch<std::complex<T>>(real, imag);
         }
 
@@ -730,7 +729,7 @@ namespace xsimd
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
             assert(n < size && "index in bounds");
@@ -739,15 +738,15 @@ namespace xsimd
 
         // select
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& a, batch<T, A> const& b, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& a, batch<T, A> const& b, requires_arch<sve>) noexcept
         {
             return svsel(cond, a, b);
         }
 
         template <class A, class T, bool... b>
-        inline batch<T, A> select(batch_bool_constant<batch<T, A>, b...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> select(batch_bool_constant<batch<T, A>, b...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sve>) noexcept
         {
-            return select(batch_bool<T, A> { b... }, true_br, false_br, detail::sve {});
+            return select(batch_bool<T, A> { b... }, true_br, false_br, sve {});
         }
 
         // zip in 128-bit lane as AVX does, unfortunatly we cannot use svzip which truly and neatly zips two vectors
@@ -829,14 +828,14 @@ namespace xsimd
 
         // zip_lo
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> zip_lo(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> zip_lo(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return detail::sve_128b_lane_zipper<XSIMD_SVE_BITS>().zip_lo(lhs, rhs);
         }
 
         // zip_hi
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> zip_hi(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> zip_hi(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return detail::sve_128b_lane_zipper<XSIMD_SVE_BITS>().zip_hi(lhs, rhs);
         }
@@ -847,34 +846,34 @@ namespace xsimd
 
         // rsqrt
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> rsqrt(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> rsqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svrsqrte(arg);
         }
 
         // sqrt
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> sqrt(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> sqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svsqrt_x(detail::sve_ptrue<T>(), arg);
         }
 
         // fused operations
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
             return svmad_x(detail::sve_ptrue<T>(), x, y, z);
         }
 
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
             return svmad_x(detail::sve_ptrue<T>(), x, y, -z);
         }
 
         // reciprocal
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch<T, A> reciprocal(const batch<T, A>& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> reciprocal(const batch<T, A>& arg, requires_arch<sve>) noexcept
         {
             return svrecpe(arg);
         }
@@ -887,37 +886,37 @@ namespace xsimd
         namespace detail
         {
             template <class A, class T, detail::enable_sized_integral_t<T, 4> = 0>
-            inline batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_f32_x(detail::sve_ptrue<T>(), arg);
             }
 
             template <class A, class T, detail::enable_sized_integral_t<T, 8> = 0>
-            inline batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_f64_x(detail::sve_ptrue<T>(), arg);
             }
 
             template <class A>
-            inline batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_s32_x(detail::sve_ptrue<float>(), arg);
             }
 
             template <class A>
-            inline batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_u32_x(detail::sve_ptrue<float>(), arg);
             }
 
             template <class A>
-            inline batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_s64_x(detail::sve_ptrue<double>(), arg);
             }
 
             template <class A>
-            inline batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<detail::sve>) noexcept
+            inline batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
             {
                 return svcvt_u64_x(detail::sve_ptrue<double>(), arg);
             }
@@ -929,13 +928,13 @@ namespace xsimd
 
         // set
         template <class A, class T, class... Args>
-        inline batch<T, A> set(batch<T, A> const&, requires_arch<detail::sve>, Args... args) noexcept
+        inline batch<T, A> set(batch<T, A> const&, requires_arch<sve>, Args... args) noexcept
         {
             return detail::sve_vector_type<T> { args... };
         }
 
         template <class A, class T, class... Args>
-        inline batch<std::complex<T>, A> set(batch<std::complex<T>, A> const&, requires_arch<detail::sve>,
+        inline batch<std::complex<T>, A> set(batch<std::complex<T>, A> const&, requires_arch<sve>,
                                              Args... args_complex) noexcept
         {
             return batch<std::complex<T>>(detail::sve_vector_type<T> { args_complex.real()... },
@@ -943,11 +942,11 @@ namespace xsimd
         }
 
         template <class A, class T, class... Args>
-        inline batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<detail::sve>, Args... args) noexcept
+        inline batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<sve>, Args... args) noexcept
         {
             using U = as_unsigned_integer_t<T>;
             const auto values = detail::sve_vector_type<U> { static_cast<U>(args)... };
-            const auto zero = broadcast<A, U>(static_cast<U>(0), detail::sve {});
+            const auto zero = broadcast<A, U>(static_cast<U>(0), sve {});
             return svcmpne(detail::sve_ptrue<T>(), values, zero);
         }
 
@@ -965,99 +964,99 @@ namespace xsimd
         } // namespace detail
 
         template <class A, class T, size_t I, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> insert(batch<T, A> const& arg, T val, index<I>, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> insert(batch<T, A> const& arg, T val, index<I>, requires_arch<sve>) noexcept
         {
             // create a predicate with only the I-th lane activated
             const auto iota = detail::sve_iota<T>();
             const auto index_predicate = svcmpeq(detail::sve_ptrue<T>(), iota, static_cast<as_unsigned_integer_t<T>>(I));
-            return svsel(index_predicate, broadcast<A, T>(val, detail::sve {}), arg);
+            return svsel(index_predicate, broadcast<A, T>(val, sve {}), arg);
         }
 
         // all
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline bool all(batch_bool<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline bool all(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return detail::sve_pcount<T>(arg) == batch_bool<T, A>::size;
         }
 
         // any
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline bool any(batch_bool<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline bool any(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svptest_any(arg, arg);
         }
 
         // bitwise_cast
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 1> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_u8(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 1> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_s8(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 2> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_u16(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 2> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_s16(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 4> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_u32(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 4> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_s32(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 8> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_u64(arg);
         }
 
         template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 8> = 0>
-        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_s64(arg);
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<float, A> bitwise_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<float, A> bitwise_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_f32(arg);
         }
 
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<double, A> bitwise_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch<double, A> bitwise_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
         {
             return svreinterpret_f64(arg);
         }
 
         // batch_bool_cast
         template <class A, class T_out, class T_in, detail::sve_enable_all_t<T_in> = 0>
-        inline batch_bool<T_out, A> batch_bool_cast(batch_bool<T_in, A> const& arg, batch_bool<T_out, A> const&, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T_out, A> batch_bool_cast(batch_bool<T_in, A> const& arg, batch_bool<T_out, A> const&, requires_arch<sve>) noexcept
         {
             return arg.data;
         }
 
         // from_bool
         template <class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> from_bool(batch_bool<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> from_bool(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return select(arg, batch<T, A>(1), batch<T, A>(0));
         }
@@ -1073,9 +1072,9 @@ namespace xsimd
                 {
                     using u8_vector = batch<uint8_t, A>;
                     const auto left = svdup_n_u8(0);
-                    const auto right = bitwise_cast(arg, u8_vector {}, detail::sve {}).data;
+                    const auto right = bitwise_cast(arg, u8_vector {}, sve {}).data;
                     const u8_vector result(svext(left, right, u8_vector::size - N));
-                    return bitwise_cast(result, batch<T, A> {}, detail::sve {});
+                    return bitwise_cast(result, batch<T, A> {}, sve {});
                 }
             };
 
@@ -1091,7 +1090,7 @@ namespace xsimd
         } // namespace detail
 
         template <size_t N, class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> slide_left(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> slide_left(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return detail::sve_slider_left<N>()(arg);
         }
@@ -1106,10 +1105,10 @@ namespace xsimd
                 inline batch<T, A> operator()(batch<T, A> const& arg) noexcept
                 {
                     using u8_vector = batch<uint8_t, A>;
-                    const auto left = bitwise_cast(arg, u8_vector {}, detail::sve {}).data;
+                    const auto left = bitwise_cast(arg, u8_vector {}, sve {}).data;
                     const auto right = svdup_n_u8(0);
                     const u8_vector result(svext(left, right, N));
-                    return bitwise_cast(result, batch<T, A> {}, detail::sve {});
+                    return bitwise_cast(result, batch<T, A> {}, sve {});
                 }
             };
 
@@ -1125,14 +1124,14 @@ namespace xsimd
         } // namespace detail
 
         template <size_t N, class A, class T, detail::sve_enable_all_t<T> = 0>
-        inline batch<T, A> slide_right(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch<T, A> slide_right(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return detail::sve_slider_right<N>()(arg);
         }
 
         // isnan
         template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
-        inline batch_bool<T, A> isnan(batch<T, A> const& arg, requires_arch<detail::sve>) noexcept
+        inline batch_bool<T, A> isnan(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return !(arg == arg);
         }

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -184,7 +184,8 @@ namespace xsimd
     {
     };
     using all_x86_architectures = arch_list<avx512bw, avx512dq, avx512cd, avx512f, fma3<avx2>, avx2, fma3<avx>, avx, fma4, fma3<sse4_2>, sse4_2, sse4_1, /*sse4a,*/ ssse3, sse3, sse2>;
-    using all_arm_architectures = arch_list<detail::sve, neon64, neon>;
+    using all_sve_architectures = arch_list<detail::sve<512>, detail::sve<256>, detail::sve<128>>;
+    using all_arm_architectures = typename detail::join<all_sve_architectures, arch_list<neon64, neon>>::type;
     using all_architectures = typename detail::join<all_arm_architectures, all_x86_architectures>::type;
 
     using supported_architectures = typename detail::supported<all_architectures>::type;

--- a/include/xsimd/types/xsimd_sve_register.hpp
+++ b/include/xsimd/types/xsimd_sve_register.hpp
@@ -22,32 +22,28 @@
 
 namespace xsimd
 {
-    /**
-     * @ingroup arch
-     *
-     * SVE instructions (fixed vector size) for arm64
-     */
     namespace detail
     {
+        /**
+         * @ingroup arch
+         *
+         * SVE instructions (fixed vector size) for arm64
+         */
+        template <size_t Width>
         struct sve : xsimd::generic
         {
-            static constexpr bool supported() noexcept { return XSIMD_WITH_SVE; }
+            static constexpr bool supported() noexcept { return Width == XSIMD_SVE_BITS; }
             static constexpr bool available() noexcept { return true; }
             static constexpr bool requires_alignment() noexcept { return true; }
             static constexpr std::size_t alignment() noexcept { return 16; }
             static constexpr unsigned version() noexcept { return generic::version(9, 0, 0); }
             static constexpr char const* name() noexcept { return "arm64+sve"; }
         };
-    } // namespace detail
+    }
 
 #if XSIMD_WITH_SVE
 
-    // Create alias with explicit vector size
-#if XSIMD_SVE_BITS == 128
-    using sve128 = detail::sve;
-#elif XSIMD_SVE_BITS == 256
-    using sve256 = detail::sve;
-#endif
+    using sve = detail::sve<__ARM_FEATURE_SVE_BITS>;
 
     namespace types
     {
@@ -123,19 +119,19 @@ namespace xsimd
                                                               unsigned_int_sve_vector_type<T>>::type;
         } // namespace detail
 
-        XSIMD_DECLARE_SIMD_REGISTER(signed char, xsimd::detail::sve, detail::sve_vector_type<signed char>);
-        XSIMD_DECLARE_SIMD_REGISTER(unsigned char, xsimd::detail::sve, detail::sve_vector_type<unsigned char>);
-        XSIMD_DECLARE_SIMD_REGISTER(char, xsimd::detail::sve, detail::sve_vector_type<char>);
-        XSIMD_DECLARE_SIMD_REGISTER(short, xsimd::detail::sve, detail::sve_vector_type<short>);
-        XSIMD_DECLARE_SIMD_REGISTER(unsigned short, xsimd::detail::sve, detail::sve_vector_type<unsigned short>);
-        XSIMD_DECLARE_SIMD_REGISTER(int, xsimd::detail::sve, detail::sve_vector_type<int>);
-        XSIMD_DECLARE_SIMD_REGISTER(unsigned int, xsimd::detail::sve, detail::sve_vector_type<unsigned int>);
-        XSIMD_DECLARE_SIMD_REGISTER(long int, xsimd::detail::sve, detail::sve_vector_type<long int>);
-        XSIMD_DECLARE_SIMD_REGISTER(unsigned long int, xsimd::detail::sve, detail::sve_vector_type<unsigned long int>);
-        XSIMD_DECLARE_SIMD_REGISTER(long long int, xsimd::detail::sve, detail::sve_vector_type<long long int>);
-        XSIMD_DECLARE_SIMD_REGISTER(unsigned long long int, xsimd::detail::sve, detail::sve_vector_type<unsigned long long int>);
-        XSIMD_DECLARE_SIMD_REGISTER(float, xsimd::detail::sve, detail::sve_vector_type<float>);
-        XSIMD_DECLARE_SIMD_REGISTER(double, xsimd::detail::sve, detail::sve_vector_type<double>);
+        XSIMD_DECLARE_SIMD_REGISTER(signed char, sve, detail::sve_vector_type<signed char>);
+        XSIMD_DECLARE_SIMD_REGISTER(unsigned char, sve, detail::sve_vector_type<unsigned char>);
+        XSIMD_DECLARE_SIMD_REGISTER(char, sve, detail::sve_vector_type<char>);
+        XSIMD_DECLARE_SIMD_REGISTER(short, sve, detail::sve_vector_type<short>);
+        XSIMD_DECLARE_SIMD_REGISTER(unsigned short, sve, detail::sve_vector_type<unsigned short>);
+        XSIMD_DECLARE_SIMD_REGISTER(int, sve, detail::sve_vector_type<int>);
+        XSIMD_DECLARE_SIMD_REGISTER(unsigned int, sve, detail::sve_vector_type<unsigned int>);
+        XSIMD_DECLARE_SIMD_REGISTER(long int, sve, detail::sve_vector_type<long int>);
+        XSIMD_DECLARE_SIMD_REGISTER(unsigned long int, sve, detail::sve_vector_type<unsigned long int>);
+        XSIMD_DECLARE_SIMD_REGISTER(long long int, sve, detail::sve_vector_type<long long int>);
+        XSIMD_DECLARE_SIMD_REGISTER(unsigned long long int, sve, detail::sve_vector_type<unsigned long long int>);
+        XSIMD_DECLARE_SIMD_REGISTER(float, sve, detail::sve_vector_type<float>);
+        XSIMD_DECLARE_SIMD_REGISTER(double, sve, detail::sve_vector_type<double>);
 
         namespace detail
         {
@@ -148,7 +144,7 @@ namespace xsimd
         } // namespace detail
 
         template <class T>
-        struct get_bool_simd_register<T, xsimd::detail::sve>
+        struct get_bool_simd_register<T, sve>
         {
             using type = detail::sve_bool_simd_register;
         };


### PR DESCRIPTION
When linking two compilation units compiled with different sve length (e.g. to
support dynamic dispatch) current implementation use the same arch type for
different width, which leads to various linkage / runtime error.

Fix that by using a size-dependent type.