### PR TITLE
Fix minor warnings

### DIFF
--- a/examples/mandelbrot.cpp
+++ b/examples/mandelbrot.cpp
@@ -274,8 +274,7 @@ struct run_archlist<xsimd::arch_list<Arch...>>
         int maxIters,
         std::vector<int, xsimd::aligned_allocator<int, Align>>& buffer)
     {
-        using expand_type = int[];
-        expand_type { (run_arch<Arch>(bencher, x0, y0, x1, x1, width, height, maxIters, buffer), 0)... };
+        (void)std::initializer_list<int> { (run_arch<Arch>(bencher, x0, y0, x1, x1, width, height, maxIters, buffer), 0)... };
     }
 };
 

--- a/test/doc/explicit_use_of_an_instruction_set.cpp
+++ b/test/doc/explicit_use_of_an_instruction_set.cpp
@@ -3,7 +3,7 @@
 
 namespace xs = xsimd;
 
-int main(int argc, char* argv[])
+int main(int, char*[])
 {
     xs::batch<double, xs::avx> a = { 1.5, 2.5, 3.5, 4.5 };
     xs::batch<double, xs::avx> b = { 2.5, 3.5, 4.5, 5.5 };


### PR DESCRIPTION
They clutter the build output for no reason.