### PR TITLE
Allow generic to be used in dispatch arch list

### DIFF
--- a/include/xsimd/types/xsimd_generic_arch.hpp
+++ b/include/xsimd/types/xsimd_generic_arch.hpp
@@ -25,6 +25,7 @@ namespace xsimd
         static constexpr bool available() noexcept { return true; }
         static constexpr std::size_t alignment() noexcept { return 0; }
         static constexpr bool requires_alignment() noexcept { return false; }
+        static constexpr unsigned version() noexcept { return generic::version(0, 0, 0); }
 
     protected:
         static constexpr unsigned version(unsigned major, unsigned minor, unsigned patch) noexcept { return major * 10000u + minor * 100u + patch; }

--- a/test/test_arch.cpp
+++ b/test/test_arch.cpp
@@ -116,7 +116,7 @@ TEST_CASE("[multi arch support]")
 
         // check that we pick the most appropriate version
         {
-            auto dispatched = xsimd::dispatch<xsimd::arch_list<xsimd::sse3, xsimd::sse2>>(get_arch_version {});
+            auto dispatched = xsimd::dispatch<xsimd::arch_list<xsimd::sse3, xsimd::sse2, xsimd::generic>>(get_arch_version {});
             unsigned expected = xsimd::available_architectures().best >= xsimd::sse3::version()
                 ? xsimd::sse3::version()
                 : xsimd::sse2::version();


### PR DESCRIPTION
Currently when `xsimd::generic` is put in dispatch arch list as a catch-all fallback, it fails the version comparison because the `version()` function is missing.  Adding it allow us to use it in dispatch, as long as the implementation does not involve any batch operation.

Fix #638