### PR TITLE
Check for macro M_LN10 before using hard coded value

### DIFF
--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -497,11 +497,19 @@ namespace xsimd
 #else
     inline float exp10(const float& x) noexcept
     {
+#if defined(M_LN10)
+        return std::exp((float)(M_LN10 * (x)));
+#else
         return std::exp(0x1.26bb1cp+1f * x);
+#endif
     }
     inline double exp10(const double& x) noexcept
     {
+#if defined(M_LN10)
+        return std::exp((double)(M_LN10 * (x)));
+#else
         return std::exp(0x1.26bb1bbb55516p+1 * x);
+#endif
     }
 #endif
 


### PR DESCRIPTION
Using the hard coded value brakes compilation with gcc12 on alpine linux with:

```
xsimd-11.0.0/include/xsimd/arch/xsimd_scalar.hpp:500:25: error: exponent has no digits  
500          return std::exp(0x1.26bb1cp+1f * x);
                         ^~~~~~~~~~~
xsimd-11.0.0/include/xsimd/arch/xsimd_scalar.hpp:504:25: error: exponent has no digits
504          return std::exp(0x1.26bb1bbb55516p+1 * x);
                         ^~~~~~~~~~~~~~~~~~
```