### PR TITLE
Remove out-of-line definition of constexpr static data members

### DIFF
--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -271,9 +271,6 @@ namespace xsimd
         XSIMD_INLINE batch logical_or(batch const& other) const noexcept;
     };
 
-    template <class T, class A>
-    constexpr std::size_t batch<T, A>::size;
-
     /**
      * @brief batch of predicate over scalar or complex values.
      *
@@ -343,9 +340,6 @@ namespace xsimd
         template <class... V>
         static XSIMD_INLINE register_type make_register(detail::index_sequence<>, V... v) noexcept;
     };
-
-    template <class T, class A>
-    constexpr std::size_t batch_bool<T, A>::size;
 
     /**
      * @brief batch of complex values.
@@ -475,9 +469,6 @@ namespace xsimd
         real_batch m_real;
         real_batch m_imag;
     };
-
-    template <class T, class A>
-    constexpr std::size_t batch<std::complex<T>, A>::size;
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
     template <typename T, bool i3ec, typename A>

--- a/include/xsimd/types/xsimd_traits.hpp
+++ b/include/xsimd/types/xsimd_traits.hpp
@@ -54,18 +54,12 @@ namespace xsimd
         };
 
         template <class T>
-        constexpr size_t simd_traits_impl<T, false>::size;
-
-        template <class T>
         struct simd_traits_impl<T, true>
         {
             using type = batch<T>;
             using bool_type = typename type::batch_bool_type;
             static constexpr size_t size = type::size;
         };
-
-        template <class T>
-        constexpr size_t simd_traits_impl<T, true>::size;
 
         template <class T, class A>
         struct static_check_supported_config_emitter
@@ -129,17 +123,11 @@ namespace xsimd
     };
 
     template <class T>
-    constexpr size_t revert_simd_traits<T>::size;
-
-    template <class T>
     struct revert_simd_traits<batch<T>>
     {
         using type = T;
         static constexpr size_t size = batch<T>::size;
     };
-
-    template <class T>
-    constexpr size_t revert_simd_traits<batch<T>>::size;
 
     template <class T>
     using simd_type = typename simd_traits<T>::type;


### PR DESCRIPTION
Fixes, eg
```
xsimd/types/xsimd_batch.hpp:284:45: error: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated [-Werror,-Wdeprecated-redundant-constexpr-static-def]
  284 |     constexpr std::size_t batch_bool<T, A>::size;
      |                                             ^
```