### PR TITLE
Loosen exp10 tests accuracy constraints

### DIFF
--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -526,11 +526,9 @@ struct xsimd_api_float_types_functions
     void test_exp10()
     {
         value_type val(2);
-#ifdef EMSCRIPTEN
+        // exp10 doesn't always have an accurate implementation, so allow for
+        // approximate result
         CHECK_EQ(extract(xsimd::exp10(T(val))), doctest::Approx(std::pow(value_type(10), val)));
-#else
-        CHECK_EQ(extract(xsimd::exp10(T(val))), std::pow(value_type(10), val));
-#endif
     }
     void test_exp2()
     {


### PR DESCRIPTION
Both some scalar version and some vector version (depending on arch) are not totally accurate, so allow for some approximation.

Should fix #917