### PR TITLE
Add proper compile definition when XTL has been configured

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,19 +86,16 @@ target_include_directories(xsimd INTERFACE
     $<BUILD_INTERFACE:${XSIMD_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>)
 
-if (ENABLE_XTL_COMPLEX)
-    target_compile_features(xsimd INTERFACE cxx_std_14)
-else()
-    target_compile_features(xsimd INTERFACE cxx_std_11)
-endif()
-
 OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
 OPTION(BUILD_TESTS "xsimd test suite" OFF)
 
 if(ENABLE_XTL_COMPLEX)
     find_package(xtl 0.7.0 REQUIRED)
+    target_compile_features(xsimd INTERFACE cxx_std_14)
     target_compile_definitions(xsimd INTERFACE XSIMD_ENABLE_XTL_COMPLEX=1)
     target_link_libraries(xsimd INTERFACE xtl)
+else()
+    target_compile_features(xsimd INTERFACE cxx_std_11)
 endif()
 
 if(BUILD_TESTS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,8 +191,10 @@ else()
 endif()
 
 if(ENABLE_XTL_COMPLEX)
-target_include_directories(test_xsimd PRIVATE ${xtl_INCLUDE_DIRS})
+  add_compile_definitions(XSIMD_ENABLE_XTL_COMPLEX=1)
+  target_include_directories(test_xsimd PRIVATE ${xtl_INCLUDE_DIRS})
 endif()
+
 add_test(NAME test_xsimd COMMAND test_xsimd)
 
 if (CROSS_COMPILE_ARM)

--- a/test/doc/CMakeLists.txt
+++ b/test/doc/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND NOT CMAKE_OSX_ARCHITECTURES)
 
+if(ENABLE_XTL_COMPLEX)
+  add_compile_definitions(XSIMD_ENABLE_XTL_COMPLEX=1)
+  include_directories(${xtl_INCLUDE_DIRS})
+endif()
+
 add_library(test_doc_any_arch OBJECT
             explicit_use_of_an_instruction_set_mean_aligned.cpp
             explicit_use_of_an_instruction_set_mean_arch_independent.cpp


### PR DESCRIPTION
Basically so that -DENABLE_XTL_COMPLEX=On at configuration step implies -DXSIMD_ENABLE_XTL_COMPLEX=1 for the tests.

Fix #942