### PR TITLE
Explicitly verify dependency between architectures (like sse3 implies…

### DIFF
--- a/.github/workflows/arch-consistency-check.yml
+++ b/.github/workflows/arch-consistency-check.yml
@@ -1,0 +1,15 @@
+name: Arch consistency check
+on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout xsimd
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt install g++
+      - name: Check architecture consistency
+        run: cd test && sh ./check_arch.sh

--- a/include/xsimd/types/xsimd_avx2_register.hpp
+++ b/include/xsimd/types/xsimd_avx2_register.hpp
@@ -29,6 +29,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_AVX2
+
+#if !XSIMD_WITH_AVX
+#error "architecture inconsistency: avx2 requires avx"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(avx2, avx);

--- a/include/xsimd/types/xsimd_avx512bw_register.hpp
+++ b/include/xsimd/types/xsimd_avx512bw_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512BW
 
+#if !XSIMD_WITH_AVX512DQ
+#error "architecture inconsistency: avx512bw requires avx512dq"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512cd_register.hpp
+++ b/include/xsimd/types/xsimd_avx512cd_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512CD
 
+#if !XSIMD_WITH_AVX512F
+#error "architecture inconsistency: avx512bw requires avx512f"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512dq_register.hpp
+++ b/include/xsimd/types/xsimd_avx512dq_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512DQ
 
+#if !XSIMD_WITH_AVX512CD
+#error "architecture inconsistency: avx512dq requires avx512cd"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512er_register.hpp
+++ b/include/xsimd/types/xsimd_avx512er_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512ER
 
+#if !XSIMD_WITH_AVX512CD
+#error "architecture inconsistency: avx512er requires avx512cd"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512f_register.hpp
+++ b/include/xsimd/types/xsimd_avx512f_register.hpp
@@ -33,6 +33,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512F
 
+#if !XSIMD_WITH_AVX2
+#error "architecture inconsistency: avx512f requires avx2"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512ifma_register.hpp
+++ b/include/xsimd/types/xsimd_avx512ifma_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512IFMA
 
+#if !XSIMD_WITH_AVX512BW
+#error "architecture inconsistency: avx512ifma requires avx512bw"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512pf_register.hpp
+++ b/include/xsimd/types/xsimd_avx512pf_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512PF
 
+#if !XSIMD_WITH_AVX512ER
+#error "architecture inconsistency: avx512pf requires avx512er"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512vbmi_register.hpp
+++ b/include/xsimd/types/xsimd_avx512vbmi_register.hpp
@@ -31,6 +31,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512VBMI
 
+#if !XSIMD_WITH_AVX512IFMA
+#error "architecture inconsistency: avx512vbmi requires avx512ifma"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512vnni_avx512bw_register.hpp
+++ b/include/xsimd/types/xsimd_avx512vnni_avx512bw_register.hpp
@@ -34,6 +34,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512VNNI_AVX512BW
 
+#if !XSIMD_WITH_AVX512BW
+#error "architecture inconsistency: avx512vnni+avx512bw requires avx512bw"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx512vnni_avx512vbmi_register.hpp
+++ b/include/xsimd/types/xsimd_avx512vnni_avx512vbmi_register.hpp
@@ -34,6 +34,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX512VNNI_AVX512VBMI
 
+#if !XSIMD_WITH_AVX512VBMI
+#error "architecture inconsistency: avx512vnni+avx512vbmi requires avx512vbmi"
+#endif
+
     namespace types
     {
         template <class T>

--- a/include/xsimd/types/xsimd_avx_register.hpp
+++ b/include/xsimd/types/xsimd_avx_register.hpp
@@ -34,6 +34,10 @@ namespace xsimd
 
 #if XSIMD_WITH_AVX
 
+#if !XSIMD_WITH_SSE4_2
+#error "architecture inconsistency: avx requires sse4.2"
+#endif
+
 #include <immintrin.h>
 
 namespace xsimd

--- a/include/xsimd/types/xsimd_avxvnni_register.hpp
+++ b/include/xsimd/types/xsimd_avxvnni_register.hpp
@@ -29,6 +29,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_AVXVNNI
+
+#if !XSIMD_WITH_AVX2
+#error "architecture inconsistency: avxvnni requires avx2"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(avxvnni, avx2);

--- a/include/xsimd/types/xsimd_fma3_avx2_register.hpp
+++ b/include/xsimd/types/xsimd_fma3_avx2_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_FMA3_AVX2
+
+#if !XSIMD_WITH_AVX2
+#error "architecture inconsistency: fma3+avx2 requires avx2"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_fma3_avx_register.hpp
+++ b/include/xsimd/types/xsimd_fma3_avx_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_FMA3_AVX
+
+#if !XSIMD_WITH_AVX
+#error "architecture inconsistency: fma3+avx requires avx"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_fma3_sse_register.hpp
+++ b/include/xsimd/types/xsimd_fma3_sse_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_FMA3_SSE
+
+#if !XSIMD_WITH_SSE4_2
+#error "architecture inconsistency: fma3+sse4.2 requires sse4.2"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_fma4_register.hpp
+++ b/include/xsimd/types/xsimd_fma4_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_FMA4
+
+#if !XSIMD_WITH_SSE4_2
+#error "architecture inconsistency: fma4 requires sse4.2"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_i8mm_neon64_register.hpp
+++ b/include/xsimd/types/xsimd_i8mm_neon64_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_I8MM_NEON64
+
+#if !XSIMD_WITH_NEON64
+#error "architecture inconsistency: i8mm+neon64 requires neon64"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_neon64_register.hpp
+++ b/include/xsimd/types/xsimd_neon64_register.hpp
@@ -32,6 +32,10 @@ namespace xsimd
 
 #if XSIMD_WITH_NEON64
 
+#if !XSIMD_WITH_NEON
+#error "architecture inconsistency: neon64 requires neon"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(neon64, neon);

--- a/include/xsimd/types/xsimd_sse3_register.hpp
+++ b/include/xsimd/types/xsimd_sse3_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_SSE3
+
+#if !XSIMD_WITH_SSE2
+#error "architecture inconsistency: sse3 requires sse2"
+#endif
+
     namespace types
     {
 

--- a/include/xsimd/types/xsimd_sse4_1_register.hpp
+++ b/include/xsimd/types/xsimd_sse4_1_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_SSE4_1
+
+#if !XSIMD_WITH_SSSE3
+#error "architecture inconsistency: sse4.1 requires ssse3"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(sse4_1, ssse3);

--- a/include/xsimd/types/xsimd_sse4_2_register.hpp
+++ b/include/xsimd/types/xsimd_sse4_2_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_SSE4_2
+
+#if !XSIMD_WITH_SSE4_1
+#error "architecture inconsistency: sse4.2 requires sse4.1"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(sse4_2, sse4_1);

--- a/include/xsimd/types/xsimd_ssse3_register.hpp
+++ b/include/xsimd/types/xsimd_ssse3_register.hpp
@@ -33,6 +33,11 @@ namespace xsimd
     };
 
 #if XSIMD_WITH_SSSE3
+
+#if !XSIMD_WITH_SSE3
+#error "architecture inconsistency: ssse3 requires sse3"
+#endif
+
     namespace types
     {
         XSIMD_DECLARE_SIMD_REGISTER_ALIAS(ssse3, sse3);

--- a/test/check_arch.sh
+++ b/test/check_arch.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -e
+CXX=g++
+printf "int main() { return 0;}" > sanity_check.cpp
+printf "#include <xsimd/xsimd.hpp>\nint main() { return 0;}" > xsimd_check.cpp
+
+sed -n '/x86[-]64/,$ p' $0 | \
+    while read arch; do \
+        if echo $arch | grep -q '#' ; then continue; fi ; \
+        echo "# $arch" ; \
+        $CXX -w -march=$arch sanity_check.cpp -fsyntax-only ;  \
+        $CXX -w -I../include -march=$arch xsimd_check.cpp -fsyntax-only ; \
+    done
+
+rm sanity_check.cpp xsimd_check.cpp
+
+exit 0
+nocona
+core2
+nehalem
+corei7
+westmere
+sandybridge
+corei7-avx
+ivybridge
+core-avx-i
+haswell
+core-avx2
+broadwell
+skylake
+skylake-avx512
+cannonlake
+icelake-client
+rocketlake
+icelake-server
+cascadelake
+tigerlake
+cooperlake
+sapphirerapids
+emeraldrapids
+alderlake
+raptorlake
+meteorlake
+graniterapids
+graniterapids-d
+bonnell
+atom
+silvermont
+slm
+goldmont
+goldmont-plus
+tremont
+gracemont
+sierraforest
+grandridge
+knl
+knm
+x86-64
+x86-64-v2
+x86-64-v3
+x86-64-v4
+eden-x2
+nano
+nano-1000
+nano-2000
+nano-3000
+nano-x2
+eden-x4
+nano-x4
+lujiazui
+k8
+k8-sse3
+opteron
+opteron-sse3
+athlon64
+athlon64-sse3
+athlon-fx
+amdfam10
+barcelona
+bdver1
+bdver2
+bdver3
+bdver4
+znver1
+znver2
+znver3
+znver4
+btver1
+btver2


### PR DESCRIPTION
… sse2)

Also add CI to make sure the assumption we make are correct on all architectures supported by GCC.

Fix #1070