### PR TITLE
Provide a generic reducer

### DIFF
--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -880,6 +880,21 @@ namespace xsimd
     /**
      * @ingroup batch_reducers
      *
+     * Generic reducer using only batch operations
+     * @param f reducing function, accepting `batch ()(batch, batch)`
+     * @param x batch involved in the reduction
+     * @return the result of the reduction, as a scalar.
+     */
+    template <class T, class A, class F>
+    inline T reduce(F&& r, batch<T, A> const& x) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::detail::reduce(std::forward<F>(r), x, std::integral_constant<unsigned, batch<T, A>::size>());
+    }
+
+    /**
+     * @ingroup batch_reducers
+     *
      * Adds all the scalars of the batch \c x.
      * @param x batch involved in the reduction
      * @return the result of the reduction.

--- a/test/test_batch.cpp
+++ b/test/test_batch.cpp
@@ -718,6 +718,19 @@ struct batch_test
         }
     }
 
+    template <size_t N>
+    typename std::enable_if<4 <= N, void>::type test_generic_horizontal_operations(std::integral_constant<size_t, N>) const
+    {
+        // reduce generic
+        {
+            value_type expected = std::accumulate(lhs.cbegin(), lhs.cend(), value_type(1), std::multiplies<value_type>());
+            value_type res = reduce(xsimd::mul<typename B::value_type, typename B::arch_type>, batch_lhs());
+            INFO("generic reduce");
+            CHECK_SCALAR_EQ(res, expected);
+        }
+    }
+    void test_generic_horizontal_operations(...) const { }
+
     void test_boolean_conversions() const
     {
         using batch_bool_type = typename batch_type::batch_bool_type;
@@ -879,6 +892,7 @@ TEST_CASE_TEMPLATE("[batch]", B, BATCH_TYPES)
     SUBCASE("horizontal_operations")
     {
         Test.test_horizontal_operations();
+        Test.test_generic_horizontal_operations(std::integral_constant<size_t, sizeof(typename B::value_type)>());
     }
 
     SUBCASE("boolean_conversions")


### PR DESCRIPTION
Note that we don't support all register size, but we test it for scalar >= 32bits.

Fix #873