### PR TITLE
Remove 'const' from batch_bool assignment operators

### DIFF
--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -331,9 +331,9 @@ namespace xsimd
         batch_bool operator||(batch_bool const& other) const noexcept;
 
         // update operators
-        batch_bool& operator&=(batch_bool const& other) const noexcept { return (*this) = (*this) & other; }
-        batch_bool& operator|=(batch_bool const& other) const noexcept { return (*this) = (*this) | other; }
-        batch_bool& operator^=(batch_bool const& other) const noexcept { return (*this) = (*this) ^ other; }
+        batch_bool& operator&=(batch_bool const& other) noexcept { return (*this) = (*this) & other; }
+        batch_bool& operator|=(batch_bool const& other) noexcept { return (*this) = (*this) | other; }
+        batch_bool& operator^=(batch_bool const& other) noexcept { return (*this) = (*this) ^ other; }
 
     private:
         template <class U, class... V, size_t I, size_t... Is>


### PR DESCRIPTION
Assignment operators like `operator|=`, `operator&=` and `operator^=` should not be const since the purpose of those operators is updating the object that defines the operator. With `const`, the following simple function does not compile:
```
void xsimd_or(xsimd::batch_bool<bool>& b1, xsimd::batch_bool<bool>& b2) {
    b1 |= b2; 
}
```