### PR TITLE
Fix find_package(xsimd) for xtl enabled xsimd, reloaded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,8 @@ OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
 OPTION(BUILD_TESTS "xsimd test suite" OFF)
 
 if(ENABLE_XTL_COMPLEX)
-    add_definitions(-DXSIMD_ENABLE_XTL_COMPLEX=1)
     find_package(xtl 0.7.0 REQUIRED)
+    target_compile_definitions(xsimd INTERFACE XSIMD_ENABLE_XTL_COMPLEX=1)
     target_link_libraries(xsimd INTERFACE xtl)
 endif()
 

--- a/xsimdConfig.cmake.in
+++ b/xsimdConfig.cmake.in
@@ -21,7 +21,7 @@ if(NOT TARGET @PROJECT_NAME@)
     set(@PROJECT_NAME@_ENABLE_XTL_COMPLEX @ENABLE_XTL_COMPLEX@)
     if(@PROJECT_NAME@_ENABLE_XTL_COMPLEX)
         include(CMakeFindDependencyMacro)
-        find_dependency(xtl)
+        find_dependency(xtl REQUIRED)
     endif()
 
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
PR #788 fixes xtl lookup by adding the corresponding find_dependency call. However, there are still two issues remaining:

- If xtl is not found, the INTERFACE_LINK_LIBRARIES property will make CMake interpret "xtl" as a .lib, pass it as a -l flag, and cause the build to fail.

- If xtl is used, the required definition XSIMD_ENABLE_XTL_COMPLEX=1 is never passsed to downstream consumers.

This commit fixes both issues, ensuring that if xtl was required at compile time, the Config module with not load unless xtl is also found.

Fixes #869