### PR TITLE
Added missing boolean operators in xsimd_api.hpp

### DIFF
--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -1158,7 +1158,7 @@ namespace xsimd
         template <class A>
         inline batch_bool<float, A> neq(batch_bool<float, A> const& self, batch_bool<float, A> const& other, requires_arch<sse2>) noexcept
         {
-            return _mm_cmpneq_ps(self, other);
+            return _mm_xor_ps(self, other);
         }
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         inline batch_bool<T, A> neq(batch_bool<T, A> const& self, batch_bool<T, A> const& other, requires_arch<sse2>) noexcept
@@ -1174,7 +1174,7 @@ namespace xsimd
         template <class A>
         inline batch_bool<double, A> neq(batch_bool<double, A> const& self, batch_bool<double, A> const& other, requires_arch<sse2>) noexcept
         {
-            return _mm_cmpneq_pd(self, other);
+            return _mm_xor_pd(self, other);
         }
 
         // reciprocal

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -649,6 +649,21 @@ namespace xsimd
     }
 
     /**
+     * @ingroup batch_logical
+     *
+     * Element-wise equality comparison of batches of boolean values \c x and \c y.
+     * @param x batch of booleans involved in the comparison.
+     * @param y batch of booleans involved in the comparison.
+     * @return a boolean batch.
+     */
+    template <class T, class A>
+    inline auto eq(batch_bool<T, A> const& x, batch_bool<T, A> const& y) noexcept -> decltype(x == y)
+    {
+        detail::static_check_supported_config<T, A>();
+        return x == y;
+    }
+
+    /**
      * @ingroup batch_math
      *
      * Computes the natural exponential of the batch \c x.
@@ -1516,6 +1531,21 @@ namespace xsimd
      */
     template <class T, class A>
     inline auto neq(batch<T, A> const& x, batch<T, A> const& y) noexcept -> decltype(x != y)
+    {
+        detail::static_check_supported_config<T, A>();
+        return x != y;
+    }
+
+    /**
+     * @ingroup batch_logical
+     *
+     * Element-wise inequality comparison of batches of boolean values \c x and \c y.
+     * @param x batch of booleans involved in the comparison.
+     * @param y batch of booleans involved in the comparison.
+     * @return a boolean batch.
+     */
+    template <class T, class A>
+    inline auto neq(batch_bool<T, A> const& x, batch_bool<T, A> const& y) noexcept -> decltype(x != y)
     {
         detail::static_check_supported_config<T, A>();
         return x != y;

--- a/test/test_batch_bool.cpp
+++ b/test/test_batch_bool.cpp
@@ -440,6 +440,21 @@ struct batch_bool_test
         CHECK_EQ(batch_bool_type::from_mask(bool_g.interspersed.mask()).mask(), bool_g.interspersed.mask());
     }
 
+    void test_comparison() const
+    {
+        auto bool_g = xsimd::get_bool<batch_bool_type> {};
+        // eq
+        {
+            bool res = xsimd::all(xsimd::eq(bool_g.half, !bool_g.ihalf));
+            CHECK_UNARY(res);
+        }
+        // neq
+        {
+            bool res = xsimd::all(xsimd::neq(bool_g.half, bool_g.ihalf));
+            CHECK_UNARY(res);
+        }
+    }
+
 private:
     batch_type batch_lhs() const
     {
@@ -469,5 +484,7 @@ TEST_CASE_TEMPLATE("[xsimd batch bool]", B, BATCH_TYPES)
     SUBCASE("update operations") { Test.test_update_operations(); }
 
     SUBCASE("mask") { Test.test_mask(); }
+
+    SUBCASE("eq neq") { Test.test_comparison(); }
 }
 #endif


### PR DESCRIPTION
Support for `eq` and `neq` operations was added for `bool_batch` in `xsimd_api.hpp`