### PR TITLE
Disable batch of bools, and suggest using batch_bool instead

### DIFF
--- a/include/xsimd/types/xsimd_avx512f_register.hpp
+++ b/include/xsimd/types/xsimd_avx512f_register.hpp
@@ -53,7 +53,6 @@ namespace xsimd
             using type = simd_avx512_bool_register<T>;
         };
 
-        XSIMD_DECLARE_SIMD_REGISTER(bool, avx512f, __m512i);
         XSIMD_DECLARE_SIMD_REGISTER(signed char, avx512f, __m512i);
         XSIMD_DECLARE_SIMD_REGISTER(unsigned char, avx512f, __m512i);
         XSIMD_DECLARE_SIMD_REGISTER(char, avx512f, __m512i);

--- a/include/xsimd/types/xsimd_avx_register.hpp
+++ b/include/xsimd/types/xsimd_avx_register.hpp
@@ -42,7 +42,6 @@ namespace xsimd
     namespace types
     {
 
-        XSIMD_DECLARE_SIMD_REGISTER(bool, avx, __m256i);
         XSIMD_DECLARE_SIMD_REGISTER(signed char, avx, __m256i);
         XSIMD_DECLARE_SIMD_REGISTER(unsigned char, avx, __m256i);
         XSIMD_DECLARE_SIMD_REGISTER(char, avx, __m256i);

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -112,6 +112,7 @@ namespace xsimd
     template <class T, class A>
     class batch : public types::simd_register<T, A>, public types::integral_only_operators<T, A>
     {
+        static_assert(!std::is_same<T, bool>::value, "use xsimd::batch_bool<T, A> instead of xsimd::batch<bool, A>");
 
     public:
         static constexpr std::size_t size = sizeof(types::simd_register<T, A>) / sizeof(T); ///< Number of scalar elements in this batch.

--- a/include/xsimd/types/xsimd_sse2_register.hpp
+++ b/include/xsimd/types/xsimd_sse2_register.hpp
@@ -40,7 +40,6 @@ namespace xsimd
 #if XSIMD_WITH_SSE2
     namespace types
     {
-        XSIMD_DECLARE_SIMD_REGISTER(bool, sse2, __m128i);
         XSIMD_DECLARE_SIMD_REGISTER(signed char, sse2, __m128i);
         XSIMD_DECLARE_SIMD_REGISTER(unsigned char, sse2, __m128i);
         XSIMD_DECLARE_SIMD_REGISTER(char, sse2, __m128i);

--- a/include/xsimd/types/xsimd_wasm_register.hpp
+++ b/include/xsimd/types/xsimd_wasm_register.hpp
@@ -40,7 +40,6 @@ namespace xsimd
 #if XSIMD_WITH_WASM
     namespace types
     {
-        XSIMD_DECLARE_SIMD_REGISTER(bool, wasm, v128_t);
         XSIMD_DECLARE_SIMD_REGISTER(signed char, wasm, v128_t);
         XSIMD_DECLARE_SIMD_REGISTER(unsigned char, wasm, v128_t);
         XSIMD_DECLARE_SIMD_REGISTER(char, wasm, v128_t);


### PR DESCRIPTION
It was only supported on Intel architectures and wasm, for no clear reason. Provide a unified experience by enforcing batch_bool instead. If someone really wants a batch of bool, then use another type to store it, e.g. uint8_t.

Fix #945