### PR TITLE
Get SSE2 value from reg[3]

### DIFF
--- a/include/xsimd/config/xsimd_cpuid.hpp
+++ b/include/xsimd/config/xsimd_cpuid.hpp
@@ -111,7 +111,7 @@ namespace xsimd
 
                 get_cpuid(regs, 0x1);
 
-                sse2 = regs[2] >> 26 & 1;
+                sse2 = regs[3] >> 26 & 1;
                 best = std::max(best, sse2::version() * sse2);
 
                 sse3 = regs[2] >> 0 & 1;


### PR DESCRIPTION
From https://www.amd.com/system/files/TechDocs/24594.pdf page 596 ,and https://www.felixcloutier.com/x86/cpuid#fig-3-6 I see that the SSE2 flag comes from a different registry than the other flags. Does EDX correspond to reg[3] ?