### PR TITLE
Reorder make_batch_constant template arguments

### DIFF
--- a/include/xsimd/arch/generic/xsimd_generic_math.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_math.hpp
@@ -2087,7 +2087,7 @@ namespace xsimd
             XSIMD_INLINE T reduce(Op op, batch<T, A> const& self, std::integral_constant<unsigned, Lvl>) noexcept
             {
                 using index_type = as_unsigned_integer_t<T>;
-                batch<T, A> split = swizzle(self, make_batch_constant<index_type, A, split_high<index_type, Lvl / 2>>());
+                batch<T, A> split = swizzle(self, make_batch_constant<index_type, split_high<index_type, Lvl / 2>, A>());
                 return reduce(op, op(split, self), std::integral_constant<unsigned, Lvl / 2>());
             }
         }

--- a/include/xsimd/arch/generic/xsimd_generic_memory.hpp
+++ b/include/xsimd/arch/generic/xsimd_generic_memory.hpp
@@ -207,7 +207,7 @@ namespace xsimd
                 }
             };
             batch<T, A> tmp(val);
-            return select(make_batch_bool_constant<T, A, index_mask>(), self, tmp);
+            return select(make_batch_bool_constant<T, index_mask, A>(), self, tmp);
         }
 
         // get
@@ -341,7 +341,7 @@ namespace xsimd
                 }
             };
 
-            return swizzle(self, make_batch_constant<as_unsigned_integer_t<T>, A, rotate_generator>(), A {});
+            return swizzle(self, make_batch_constant<as_unsigned_integer_t<T>, rotate_generator, A>(), A {});
         }
 
         template <size_t N, class A, class T>
@@ -362,7 +362,7 @@ namespace xsimd
                 }
             };
 
-            return swizzle(self, make_batch_constant<as_unsigned_integer_t<T>, A, rotate_generator>(), A {});
+            return swizzle(self, make_batch_constant<as_unsigned_integer_t<T>, rotate_generator, A>(), A {});
         }
 
         template <size_t N, class A, class T>

