### PR TITLE
Use intrinsic instead of generic implementation of ldexp on avx512f

### DIFF
--- a/include/xsimd/arch/xsimd_avx512dq.hpp
+++ b/include/xsimd/arch/xsimd_avx512dq.hpp
@@ -150,6 +150,13 @@ namespace xsimd
             return concat;
         }
 
+        // ldexp
+        template <class A>
+        inline batch<double, A> ldexp(const batch<double, A>& self, const batch<as_integer_t<double>, A>& other, requires_arch<avx512dq>) noexcept
+        {
+            return _mm512_scalef_pd(self, _mm512_cvtepi64_pd(other));
+        }
+
         // mul
         template <class A>
         inline batch<uint64_t, A> mul(batch<uint64_t, A> const& self, batch<uint64_t, A> const& other, requires_arch<avx512dq>) noexcept

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -976,6 +976,22 @@ namespace xsimd
             return _mm512_cmp_pd_mask(self, self, _CMP_UNORD_Q);
         }
 
+        // ldexp
+        template <class A>
+        inline batch<float, A> ldexp(const batch<float, A>& self, const batch<as_integer_t<float>, A>& other, requires_arch<avx512f>) noexcept
+        {
+            return _mm512_scalef_ps(self, _mm512_cvtepi32_ps(other));
+        }
+
+        template <class A>
+        inline batch<double, A> ldexp(const batch<double, A>& self, const batch<as_integer_t<double>, A>& other, requires_arch<avx512f>) noexcept
+        {
+            // FIXME: potential data loss here when converting other elements to
+            // int32 before converting them back to double.
+            __m512d adjusted_index = _mm512_cvtepi32_pd(_mm512_cvtepi64_epi32(other));
+            return _mm512_scalef_pd(self, adjusted_index);
+        }
+
         // le
         template <class A>
         inline batch_bool<float, A> le(batch<float, A> const& self, batch<float, A> const& other, requires_arch<avx512f>) noexcept


### PR DESCRIPTION
Thanks to @fritterhoff for pointing at the associated intrinsic. Fix #331