### PR TITLE
xsimd_scalar.hpp: fix for missing exp10 on macOS < 10.9

### DIFF
--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -24,6 +24,10 @@
 #include "xtl/xcomplex.hpp"
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 namespace xsimd
 {
     template <class T, class A>
@@ -502,7 +506,7 @@ namespace xsimd
         return !(x0 == x1);
     }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1080)
     inline float exp10(const float& x) noexcept
     {
         return __exp10f(x);
@@ -519,6 +523,15 @@ namespace xsimd
     inline double exp10(const double& x) noexcept
     {
         return ::exp10(x);
+    }
+#elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 5)
+    inline float exp10(const float& x) noexcept
+    {
+        return __builtin_exp10f(x);
+    }
+    inline double exp10(const double& x) noexcept
+    {
+        return __builtin_exp10(x);
     }
 #elif defined(_WIN32)
     template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>


### PR DESCRIPTION
`exp10` and `exp10f` are missing on macOS before 10.9, which breaks building some dependents that use `xsimd` headers. Fix that.