### PR TITLE
Do not specialize the behavior of simd_return_type for char

### DIFF
--- a/include/xsimd/types/xsimd_traits.hpp
+++ b/include/xsimd/types/xsimd_traits.hpp
@@ -150,13 +150,6 @@ namespace xsimd
             : std::enable_if<simd_condition<T1, T2>::value, batch<T2, A>>
         {
         };
-        template <class A>
-        struct simd_return_type_impl<char, char, A>
-            : std::conditional<std::is_signed<char>::value,
-                               simd_return_type_impl<int8_t, int8_t, A>,
-                               simd_return_type_impl<uint8_t, uint8_t, A>>::type
-        {
-        };
 
         template <class T2, class A>
         struct simd_return_type_impl<bool, T2, A>

--- a/test/test_load_store.cpp
+++ b/test/test_load_store.cpp
@@ -176,6 +176,17 @@ private:
         EXPECT_BATCH_EQ(b, expected) << print_function_name(name + " aligned (load_as)");
     }
 
+    struct test_load_char
+    {
+        /* Make sure xsimd doesn't try to be smart with char types */
+        static_assert(std::is_same<xsimd::batch<char>, decltype(xsimd::load_as<char>(std::declval<char*>(), xsimd::aligned_mode()))>::value,
+                      "honor explicit type request");
+        static_assert(std::is_same<xsimd::batch<unsigned char>, decltype(xsimd::load_as<unsigned char>(std::declval<unsigned char*>(), xsimd::aligned_mode()))>::value,
+                      "honor explicit type request");
+        static_assert(std::is_same<xsimd::batch<signed char>, decltype(xsimd::load_as<signed char>(std::declval<signed char*>(), xsimd::aligned_mode()))>::value,
+                      "honor explicit type request");
+    };
+
     template <class V>
     void test_store_impl(const V& v, const std::string& name)
     {


### PR DESCRIPTION
I understand the issue with char being either signed or unsigned, but

        load_as<char>

not returning a

        batch<char>

is too surprising--and currently leads to compile error anyway.