### PR TITLE
Support isfinite/isinf for std::complex<X>

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_complex.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_complex.hpp
@@ -90,6 +90,18 @@ namespace xsimd
         {
             return batch_bool<T, A>(isnan(self.real()) || isnan(self.imag()));
         }
+
+        template <class A, class T>
+        inline batch_bool<T, A> isinf(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        {
+            return batch_bool<T, A>(isinf(self.real()) || isinf(self.imag()));
+        }
+
+        template <class A, class T>
+        inline batch_bool<T, A> isfinite(batch<std::complex<T>, A> const& self, requires_arch<generic>) noexcept
+        {
+            return batch_bool<T, A>(isfinite(self.real()) && isfinite(self.imag()));
+        }
     }
 }
 

--- a/include/xsimd/arch/generic/xsimd_generic_details.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_details.hpp
@@ -59,7 +59,9 @@ namespace xsimd
     template <class T, class A>
     inline batch_bool<T, A> is_odd(batch<T, A> const& self) noexcept;
     template <class T, class A>
-    inline batch_bool<T, A> isinf(batch<T, A> const& self) noexcept;
+    inline typename batch<T, A>::batch_bool_type isinf(batch<T, A> const& self) noexcept;
+    template <class T, class A>
+    inline typename batch<T, A>::batch_bool_type isfinite(batch<T, A> const& self) noexcept;
     template <class T, class A>
     inline typename batch<T, A>::batch_bool_type isnan(batch<T, A> const& self) noexcept;
     template <class T, class A>

--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -348,7 +348,6 @@ namespace xsimd
         return 1. / x;
     }
 
-#ifdef XSIMD_ENABLE_NUMPY_COMPLEX
     template <class T>
     inline bool isnan(std::complex<T> var) noexcept
     {
@@ -360,7 +359,12 @@ namespace xsimd
     {
         return std::isinf(std::real(var)) || std::isinf(std::imag(var));
     }
-#endif
+
+    template <class T>
+    inline bool isfinite(std::complex<T> var) noexcept
+    {
+        return std::isfinite(std::real(var)) && std::isfinite(std::imag(var));
+    }
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
     using xtl::abs;

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1065,7 +1065,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> isinf(batch<T, A> const& x) noexcept
+    inline typename batch<T, A>::batch_bool_type isinf(batch<T, A> const& x) noexcept
     {
         detail::static_check_supported_config<T, A>();
         return kernel::isinf<A>(x, A {});
@@ -1079,7 +1079,7 @@ namespace xsimd
      * @return a batch of booleans.
      */
     template <class T, class A>
-    inline batch_bool<T, A> isfinite(batch<T, A> const& x) noexcept
+    inline typename batch<T, A>::batch_bool_type isfinite(batch<T, A> const& x) noexcept
     {
         detail::static_check_supported_config<T, A>();
         return kernel::isfinite<A>(x, A {});

--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -549,21 +549,6 @@ struct xsimd_api_float_types_functions
         value_type val(4);
         CHECK_EQ(extract(xsimd::is_odd(T(val))), (val == long(val)) && (long(val) % 2 == 1));
     }
-    void test_isinf()
-    {
-        value_type val(4);
-        CHECK_EQ(extract(xsimd::isinf(T(val))), std::isinf(val));
-    }
-    void test_isfinite()
-    {
-        value_type val(4);
-        CHECK_EQ(extract(xsimd::isfinite(T(val))), std::isfinite(val));
-    }
-    void test_isnan()
-    {
-        value_type val(4);
-        CHECK_EQ(extract(xsimd::isnan(T(val))), std::isnan(val));
-    }
     void test_ldexp()
     {
         value_type val0(4);
@@ -835,18 +820,6 @@ TEST_CASE_TEMPLATE("[xsimd api | float types functions]", B, FLOAT_TYPES)
     {
         Test.test_is_odd();
     }
-    SUBCASE("isinf")
-    {
-        Test.test_isinf();
-    }
-    SUBCASE("isfinite")
-    {
-        Test.test_isfinite();
-    }
-    SUBCASE("isnan")
-    {
-        Test.test_isnan();
-    }
     SUBCASE("ldexp")
     {
         Test.test_ldexp();
@@ -994,6 +967,24 @@ struct xsimd_api_complex_types_functions
         value_type val(1);
         CHECK_EQ(extract(xsimd::proj(T(val))), std::proj(val));
     }
+
+    void test_isinf()
+    {
+        value_type val(4);
+        CHECK_EQ(extract(xsimd::isinf(T(val))), std::isinf(std::real(val)));
+    }
+
+    void test_isfinite()
+    {
+        value_type val(4);
+        CHECK_EQ(extract(xsimd::isfinite(T(val))), std::isfinite(std::real(val)));
+    }
+
+    void test_isnan()
+    {
+        value_type val(4);
+        CHECK_EQ(extract(xsimd::isnan(T(val))), std::isnan(std::real(val)));
+    }
 };
 
 TEST_CASE_TEMPLATE("[xsimd api | complex types functions]", B, COMPLEX_TYPES)
@@ -1017,6 +1008,21 @@ TEST_CASE_TEMPLATE("[xsimd api | complex types functions]", B, COMPLEX_TYPES)
     SUBCASE("proj")
     {
         Test.test_proj();
+    }
+
+    SUBCASE("isinf")
+    {
+        Test.test_isinf();
+    }
+
+    SUBCASE("isfinite")
+    {
+        Test.test_isfinite();
+    }
+
+    SUBCASE("isnan")
+    {
+        Test.test_isnan();
     }
 }
 


### PR DESCRIPTION
Support xsimd::isfinite and xsimd::isinf, analogous to the existing xsimd::isnan implementation.

Extend tests so they also compile and run these functions with complex values.