### PR TITLE
Provide and test comparison operators overloads that accept scalars

### DIFF
--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -23,6 +23,7 @@ namespace xsimd
 {
     template <class T, class A = default_arch>
     class batch;
+
     namespace types
     {
         template <class T, class A>
@@ -73,6 +74,30 @@ namespace xsimd
         {
         };
 
+    }
+
+    namespace details
+    {
+        // These functions are forwarded declared here so that they can be used by friend functions
+        // with batch<T, A>. Their implementation must appear only once the
+        // kernel implementations have been included.
+        template <class T, class A>
+        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+
+        template <class T, class A>
+        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+
+        template <class T, class A>
+        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+
+        template <class T, class A>
+        inline batch_bool<T, A> le(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+
+        template <class T, class A>
+        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other) noexcept;
+
+        template <class T, class A>
+        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other) noexcept;
     }
 
     /**
@@ -133,13 +158,33 @@ namespace xsimd
 
         T get(std::size_t i) const noexcept;
 
-        // comparison operators
-        inline batch_bool_type operator==(batch const& other) const noexcept;
-        inline batch_bool_type operator!=(batch const& other) const noexcept;
-        inline batch_bool_type operator>=(batch const& other) const noexcept;
-        inline batch_bool_type operator<=(batch const& other) const noexcept;
-        inline batch_bool_type operator>(batch const& other) const noexcept;
-        inline batch_bool_type operator<(batch const& other) const noexcept;
+        // comparison operators. Defined as friend to enable automatic
+        // conversion of parameters from scalar to batch, at the cost of using a
+        // proxy implementation from details::.
+        friend batch_bool<T, A> operator==(batch const& self, batch const& other) noexcept
+        {
+            return details::eq<T, A>(self, other);
+        }
+        friend batch_bool<T, A> operator!=(batch const& self, batch const& other) noexcept
+        {
+            return details::neq<T, A>(self, other);
+        }
+        friend batch_bool<T, A> operator>=(batch const& self, batch const& other) noexcept
+        {
+            return details::ge<T, A>(self, other);
+        }
+        friend batch_bool<T, A> operator<=(batch const& self, batch const& other) noexcept
+        {
+            return details::le<T, A>(self, other);
+        }
+        friend batch_bool<T, A> operator>(batch const& self, batch const& other) noexcept
+        {
+            return details::gt<T, A>(self, other);
+        }
+        friend batch_bool<T, A> operator<(batch const& self, batch const& other) noexcept
+        {
+            return details::lt<T, A>(self, other);
+        }
 
         // Update operators
         inline batch& operator+=(batch const& other) noexcept;
@@ -650,65 +695,67 @@ namespace xsimd
     /******************************
      * batch comparison operators *
      ******************************/
-
-    /**
-     * Shorthand for xsimd::eq()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator==(batch<T, A> const& other) const noexcept
+    namespace details
     {
-        detail::static_check_supported_config<T, A>();
-        return kernel::eq<A>(*this, other, A {});
-    }
+        /**
+         * Shorthand for xsimd::eq()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> eq(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::eq<A>(self, other, A {});
+        }
 
-    /**
-     * Shorthand for xsimd::neq()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator!=(batch<T, A> const& other) const noexcept
-    {
-        detail::static_check_supported_config<T, A>();
-        return kernel::neq<A>(*this, other, A {});
-    }
+        /**
+         * Shorthand for xsimd::neq()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> neq(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::neq<A>(self, other, A {});
+        }
 
-    /**
-     * Shorthand for xsimd::ge()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator>=(batch<T, A> const& other) const noexcept
-    {
-        detail::static_check_supported_config<T, A>();
-        return kernel::ge<A>(*this, other, A {});
-    }
+        /**
+         * Shorthand for xsimd::ge()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> ge(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::ge<A>(self, other, A {});
+        }
 
-    /**
-     * Shorthand for xsimd::le()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator<=(batch<T, A> const& other) const noexcept
-    {
-        detail::static_check_supported_config<T, A>();
-        return kernel::le<A>(*this, other, A {});
-    }
+        /**
+         * Shorthand for xsimd::le()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> le(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::le<A>(self, other, A {});
+        }
 
-    /**
-     * Shorthand for xsimd::gt()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator>(batch<T, A> const& other) const noexcept
-    {
-        detail::static_check_supported_config<T, A>();
-        return kernel::gt<A>(*this, other, A {});
-    }
+        /**
+         * Shorthand for xsimd::gt()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::gt<A>(self, other, A {});
+        }
 
-    /**
-     * Shorthand for xsimd::lt()
-     */
-    template <class T, class A>
-    inline batch_bool<T, A> batch<T, A>::operator<(batch<T, A> const& other) const noexcept
-    {
-        detail::static_check_supported_config<T, A>();
-        return kernel::lt<A>(*this, other, A {});
+        /**
+         * Shorthand for xsimd::lt()
+         */
+        template <class T, class A>
+        inline batch_bool<T, A> lt(batch<T, A> const& self, batch<T, A> const& other) noexcept
+        {
+            detail::static_check_supported_config<T, A>();
+            return kernel::lt<A>(self, other, A {});
+        }
     }
 
     /**************************

--- a/test/test_batch.cpp
+++ b/test/test_batch.cpp
@@ -437,6 +437,10 @@ struct batch_test
             auto res = batch_lhs() < scalar;
             INFO("batch < scalar");
             CHECK_BATCH_EQ(res, expected);
+
+            auto res_neg = batch_lhs() >= scalar;
+            INFO("batch >= scalar");
+            CHECK_BATCH_EQ(!res_neg, expected);
         }
 
         // batch <= batch
@@ -458,6 +462,10 @@ struct batch_test
             auto res = batch_lhs() <= scalar;
             INFO("batch <= scalar");
             CHECK_BATCH_EQ(res, expected);
+
+            auto res_neg = batch_lhs() > scalar;
+            INFO("batch > scalar");
+            CHECK_BATCH_EQ(!res_neg, expected);
         }
 
         // batch > batch
@@ -479,6 +487,10 @@ struct batch_test
             auto res = batch_lhs() > scalar;
             INFO("batch > scalar");
             CHECK_BATCH_EQ(res, expected);
+
+            auto res_neg = batch_lhs() <= scalar;
+            INFO("batch <= scalar");
+            CHECK_BATCH_EQ(!res_neg, expected);
         }
         // batch >= batch
         {
@@ -499,6 +511,10 @@ struct batch_test
             auto res = batch_lhs() >= scalar;
             INFO("batch >= scalar");
             CHECK_BATCH_EQ(res, expected);
+
+            auto res_neg = batch_lhs() < scalar;
+            INFO("batch < scalar");
+            CHECK_BATCH_EQ(!res_neg, expected);
         }
     }
 

--- a/test/test_batch_bool.cpp
+++ b/test/test_batch_bool.cpp
@@ -365,6 +365,9 @@ struct batch_bool_test
         }
         {
             bool res = xsimd::all((bool_g.half | bool_g.ihalf) == bool_g.all_true);
+            // FIXME: this volatile statement is useless on its own, but it
+            // workaround a bug in MSVC 2022 on avx2 that shows up in CI.
+            volatile auto _ = ((bool_g.half | bool_g.ihalf) == bool_g.all_true);
             INFO("operator|");
             CHECK_UNARY(res);
         }


### PR DESCRIPTION
Instead of writing the actual scalar overloads, rely on the nice property of friend operators defined inline that allow for implicit conversion.

Fix #229