### PR TITLE
Introduce XSIMD_DEFAULT_ARCH as a way to customize the default archit…

### DIFF
--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -24,7 +24,7 @@ namespace xsimd
     using duration_type = std::chrono::duration<double, std::milli>;
 
     template <class T>
-    using bench_vector = std::vector<T, xsimd::aligned_allocator<T>>;
+    using bench_vector = std::vector<T, xsimd::aligned_allocator<T, default_arch::alignment()>>;
 
     template <class T>
     void init_benchmark(bench_vector<T>& lhs, bench_vector<T>& rhs, bench_vector<T>& res, size_t size)

--- a/docs/source/api/instr_macros.rst
+++ b/docs/source/api/instr_macros.rst
@@ -36,3 +36,10 @@ can be used to filter arch-specific code.
    :project: xsimd
    :content-only:
 
+Changing Default architecture
+*****************************
+
+You can change the default instruction set used by xsimd (when none is provided
+explicitely) by setting the ``XSIMD_DEFAULT_ARCH`` macro to, say, ``xsimd::avx2``.
+A common usage is to set it to ``xsimd::unsupported`` as a way to detect
+instantiation of batches with the default architecture.

--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -230,7 +230,7 @@ namespace scalar
 } // namespace scalar
 
 // run simd version of mandelbrot benchmark for a specific arch
-template <class arch, class bencher_t>
+template <class arch, class bencher_t, size_t Align>
 void run_arch(
     bencher_t& bencher,
     float x0,
@@ -240,7 +240,7 @@ void run_arch(
     int width,
     int height,
     int maxIters,
-    std::vector<int, xsimd::aligned_allocator<int>>& buffer)
+    std::vector<int, xsimd::aligned_allocator<int, Align>>& buffer)
 {
     std::fill(buffer.begin(), buffer.end(), 0);
     auto stats = bencher([&]()
@@ -262,7 +262,7 @@ struct run_archlist;
 template <class... Arch>
 struct run_archlist<xsimd::arch_list<Arch...>>
 {
-    template <class bencher_t>
+    template <class bencher_t, size_t Align>
     static void run(
         bencher_t& bencher,
         float x0,
@@ -272,7 +272,7 @@ struct run_archlist<xsimd::arch_list<Arch...>>
         int width,
         int height,
         int maxIters,
-        std::vector<int, xsimd::aligned_allocator<int>>& buffer)
+        std::vector<int, xsimd::aligned_allocator<int, Align>>& buffer)
     {
         using expand_type = int[];
         expand_type { (run_arch<Arch>(bencher, x0, y0, x1, x1, width, height, maxIters, buffer), 0)... };
@@ -291,7 +291,7 @@ int main()
     const float y1 = 1;
     const int maxIters = 256;
 
-    std::vector<int, xsimd::aligned_allocator<int>> buf(width * height);
+    std::vector<int, xsimd::aligned_allocator<int, xsimd::default_arch::alignment()>> buf(width * height);
 
     auto bencher = pico_bench::Benchmarker<milliseconds> { 64, seconds { 10 } };
 

--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -378,8 +378,8 @@ namespace xsimd
                                                  std::complex<float> c0, std::complex<float> c1,
                                                  std::complex<float> c2, std::complex<float> c3) noexcept
         {
-            return batch<std::complex<float>>(float32x4_t { c0.real(), c1.real(), c2.real(), c3.real() },
-                                              float32x4_t { c0.imag(), c1.imag(), c2.imag(), c3.imag() });
+            return batch<std::complex<float>, A>(float32x4_t { c0.real(), c1.real(), c2.real(), c3.real() },
+                                                 float32x4_t { c0.imag(), c1.imag(), c2.imag(), c3.imag() });
         }
 
         template <class A, class... Args>

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -200,7 +200,12 @@ namespace xsimd
     using x86_arch = typename detail::supported<all_x86_architectures>::type::best;
     using arm_arch = typename detail::supported<all_arm_architectures>::type::best;
     using best_arch = typename supported_architectures::best;
+
+#ifdef XSIMD_DEFAULT_ARCH
+    using default_arch = XSIMD_DEFAULT_ARCH;
+#else
     using default_arch = best_arch;
+#endif
 
     namespace detail
     {

--- a/include/xsimd/memory/xsimd_aligned_allocator.hpp
+++ b/include/xsimd/memory/xsimd_aligned_allocator.hpp
@@ -39,7 +39,7 @@ namespace xsimd
      * @tparam T type of objects to allocate.
      * @tparam Align alignment in bytes.
      */
-    template <class T, size_t Align = default_arch::alignment()>
+    template <class T, size_t Align>
     class aligned_allocator
     {
     public:

--- a/include/xsimd/memory/xsimd_alignment.hpp
+++ b/include/xsimd/memory/xsimd_alignment.hpp
@@ -43,8 +43,8 @@ namespace xsimd
         using type = unaligned_mode;
     };
 
-    template <class T>
-    struct allocator_alignment<aligned_allocator<T>>
+    template <class T, size_t N>
+    struct allocator_alignment<aligned_allocator<T, N>>
     {
         using type = aligned_mode;
     };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,6 +141,7 @@ set(XSIMD_TESTS
     test_complex_power.cpp
     test_complex_trigonometric.cpp
     test_conversion.cpp
+    test_custom_default_arch.cpp
     test_error_gamma.cpp
     test_explicit_batch_instantiation.cpp
     test_exponential.cpp

--- a/test/test_custom_default_arch.cpp
+++ b/test/test_custom_default_arch.cpp
@@ -1,0 +1,26 @@
+/***************************************************************************
+ * Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+ * Martin Renou                                                             *
+ * Copyright (c) QuantStack                                                 *
+ * Copyright (c) Serge Guelton                                              *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+#ifdef __STSE2__
+
+#define XSIMD_DEFAULT_ARCH xsimd::sse2
+#include "xsimd/xsimd.hpp"
+
+#include "test_utils.hpp"
+
+// Could be different than sse2 if we compile for other architecture avx
+static_assert(std::is_same<xsimd::default_arch, xsimd::sse2>::value, "default arch correctly hooked");
+
+#else
+
+#define XSIMD_DEFAULT_ARCH xsimd::unsupported
+#include "xsimd/xsimd.hpp"
+
+#endif


### PR DESCRIPTION
…ecture

One of the use-case is to detect when the default architecture is used by #defining XSIMD_DEFAULT_ARCH xsimd::unsupported.