--- a/include/xsimd/types/xsimd_batch_constant.hpp
+++ b/include/xsimd/types/xsimd_batch_constant.hpp
@@ -245,13 +245,13 @@ namespace xsimd
 
     namespace detail
     {
-        template <typename T, class A, class G, std::size_t... Is>
+        template <typename T, class G, class A, std::size_t... Is>
         XSIMD_INLINE constexpr auto make_batch_constant(detail::index_sequence<Is...>) noexcept
             -> batch_constant<T, A, (T)G::get(Is, sizeof...(Is))...>
         {
             return {};
         }
-        template <typename T, class A, class G, std::size_t... Is>
+        template <typename T, class G, class A, std::size_t... Is>
         XSIMD_INLINE constexpr auto make_batch_bool_constant(detail::index_sequence<Is...>) noexcept
             -> batch_bool_constant<T, A, G::get(Is, sizeof...(Is))...>
         {
@@ -280,18 +280,18 @@ namespace xsimd
      * };
      * @endcode
      */
-    template <typename T, class A, class G>
-    XSIMD_INLINE constexpr auto make_batch_constant() noexcept -> decltype(detail::make_batch_constant<T, A, G>(detail::make_index_sequence<batch<T, A>::size>()))
+    template <typename T, class G, class A = default_arch>
+    XSIMD_INLINE constexpr auto make_batch_constant() noexcept -> decltype(detail::make_batch_constant<T, G, A>(detail::make_index_sequence<batch<T, A>::size>()))
     {
-        return detail::make_batch_constant<T, A, G>(detail::make_index_sequence<batch<T, A>::size>());
+        return detail::make_batch_constant<T, G, A>(detail::make_index_sequence<batch<T, A>::size>());
     }
 
-    template <typename T, class A, class G>
+    template <typename T, class G, class A = default_arch>
     XSIMD_INLINE constexpr auto make_batch_bool_constant() noexcept
-        -> decltype(detail::make_batch_bool_constant<T, A, G>(
+        -> decltype(detail::make_batch_bool_constant<T, G, A>(
             detail::make_index_sequence<batch<T, A>::size>()))
     {
-        return detail::make_batch_bool_constant<T, A, G>(
+        return detail::make_batch_bool_constant<T, G, A>(
             detail::make_index_sequence<batch<T, A>::size>());
     }
 

--- a/test/test_batch_constant.cpp
+++ b/test/test_batch_constant.cpp
@@ -40,14 +40,14 @@ struct constant_batch_test
         std::generate(expected.begin(), expected.end(),
                       [&i]()
                       { return generator::get(i++, size); });
-        constexpr auto b = xsimd::make_batch_constant<value_type, arch_type, generator>();
+        constexpr auto b = xsimd::make_batch_constant<value_type, generator, arch_type>();
         INFO("batch(value_type)");
         CHECK_BATCH_EQ((batch_type)b, expected);
     }
 
     void test_cast() const
     {
-        constexpr auto cst_b = xsimd::make_batch_constant<value_type, arch_type, generator>();
+        constexpr auto cst_b = xsimd::make_batch_constant<value_type, generator, arch_type>();
         auto b0 = cst_b.as_batch();
         auto b1 = (batch_type)cst_b;
         CHECK_BATCH_EQ(b0, b1);
@@ -69,7 +69,7 @@ struct constant_batch_test
         std::generate(expected.begin(), expected.end(),
                       [&i]()
                       { return arange::get(i++, size); });
-        constexpr auto b = xsimd::make_batch_constant<value_type, arch_type, arange>();
+        constexpr auto b = xsimd::make_batch_constant<value_type, arange, arch_type>();
         INFO("batch(value_type)");
         CHECK_BATCH_EQ((batch_type)b, expected);
     }
@@ -87,34 +87,34 @@ struct constant_batch_test
     {
         array_type expected;
         std::fill(expected.begin(), expected.end(), constant<3>::get(0, 0));
-        constexpr auto b = xsimd::make_batch_constant<value_type, arch_type, constant<3>>();
+        constexpr auto b = xsimd::make_batch_constant<value_type, constant<3>, arch_type>();
         INFO("batch(value_type)");
         CHECK_BATCH_EQ((batch_type)b, expected);
     }
 
     void test_ops() const
     {
-        constexpr auto n12 = xsimd::make_batch_constant<value_type, arch_type, constant<12>>();
-        constexpr auto n3 = xsimd::make_batch_constant<value_type, arch_type, constant<3>>();
+        constexpr auto n12 = xsimd::make_batch_constant<value_type, constant<12>, arch_type>();
+        constexpr auto n3 = xsimd::make_batch_constant<value_type, constant<3>, arch_type>();
 
         constexpr auto n12_add_n3 = n12 + n3;
-        constexpr auto n15 = xsimd::make_batch_constant<value_type, arch_type, constant<15>>();
+        constexpr auto n15 = xsimd::make_batch_constant<value_type, constant<15>, arch_type>();
         static_assert(std::is_same<decltype(n12_add_n3), decltype(n15)>::value, "n12 + n3 == n15");
 
         constexpr auto n12_sub_n3 = n12 - n3;
-        constexpr auto n9 = xsimd::make_batch_constant<value_type, arch_type, constant<9>>();
+        constexpr auto n9 = xsimd::make_batch_constant<value_type, constant<9>, arch_type>();
         static_assert(std::is_same<decltype(n12_sub_n3), decltype(n9)>::value, "n12 - n3 == n9");
 
         constexpr auto n12_mul_n3 = n12 * n3;
-        constexpr auto n36 = xsimd::make_batch_constant<value_type, arch_type, constant<36>>();
+        constexpr auto n36 = xsimd::make_batch_constant<value_type, constant<36>, arch_type>();
         static_assert(std::is_same<decltype(n12_mul_n3), decltype(n36)>::value, "n12 * n3 == n36");
 
         constexpr auto n12_div_n3 = n12 / n3;
-        constexpr auto n4 = xsimd::make_batch_constant<value_type, arch_type, constant<4>>();
+        constexpr auto n4 = xsimd::make_batch_constant<value_type, constant<4>, arch_type>();
         static_assert(std::is_same<decltype(n12_div_n3), decltype(n4)>::value, "n12 / n3 == n4");
 
         constexpr auto n12_mod_n3 = n12 % n3;
-        constexpr auto n0 = xsimd::make_batch_constant<value_type, arch_type, constant<0>>();
+        constexpr auto n0 = xsimd::make_batch_constant<value_type, constant<0>, arch_type>();
         static_assert(std::is_same<decltype(n12_mod_n3), decltype(n0)>::value, "n12 % n3 == n0");
 
         constexpr auto n12_land_n3 = n12 & n3;
@@ -130,11 +130,11 @@ struct constant_batch_test
         static_assert(std::is_same<decltype(n12_uadd), decltype(n12)>::value, "+n12 == n12");
 
         constexpr auto n12_inv = ~n12;
-        constexpr auto n12_inv_ = xsimd::make_batch_constant<value_type, arch_type, constant<(value_type)~12>>();
+        constexpr auto n12_inv_ = xsimd::make_batch_constant<value_type, constant<(value_type)~12>, arch_type>();
         static_assert(std::is_same<decltype(n12_inv), decltype(n12_inv_)>::value, "~n12 == n12_inv");
 
         constexpr auto n12_usub = -n12;
-        constexpr auto n12_usub_ = xsimd::make_batch_constant<value_type, arch_type, constant<(value_type)-12>>();
+        constexpr auto n12_usub_ = xsimd::make_batch_constant<value_type, constant<(value_type)-12>, arch_type>();
         static_assert(std::is_same<decltype(n12_usub), decltype(n12_usub_)>::value, "-n12 == n12_usub");
     }
 };
@@ -185,7 +185,7 @@ struct constant_bool_batch_test
         std::generate(expected.begin(), expected.end(),
                       [&i]()
                       { return generator::get(i++, size); });
-        constexpr auto b = xsimd::make_batch_bool_constant<value_type, arch_type, generator>();
+        constexpr auto b = xsimd::make_batch_bool_constant<value_type, generator, arch_type>();
         INFO("batch_bool_constant(value_type)");
         CHECK_BATCH_EQ((batch_bool_type)b, expected);
     }
@@ -205,7 +205,7 @@ struct constant_bool_batch_test
         std::generate(expected.begin(), expected.end(),
                       [&i]()
                       { return split::get(i++, size); });
-        constexpr auto b = xsimd::make_batch_bool_constant<value_type, arch_type, split>();
+        constexpr auto b = xsimd::make_batch_bool_constant<value_type, split, arch_type>();
         INFO("batch_bool_constant(value_type)");
         CHECK_BATCH_EQ((batch_bool_type)b, expected);
     }
