### PR TITLE
11.1.0

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -9,6 +9,15 @@
 Changelog
 =========
 
+11.1.0
+------
+
+    * Introduce XSIMD_DEFAULT_ARCH to force default architecture (if any)
+
+    * Remove C++ requirement on xsimd::exp10 scalar implementation
+
+    * Improve and test documentation
+
 11.0.0
 ------
 

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -14,7 +14,7 @@
 
 #define XSIMD_VERSION_MAJOR 11
 #define XSIMD_VERSION_MINOR 0
-#define XSIMD_VERSION_PATCH 0
+#define XSIMD_VERSION_PATCH 1
 
 /**
  * high level free functions


### PR DESCRIPTION
@JohanMabille 11.0.0 was missing the compatibility patch introduced by a1e07510dd81a0b074d2cef8e09bf8e59b926aae, which breaks some Pythran dependencies.