### PR TITLE
Cleanup benchmark code

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -33,7 +33,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     if(NOT CMAKE_CXX_FLAGS MATCHES "-march" AND NOT CMAKE_CXX_FLAGS MATCHES "-arch" AND NOT CMAKE_OSX_ARCHITECTURES)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-parameter -Wextra -Wreorder -Wconversion")
 
     if(NOT MSVC)
         CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_CPP11_FLAG)

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, char* argv[])
         }
         else
         {
+            std::cout << "############################" << std::endl
+                      << "# " << xsimd::default_arch::name() << std::endl
+                      << "############################" << std::endl;
             for (int i = 1; i < argc; ++i)
             {
                 fn_map.at(argv[i]).second();
@@ -144,6 +147,9 @@ int main(int argc, char* argv[])
     }
     else
     {
+        std::cout << "############################" << std::endl
+                  << "# " << xsimd::default_arch::name() << std::endl
+                  << "############################" << std::endl;
         for (auto const& kv : fn_map)
         {
             kv.second.second();

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -382,7 +382,7 @@ namespace xsimd
 #endif
 
         out << "============================" << std::endl;
-        out << default_arch::name() << std::endl;
+        out << f.name() << std::endl;
         out << "scalar float      : " << t_float_scalar.count() << "ms" << std::endl;
         out << "vector float      : " << t_float_vector.count() << "ms" << std::endl;
         out << "vector float unr  : " << t_float_vector_u.count() << "ms" << std::endl;
@@ -413,7 +413,7 @@ namespace xsimd
 #endif
 
         out << "============================" << std::endl;
-        out << default_arch::name() << std::endl;
+        out << f.name() << std::endl;
         out << "scalar float      : " << t_float_scalar.count() << "ms" << std::endl;
         out << "vector float      : " << t_float_vector.count() << "ms" << std::endl;
         out << "vector float unr  : " << t_float_vector_u.count() << "ms" << std::endl;


### PR DESCRIPTION
* It's not benchmark's role to track warnings.
* Dump architecture name at the beginning of the bench
* Fix an incorrect dump of arch instead of benchmark name