### PR TITLE
Only provide % << and >> operators for integral batch types

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -142,6 +142,7 @@ set(XSIMD_TESTS
     test_complex_trigonometric.cpp
     test_conversion.cpp
     test_error_gamma.cpp
+    test_explicit_batch_instantiation.cpp
     test_exponential.cpp
     test_extract_pair.cpp
     test_fp_manipulation.cpp

--- a/test/test_explicit_batch_instantiation.cpp
+++ b/test/test_explicit_batch_instantiation.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+ * Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+ * Martin Renou                                                             *
+ * Copyright (c) QuantStack                                                 *
+ * Copyright (c) Serge Guelton                                              *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+
+#include "xsimd/xsimd.hpp"
+#ifndef XSIMD_NO_SUPPORTED_ARCHITECTURE
+
+namespace xsimd
+{
+
+    template class batch<char>;
+    template class batch<unsigned char>;
+    template class batch<signed char>;
+    template class batch<unsigned short>;
+    template class batch<signed short>;
+    template class batch<unsigned int>;
+    template class batch<signed int>;
+    template class batch<unsigned long>;
+    template class batch<signed long>;
+    template class batch<float>;
+#if !XSIMD_WITH_NEON || XSIMD_WITH_NEON64
+    template class batch<double>;
+#endif
+}
+#endif


### PR DESCRIPTION
These operators don"t make sens for floating point operation, so don't provide them.

Fix #792