@@ -229,7 +229,7 @@ struct constant_bool_batch_test
 
     void test_cast() const
     {
-        constexpr auto all_true = xsimd::make_batch_bool_constant<value_type, arch_type, constant<true>>();
+        constexpr auto all_true = xsimd::make_batch_bool_constant<value_type, constant<true>, arch_type>();
         auto b0 = all_true.as_batch_bool();
         auto b1 = (batch_bool_type)all_true;
         CHECK_BATCH_EQ(b0, batch_bool_type(true));
@@ -238,11 +238,11 @@ struct constant_bool_batch_test
 
     void test_ops() const
     {
-        constexpr auto all_true = xsimd::make_batch_bool_constant<value_type, arch_type, constant<true>>();
-        constexpr auto all_false = xsimd::make_batch_bool_constant<value_type, arch_type, constant<false>>();
+        constexpr auto all_true = xsimd::make_batch_bool_constant<value_type, constant<true>, arch_type>();
+        constexpr auto all_false = xsimd::make_batch_bool_constant<value_type, constant<false>, arch_type>();
 
-        constexpr auto x = xsimd::make_batch_bool_constant<value_type, arch_type, split>();
-        constexpr auto y = xsimd::make_batch_bool_constant<value_type, arch_type, inv_split>();
+        constexpr auto x = xsimd::make_batch_bool_constant<value_type, split, arch_type>();
+        constexpr auto y = xsimd::make_batch_bool_constant<value_type, inv_split, arch_type>();
 
         constexpr auto x_or_y = x | y;
         static_assert(std::is_same<decltype(x_or_y), decltype(all_true)>::value, "x | y == true");

--- a/test/test_batch_manip.cpp
+++ b/test/test_batch_manip.cpp
@@ -187,7 +187,7 @@ struct swizzle_test
         B b_exped = B::load_unaligned(v_exped.data());
 
         using index_type = typename as_index<value_type>::type;
-        auto index_batch = xsimd::make_batch_constant<index_type, arch_type, Reversor<index_type>>();
+        auto index_batch = xsimd::make_batch_constant<index_type, Reversor<index_type>, arch_type>();
 
         B b_res = xsimd::swizzle(b_lhs, index_batch);
         CHECK_BATCH_EQ(b_res, b_exped);
@@ -207,7 +207,7 @@ struct swizzle_test
         B b_exped = B::load_unaligned(v_exped.data());
 
         using index_type = typename as_index<value_type>::type;
-        auto index_batch = xsimd::make_batch_constant<index_type, arch_type, Last<index_type>>();
+        auto index_batch = xsimd::make_batch_constant<index_type, Last<index_type>, arch_type>();
 
         B b_res = xsimd::swizzle(b_lhs, index_batch);
         CHECK_BATCH_EQ(b_res, b_exped);
@@ -227,7 +227,7 @@ struct swizzle_test
         B b_exped = B::load_unaligned(v_exped.data());
 
         using index_type = typename as_index<value_type>::type;
-        auto index_batch = xsimd::make_batch_constant<index_type, arch_type, Dup<index_type>>();
+        auto index_batch = xsimd::make_batch_constant<index_type, Dup<index_type>, arch_type>();
 
         B b_res = xsimd::swizzle(b_lhs, index_batch);
         CHECK_BATCH_EQ(b_res, b_exped);

--- a/test/test_select.cpp
+++ b/test/test_select.cpp
@@ -68,7 +68,7 @@ struct select_test
 
     void test_select_static()
     {
-        constexpr auto mask = xsimd::make_batch_bool_constant<value_type, arch_type, pattern>();
+        constexpr auto mask = xsimd::make_batch_bool_constant<value_type, pattern, arch_type>();
 
         for (size_t i = 0; i < nb_input; ++i)
         {

--- a/test/test_shuffle.cpp
+++ b/test/test_shuffle.cpp
@@ -498,7 +498,7 @@ struct shuffle_test
         };
 
         INFO("no op lhs");
-        B b_res_lhs = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, no_op_lhs_generator>());
+        B b_res_lhs = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, no_op_lhs_generator, arch_type>());
         CHECK_BATCH_EQ(b_res_lhs, b_lhs);
 
         struct no_op_rhs_generator
@@ -510,7 +510,7 @@ struct shuffle_test
         };
 
         INFO("no op rhs");
