### PR TITLE
Fix ambiguous symbol error with MSVC

### DIFF
--- a/include/xsimd/types/xsimd_traits.hpp
+++ b/include/xsimd/types/xsimd_traits.hpp
@@ -61,7 +61,7 @@ namespace xsimd
 
             static_assert(A::supported(),
                           "usage of batch type with unsupported architecture");
-            static_assert(!A::supported() || has_simd_register<T, A>::value,
+            static_assert(!A::supported() || xsimd::has_simd_register<T, A>::value,
                           "usage of batch type with unsupported type");
         };
 
@@ -86,20 +86,20 @@ namespace xsimd
     }
 
     template <class T>
-    struct simd_traits : detail::simd_traits_impl<T, has_simd_register<T>::value>
+    struct simd_traits : detail::simd_traits_impl<T, xsimd::has_simd_register<T>::value>
     {
     };
 
     template <class T>
     struct simd_traits<std::complex<T>>
-        : detail::simd_traits_impl<std::complex<T>, has_simd_register<T>::value>
+        : detail::simd_traits_impl<std::complex<T>, xsimd::has_simd_register<T>::value>
     {
     };
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
     template <class T, bool i3ec>
     struct simd_traits<xtl::xcomplex<T, T, i3ec>>
-        : detail::simd_traits_impl<std::complex<T>, has_simd_register<T>::value>
+        : detail::simd_traits_impl<std::complex<T>, xsimd::has_simd_register<T>::value>
     {
     };
 #endif


### PR DESCRIPTION
When compiling on MSVC I was getting an "ambiguous symbol" error for `has_simd_register`. Here's the first few lines of the error message:
```bash
D:\a\BYOD\BYOD\modules\chowdsp_utils\modules\dsp\chowdsp_simd\third_party\xsimd\include\xsimd\types\./xsimd_traits.hpp(64,1): error C2872: 'has_simd_register<float,xsimd::sse4_2>': ambiguous symbol [D:\a\BYOD\BYOD\build\modules\juce_plugin_modules.vcxproj]
D:\a\BYOD\BYOD\modules\chowdsp_utils\modules\dsp\chowdsp_simd\third_party\xsimd\include\xsimd\types\./xsimd_traits.hpp(64,46): message : could be 'xsimd::has_simd_register<T,A>' [D:\a\BYOD\BYOD\build\modules\juce_plugin_modules.vcxproj]
          with
          [
              T=float,
              A=xsimd::default_arch
          ]
D:\a\BYOD\BYOD\modules\chowdsp_utils\modules\dsp\chowdsp_simd\third_party\xsimd\include\xsimd\types\./xsimd_traits.hpp(27,39): message : or       'xsimd::types::has_simd_register<T,A>' [D:\a\BYOD\BYOD\build\modules\juce_plugin_modules.vcxproj]
          with
          [
              T=float,
              A=xsimd::default_arch
          ]
```
The change in this PR seems to fix the issue, but it does seem like a rather clunky solution. If someone more familiar with this part of the code knows of a better way to resolve the issue, that would be great as well!