### PR TITLE
back to slow implementation of exp10 on Windows on Windows

### DIFF
--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -459,14 +459,13 @@ namespace xsimd
     {
         return ::exp10(x);
     }
-#elif defined(__MINGW32__)
-    inline float exp10(const float& x) noexcept
+#elif defined(_WIN32)
+    template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>
+    inline T exp10(const T& x) noexcept
     {
-        return std::exp((float)(2.30258509F * (x)));
-    }
-    inline double exp10(const double& x) noexcept
-    {
-        return std::exp((double)(2.30258509299404568402 * (x)));
+        // Very inefficient but other implementations give incorrect results
+        // on Windows
+        return std::pow(T(10), x);
     }
 #else
     inline float exp10(const float& x) noexcept

--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -463,11 +463,7 @@ struct xsimd_api_float_types_functions
     void test_exp10()
     {
         value_type val(2);
-#ifndef _WIN32
         CHECK_EQ(extract(xsimd::exp10(T(val))), std::pow(value_type(10), val));
-#else
-        WARN_EQ(extract(xsimd::exp10(T(val))), std::pow(value_type(10), val));
-#endif
     }
     void test_exp2()
     {


### PR DESCRIPTION
Fixes #898

@serge-sans-paille it seems that it is the only way to get correct results of `exp10` on Windows.