### PR TITLE
Fixed `constants::signmask` for GCC when using `ffast-math`

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -95,12 +95,22 @@ namespace xsimd
         template <class A>
         inline batch<float, A> bitofsign(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
+            // Under fast-math, the compiler might replace minus zero by zero
+#ifdef __FAST_MATH__
+            return self & bitwise_cast<float>(batch<uint32_t, A>::broadcast(0x80000000u));
+#else
             return self & constants::minuszero<batch<float, A>>();
+#endif
         }
         template <class A>
         inline batch<double, A> bitofsign(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
+            // Under fast-math, the compiler might replace minus zero by zero
+#ifdef __FAST_MATH__
+            return self & bitwise_cast<double>(batch<uint64_t, A>::broadcast(0x8000000000000000lu));
+#else
             return self & constants::minuszero<batch<double, A>>();
+#endif
         }
 
         // bitwise_cast

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -15,7 +15,6 @@
 #include "../xsimd_scalar.hpp"
 #include "./xsimd_generic_details.hpp"
 #include "./xsimd_generic_trigo.hpp"
-#include "xsimd/arch/xsimd_constants.hpp"
 
 #include <type_traits>
 

--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -15,6 +15,7 @@
 #include "../xsimd_scalar.hpp"
 #include "./xsimd_generic_details.hpp"
 #include "./xsimd_generic_trigo.hpp"
+#include "xsimd/arch/xsimd_constants.hpp"
 
 #include <type_traits>
 
@@ -95,22 +96,12 @@ namespace xsimd
         template <class A>
         inline batch<float, A> bitofsign(batch<float, A> const& self, requires_arch<generic>) noexcept
         {
-            // Under fast-math, the compiler might replace minus zero by zero
-#ifdef __FAST_MATH__
-            return self & bitwise_cast<float>(batch<uint32_t, A>::broadcast(0x80000000u));
-#else
-            return self & constants::minuszero<batch<float, A>>();
-#endif
+            return self & constants::signmask<batch<float, A>>();
         }
         template <class A>
         inline batch<double, A> bitofsign(batch<double, A> const& self, requires_arch<generic>) noexcept
         {
-            // Under fast-math, the compiler might replace minus zero by zero
-#ifdef __FAST_MATH__
-            return self & bitwise_cast<double>(batch<uint64_t, A>::broadcast(0x8000000000000000lu));
-#else
-            return self & constants::minuszero<batch<double, A>>();
-#endif
+            return self & constants::signmask<batch<double, A>>();
         }
 
         // bitwise_cast

--- a/include/xsimd/arch/xsimd_constants.hpp
+++ b/include/xsimd/arch/xsimd_constants.hpp
@@ -56,6 +56,12 @@ namespace xsimd
         return bit_cast<double>((uint64_t)DOUBLE);      \
     }
 
+// Under fast-math, GCC might replace minus zero by zero
+// minuszero wouldn't be patched, but this works for signmask
+#if defined(__FAST_MATH__) && defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize("signed-zeros")
+#endif
         XSIMD_DEFINE_CONSTANT(infinity, (std::numeric_limits<float>::infinity()), (std::numeric_limits<double>::infinity()))
         XSIMD_DEFINE_CONSTANT(invlog_2, 1.442695040888963407359924681001892137426645954152986f, 1.442695040888963407359924681001892137426645954152986)
         XSIMD_DEFINE_CONSTANT_HEX(invlog_2hi, 0x3fb8b000, 0x3ff7154765200000)
@@ -104,6 +110,9 @@ namespace xsimd
         XSIMD_DEFINE_CONSTANT_HEX(twoopi, 0x3f22f983, 0x3fe45f306dc9c883)
         XSIMD_DEFINE_CONSTANT(twotonmb, 8388608.0f, 4503599627370496.0)
         XSIMD_DEFINE_CONSTANT_HEX(twotonmbo3, 0x3ba14518, 0x3ed428a2f98d7286)
+#if defined(__FAST_MATH__) && defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 #undef XSIMD_DEFINE_CONSTANT
 #undef XSIMD_DEFINE_CONSTANT_HEX

--- a/include/xsimd/arch/xsimd_constants.hpp
+++ b/include/xsimd/arch/xsimd_constants.hpp
@@ -56,7 +56,7 @@ namespace xsimd
         return bit_cast<double>((uint64_t)DOUBLE);      \
     }
 
-// Under fast-math, GCC might signmask (minus zero) by zero
+// Under fast-math, GCC might replace signmask (minus zero) by zero
 #if defined(__FAST_MATH__) && defined(__GNUC__) && !defined(__clang__)
 #pragma GCC push_options
 #pragma GCC optimize("signed-zeros")

--- a/include/xsimd/arch/xsimd_constants.hpp
+++ b/include/xsimd/arch/xsimd_constants.hpp
@@ -56,8 +56,7 @@ namespace xsimd
         return bit_cast<double>((uint64_t)DOUBLE);      \
     }
 
-// Under fast-math, GCC might replace minus zero by zero
-// minuszero wouldn't be patched, but this works for signmask
+// Under fast-math, GCC might signmask (minus zero) by zero
 #if defined(__FAST_MATH__) && defined(__GNUC__) && !defined(__clang__)
 #pragma GCC push_options
 #pragma GCC optimize("signed-zeros")
@@ -85,7 +84,6 @@ namespace xsimd
         XSIMD_DEFINE_CONSTANT(minlog2, -127.0f, -1023.)
         XSIMD_DEFINE_CONSTANT(minlog10, -37.89999771118164f, -308.2547155599167)
         XSIMD_DEFINE_CONSTANT(minusinfinity, (-infinity<float>()), (-infinity<double>()))
-        XSIMD_DEFINE_CONSTANT(minuszero, -0.0f, -0.0)
         XSIMD_DEFINE_CONSTANT_HEX(nan, 0xffffffff, 0xffffffffffffffff)
         XSIMD_DEFINE_CONSTANT_HEX(oneosqrteps, 0x453504f3, 0x4190000000000000)
         XSIMD_DEFINE_CONSTANT_HEX(oneotwoeps, 0x4a800000, 0x4320000000000000)


### PR DESCRIPTION
This PR fix a bug than can occur with `-ffast-math`, where the compiler replace -0. values with 0. and therefore breaks the `bitofsign` function as well as several function (exp, sin, cos...) that make use of a bitwise `&` comparison with `constants::signmask`

To fix the `bitofsign` function I had to update it and stop using `minuszero` and use `signmask` instead. `minuszero` is therefore not used anywhere anymore and could maybe be deleted ?

I investigated a bit on how to do the same for clang but I didn't find a solution, and I wasn't able to reproduce the issue with a clang-based aarch64 compiler anyway.

This PR fixes #971 