### PR TITLE
Sort all_architectures according to their versions

### DIFF
--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -196,7 +196,7 @@ namespace xsimd
     using all_arm_architectures = typename detail::join<all_sve_architectures, arch_list<neon64, neon>>::type;
     using all_riscv_architectures = all_rvv_architectures;
     using all_wasm_architectures = arch_list<wasm>;
-    using all_architectures = typename detail::join<all_wasm_architectures, all_arm_architectures, all_x86_architectures, all_riscv_architectures>::type;
+    using all_architectures = typename detail::join<all_riscv_architectures, all_wasm_architectures, all_arm_architectures, all_x86_architectures>::type;
 
     using supported_architectures = typename detail::supported<all_architectures>::type;
 

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -196,7 +196,7 @@ namespace xsimd
     using all_arm_architectures = typename detail::join<all_sve_architectures, arch_list<neon64, neon>>::type;
     using all_riscv_architectures = all_rvv_architectures;
     using all_wasm_architectures = arch_list<wasm>;
-    using all_architectures = typename detail::join<all_arm_architectures, all_x86_architectures, all_riscv_architectures, all_wasm_architectures>::type;
+    using all_architectures = typename detail::join<all_wasm_architectures, all_arm_architectures, all_x86_architectures, all_riscv_architectures>::type;
 
     using supported_architectures = typename detail::supported<all_architectures>::type;
 

--- a/include/xsimd/types/xsimd_batch_constant.hpp
+++ b/include/xsimd/types/xsimd_batch_constant.hpp
@@ -215,17 +215,17 @@ namespace xsimd
 
 #undef MAKE_BINARY_OP
 
-        constexpr batch_constant<batch_type, (value_type)-Values...> operator-() const
+        constexpr batch_constant<batch_type, static_cast<value_type>(0-Values)...> operator-() const
         {
             return {};
         }
 
-        constexpr batch_constant<batch_type, (value_type) + Values...> operator+() const
+        constexpr batch_constant<batch_type, static_cast<value_type>(+Values)...> operator+() const
         {
             return {};
         }
 
-        constexpr batch_constant<batch_type, (value_type)~Values...> operator~() const
+        constexpr batch_constant<batch_type, static_cast<value_type>(~Values)...> operator~() const
         {
             return {};
         }


### PR DESCRIPTION
all_architectures should satisfy 
```
static_assert(detail::is_sorted<Archs...>::value, "architecture list must be sorted by version");
```
Also fixed msvc warning for unary minus for unsigned type. 