### PR TITLE
Test compatibility of xsimd/xsimd.hpp headers with _GNU_SOURCE

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,6 +185,7 @@ set(XSIMD_TESTS
     test_exponential.cpp
     test_extract_pair.cpp
     test_fp_manipulation.cpp
+    test_gnu_source.cpp
     test_hyperbolic.cpp
     test_load_store.cpp
     test_memory.cpp

--- a/test/test_gnu_source.cpp
+++ b/test/test_gnu_source.cpp
@@ -1,0 +1,26 @@
+/***************************************************************************
+ * Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+ * Martin Renou                                                             *
+ * Copyright (c) QuantStack                                                 *
+ * Copyright (c) Serge Guelton                                              *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+
+/*
+ * Make sure the inclusion works correctly without _GNU_SOURCE
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include "xsimd/xsimd.hpp"
+
+#include "gtest/gtest.h"
+
+TEST(gnu_source, exp10)
+{
+    EXPECT_EQ(xsimd::exp10(0.), 1.);
+    EXPECT_EQ(xsimd::exp10(0.f), 1.f);
+}


### PR DESCRIPTION
Currently only xsimd::exp10 is being specialized under that macro. This is a companion patch for #827.