-        B b_res_rhs = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, no_op_rhs_generator>());
+        B b_res_rhs = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, no_op_rhs_generator, arch_type>());
         CHECK_BATCH_EQ(b_res_rhs, b_rhs);
     }
 
@@ -535,7 +535,7 @@ struct shuffle_test
         }
         B b_ref = B::load_unaligned(ref.data());
 
-        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, generic_generator>());
+        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, generic_generator, arch_type>());
         CHECK_BATCH_EQ(b_res, b_ref);
     }
 
@@ -557,7 +557,7 @@ struct shuffle_test
             ref[i] = (i > 2) ? lhs[0] : rhs[0];
         B b_ref = B::load_unaligned(ref.data());
 
-        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, pick_generator>());
+        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, pick_generator, arch_type>());
         CHECK_BATCH_EQ(b_res, b_ref);
     }
 
@@ -581,7 +581,7 @@ struct shuffle_test
             B b_ref = B::load_unaligned(ref.data());
 
             INFO("swizzle first batch");
-            B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, swizzle_lo_generator>());
+            B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, swizzle_lo_generator, arch_type>());
             CHECK_BATCH_EQ(b_res, b_ref);
         }
 
@@ -600,7 +600,7 @@ struct shuffle_test
             B b_ref = B::load_unaligned(ref.data());
 
             INFO("swizzle second batch");
-            B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, swizzle_hi_generator>());
+            B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, swizzle_hi_generator, arch_type>());
             CHECK_BATCH_EQ(b_res, b_ref);
         }
     }
@@ -643,7 +643,7 @@ struct shuffle_test
         B b_ref = B::load_unaligned(ref.data());
 
         INFO("select");
-        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, select_generator>());
+        B b_res = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, select_generator, arch_type>());
         CHECK_BATCH_EQ(b_res, b_ref);
     }
 
@@ -666,7 +666,7 @@ struct shuffle_test
         B b_ref_lo = B::load_unaligned(ref_lo.data());
 
         INFO("zip_lo");
-        B b_res_lo = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, zip_lo_generator>());
+        B b_res_lo = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, zip_lo_generator, arch_type>());
         CHECK_BATCH_EQ(b_res_lo, b_ref_lo);
 
         struct zip_hi_generator
@@ -685,7 +685,7 @@ struct shuffle_test
         B b_ref_hi = B::load_unaligned(ref_hi.data());
 
         INFO("zip_hi");
-        B b_res_hi = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, arch_type, zip_hi_generator>());
+        B b_res_hi = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, zip_hi_generator, arch_type>());
         CHECK_BATCH_EQ(b_res_hi, b_ref_hi);
     }
 };


### PR DESCRIPTION
So that we can use a default architecture, which is consistent with other API.

This is an API breaking change