### PR TITLE
Test nearbyint_as_int using xsimd's scalar version instead of lround

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -1855,7 +1855,7 @@ namespace xsimd
         {
             using U = as_integer_t<float>;
             return kernel::detail::apply_transform<U>([](float x) noexcept -> U
-                                                      { return std::lroundf(x); },
+                                                      { return std::nearbyintf(x); },
                                                       self);
         }
 
@@ -1865,7 +1865,7 @@ namespace xsimd
         {
             using U = as_integer_t<double>;
             return kernel::detail::apply_transform<U>([](double x) noexcept -> U
-                                                      { return std::llround(x); },
+                                                      { return std::nearbyint(x); },
                                                       self);
         }
 

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -1124,14 +1124,14 @@ namespace xsimd
         template <class A>
         inline batch<int32_t, A> nearbyint_as_int(batch<float, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto nearest = svrinta_x(detail::sve_ptrue<float>(), arg);
+            const auto nearest = svrintx_x(detail::sve_ptrue<float>(), arg);
             return svcvt_s32_x(detail::sve_ptrue<float>(), nearest);
         }
 
         template <class A>
         inline batch<int64_t, A> nearbyint_as_int(batch<double, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto nearest = svrinta_x(detail::sve_ptrue<double>(), arg);
+            const auto nearest = svrintx_x(detail::sve_ptrue<double>(), arg);
             return svcvt_s64_x(detail::sve_ptrue<double>(), nearest);
         }
 

--- a/test/test_rounding.cpp
+++ b/test/test_rounding.cpp
@@ -14,19 +14,6 @@
 
 #include "test_utils.hpp"
 
-namespace detail
-{
-    inline xsimd::as_integer_t<float> nearbyint_as_int(float a)
-    {
-        return std::lroundf(a);
-    }
-
-    inline xsimd::as_integer_t<double> nearbyint_as_int(double a)
-    {
-        return std::llround(a);
-    }
-}
-
 template <class B>
 struct rounding_test
 {
@@ -163,7 +150,7 @@ struct rounding_test
             std::array<int_value_type, nb_input> res;
             std::transform(input.cbegin(), input.cend(), expected.begin(),
                            [](const value_type& v)
-                           { return detail::nearbyint_as_int(v); });
+                           { return xsimd::nearbyint_as_int(v); });
             batch_type in;
             int_batch_type out;
             for (size_t i = 0; i < nb_batches; i += size)
@@ -174,7 +161,7 @@ struct rounding_test
             }
             for (size_t i = nb_batches; i < nb_input; ++i)
             {
-                res[i] = detail::nearbyint_as_int(input[i]);
+                res[i] = xsimd::nearbyint_as_int(input[i]);
             }
             size_t diff = detail::get_nb_diff(res, expected);
             INFO("nearbyint_as_int");


### PR DESCRIPTION
Fix #948