### PR TITLE
Add an option to skip installtion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docs/build/
 # VSCode / clangd IntelliSense
 .vscode/
 .cache/
+
+# CLion / IDEA
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ endif()
 # Installation
 # ============
 
+OPTION(XSIMD_SKIP_INSTALL "Skip installation or not. By default it is OFF" OFF)
+if(${XSIMD_SKIP_INSTALL})
+    return() # skip installation
+endif ()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(JoinPaths)
 include(GNUInstallDirs)


### PR DESCRIPTION
An option `XSIMD_SKIP_INSTALL` is added to decide whether to install xsimd files. This can be useful when xsimd is used as an subproject.

To keep default behavior unchanged, the default value of this option is OFF. Developers can set `XSIMD_SKIP_INSTALL` to ON in order to skip xsimd installtion.

This pr implements #959 