### PR TITLE
Added first() function for SSE/AVX/AVX512F

### DIFF
--- a/include/xsimd/arch/common/xsimd_common_memory.hpp
+++ b/include/xsimd/arch/common/xsimd_common_memory.hpp
@@ -270,13 +270,13 @@ namespace xsimd
         template <class A, class T>
         XSIMD_INLINE T first(batch_bool<T, A> const& self, requires_arch<common>) noexcept
         {
-            return get(self, 0, common {});
+            return first(batch<T, A>(self), A {});
         }
 
         template <class A, class T>
         XSIMD_INLINE auto first(batch<std::complex<T>, A> const& self, requires_arch<common>) noexcept -> typename batch<std::complex<T>, A>::value_type
         {
-            return get(self, 0, common {});
+            return { first(self.real(), A {}), first(self.imag(), A {}) };
         }
 
         // load

--- a/include/xsimd/arch/common/xsimd_common_memory.hpp
+++ b/include/xsimd/arch/common/xsimd_common_memory.hpp
@@ -260,6 +260,25 @@ namespace xsimd
             return buffer[i];
         }
 
+        // first
+        template <class A, class T>
+        XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<common>) noexcept
+        {
+            return get(self, 0, common {});
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE T first(batch_bool<T, A> const& self, requires_arch<common>) noexcept
+        {
+            return get(self, 0, common {});
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE auto first(batch<std::complex<T>, A> const& self, requires_arch<common>) noexcept -> typename batch<std::complex<T>, A>::value_type
+        {
+            return get(self, 0, common {});
+        }
+
         // load
         template <class A, class T>
         XSIMD_INLINE batch_bool<T, A> load_unaligned(bool const* mem, batch_bool<T, A>, requires_arch<common>) noexcept

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1901,17 +1901,6 @@ namespace xsimd
             }
         }
 
-        template <class A, class T>
-        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<avx>) noexcept
-        {
-            return { first(self.real(), A {}), first(self.imag(), A {}) };
-        }
-
-        template <class A, class T>
-        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
-        {
-            return first(batch<T, A>(self), A {});
-        }
     }
 }
 

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -20,7 +20,6 @@
 
 namespace xsimd
 {
-
     namespace kernel
     {
         using namespace types;
@@ -1860,6 +1859,58 @@ namespace xsimd
             auto lo = _mm256_unpacklo_pd(self, other);
             auto hi = _mm256_unpackhi_pd(self, other);
             return _mm256_insertf128_pd(lo, _mm256_castpd256_pd128(hi), 1);
+        }
+
+        // first
+        template <class A>
+        XSIMD_INLINE float first(batch<float, A> const& self, requires_arch<avx>) noexcept
+        {
+            return _mm256_cvtss_f32(self);
+        }
+
+        template <class A>
+        XSIMD_INLINE double first(batch<double, A> const& self, requires_arch<avx>) noexcept
+        {
+            return _mm256_cvtsd_f64(self);
+        }
+
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<avx>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
+            {
+                return static_cast<T>(_mm256_cvtsi256_si32(self) & 0xFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return static_cast<T>(_mm256_cvtsi256_si32(self) & 0xFFFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                return static_cast<T>(_mm256_cvtsi256_si32(self));
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
+            {
+                __m128i low = _mm256_castsi256_si128(self);
+                return static_cast<T>(_mm_cvtsi128_si64(low));
+            }
+            else
+            {
+                assert(false && "unsupported arch/op combination");
+                return {};
+            }
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<avx>) noexcept
+        {
+            return { first(self.real(), A {}), first(self.imag(), A {}) };
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<avx>) noexcept
+        {
+            return first(batch<T, A>(self), A {});
         }
     }
 }

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1891,8 +1891,8 @@ namespace xsimd
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
             {
-                __m128i low = _mm256_castsi256_si128(self);
-                return static_cast<T>(_mm_cvtsi128_si64(low));
+                batch<T, sse4_2> low = _mm256_castsi256_si128(self);
+                return first(low, sse4_2 {});
             }
             else
             {
@@ -1900,7 +1900,6 @@ namespace xsimd
                 return {};
             }
         }
-
     }
 }
 

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -2369,7 +2369,8 @@ namespace xsimd
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
             {
-                return static_cast<T>(_mm_cvtsi128_si64(_mm512_castsi512_si128(self)));
+                batch<T, sse4_2> low = _mm512_castsi256_si128(self);
+                return first(low, sse4_2 {});
             }
             else
             {

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -2369,7 +2369,7 @@ namespace xsimd
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
             {
-                batch<T, sse4_2> low = _mm512_castsi256_si128(self);
+                batch<T, sse4_2> low = _mm512_castsi512_si128(self);
                 return first(low, sse4_2 {});
             }
             else

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -2378,18 +2378,6 @@ namespace xsimd
             }
         }
 
-        template <class A, class T>
-        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<avx512f>) noexcept
-        {
-            return { first(self.real(), A {}), first(self.imag(), A {}) };
-        }
-
-        template <class A, class T>
-        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
-        {
-            return first(batch<T, A>(self), A {});
-        }
-
     }
 
 }

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -2339,6 +2339,57 @@ namespace xsimd
                 2));
         }
 
+        // first
+        template <class A>
+        XSIMD_INLINE float first(batch<float, A> const& self, requires_arch<avx512f>) noexcept
+        {
+            return _mm512_cvtss_f32(self);
+        }
+
+        template <class A>
+        XSIMD_INLINE double first(batch<double, A> const& self, requires_arch<avx512f>) noexcept
+        {
+            return _mm512_cvtsd_f64(self);
+        }
+
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<avx512f>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
+            {
+                return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFFFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                return static_cast<T>(_mm512_cvtsi512_si32(self));
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
+            {
+                return static_cast<T>(_mm_cvtsi128_si64(_mm512_castsi512_si128(self)));
+            }
+            else
+            {
+                assert(false && "unsupported arch/op combination");
+                return {};
+            }
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<avx512f>) noexcept
+        {
+            return { first(self.real(), A {}), first(self.imag(), A {}) };
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<avx512f>) noexcept
+        {
+            return first(batch<T, A>(self), A {});
+        }
+
     }
 
 }

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -1782,6 +1782,57 @@ namespace xsimd
         {
             return _mm_unpacklo_pd(self, other);
         }
+
+        // first
+        template <class A>
+        XSIMD_INLINE float first(batch<float, A> const& self, requires_arch<sse2>) noexcept
+        {
+            return _mm_cvtss_f32(self);
+        }
+
+        template <class A>
+        XSIMD_INLINE double first(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        {
+            return _mm_cvtsd_f64(self);
+        }
+
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<sse2>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
+            {
+                return static_cast<T>(_mm_cvtsi128_si32(self) & 0xFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return static_cast<T>(_mm_cvtsi128_si32(self) & 0xFFFF);
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                return static_cast<T>(_mm_cvtsi128_si32(self));
+            }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
+            {
+                return static_cast<T>(_mm_cvtsi128_si64(self));
+            }
+            else
+            {
+                assert(false && "unsupported arch/op combination");
+                return {};
+            }
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<sse2>) noexcept
+        {
+            return { first(self.real(), A {}), first(self.imag(), A {}) };
+        }
+
+        template <class A, class T>
+        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
+        {
+            return first(batch<T, A>(self), A {});
+        }
     }
 }
 

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -1813,7 +1813,15 @@ namespace xsimd
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
             {
+#if defined(__x86_64__)
                 return static_cast<T>(_mm_cvtsi128_si64(self));
+#else
+                __m128i m;
+                _mm_storel_epi64(&m, self);
+                int64_t i;
+                std::memcpy(&i, &m, sizeof(i));
+                return i;
+#endif
             }
             else
             {

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -1822,17 +1822,6 @@ namespace xsimd
             }
         }
 
-        template <class A, class T>
-        XSIMD_INLINE std::complex<T> first(batch<std::complex<T>, A> const& self, requires_arch<sse2>) noexcept
-        {
-            return { first(self.real(), A {}), first(self.imag(), A {}) };
-        }
-
-        template <class A, class T>
-        XSIMD_INLINE bool first(batch_bool<T, A> const& self, requires_arch<sse2>) noexcept
-        {
-            return first(batch<T, A>(self), A {});
-        }
     }
 }
 

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -1100,7 +1100,6 @@ namespace xsimd
     {
     }
 
-
     template <class T, class A>
     template <class U, class... V, size_t I, size_t... Is>
     XSIMD_INLINE auto batch_bool<T, A>::make_register(detail::index_sequence<I, Is...>, U u, V... v) noexcept -> register_type

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -159,6 +159,8 @@ namespace xsimd
 
         XSIMD_INLINE T get(std::size_t i) const noexcept;
 
+        XSIMD_INLINE T first() const noexcept;
+
         // comparison operators. Defined as friend to enable automatic
         // conversion of parameters from scalar to batch, at the cost of using a
         // proxy implementation from details::.
@@ -314,6 +316,8 @@ namespace xsimd
 
         XSIMD_INLINE bool get(std::size_t i) const noexcept;
 
+        XSIMD_INLINE bool first() const noexcept;
+
         // mask operations
         XSIMD_INLINE uint64_t mask() const noexcept;
         XSIMD_INLINE static batch_bool from_mask(uint64_t mask) noexcept;
@@ -404,6 +408,8 @@ namespace xsimd
         XSIMD_INLINE real_batch imag() const noexcept;
 
         XSIMD_INLINE value_type get(std::size_t i) const noexcept;
+
+        XSIMD_INLINE value_type first() const noexcept;
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
         // xtl-related methods
@@ -691,6 +697,16 @@ namespace xsimd
     XSIMD_INLINE T batch<T, A>::get(std::size_t i) const noexcept
     {
         return kernel::get(*this, i, A {});
+    }
+
+    /**
+     * Retrieve the first scalar element in this batch.
+     */
+    template <class T, class A>
+    XSIMD_INLINE T batch<T, A>::first() const noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::first(*this, A {});
     }
 
     /******************************
@@ -1005,6 +1021,13 @@ namespace xsimd
         return kernel::get(*this, i, A {});
     }
 
+    template <class T, class A>
+    XSIMD_INLINE bool batch_bool<T, A>::first() const noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::first(*this, A {});
+    }
+
     /***********************************
      * batch_bool comparison operators *
      ***********************************/
@@ -1076,6 +1099,7 @@ namespace xsimd
         : base_type { make_register(detail::make_index_sequence<size - 1>(), val) }
     {
     }
+
 
     template <class T, class A>
     template <class U, class... V, size_t I, size_t... Is>
@@ -1246,6 +1270,13 @@ namespace xsimd
     XSIMD_INLINE auto batch<std::complex<T>, A>::get(std::size_t i) const noexcept -> value_type
     {
         return kernel::get(*this, i, A {});
+    }
+
+    template <class T, class A>
+    XSIMD_INLINE auto batch<std::complex<T>, A>::first() const noexcept -> value_type
+    {
+        detail::static_check_supported_config<std::complex<T>, A>();
+        return kernel::first(*this, A {});
     }
 
     /**************************************

--- a/test/test_batch.cpp
+++ b/test/test_batch.cpp
@@ -152,6 +152,12 @@ struct batch_test
         }
     }
 
+    void test_first_element() const
+    {
+        batch_type res = batch_lhs();
+        CHECK_EQ(res.first(), lhs[0]);
+    }
+
     void test_arithmetic() const
     {
         // +batch
@@ -932,6 +938,11 @@ TEST_CASE_TEMPLATE("[batch]", B, BATCH_TYPES)
     SUBCASE("access_operator")
     {
         Test.test_access_operator();
+    }
+
+    SUBCASE("first element")
+    {
+        Test.test_first_element();
     }
 
     SUBCASE("arithmetic")

--- a/test/test_batch_complex.cpp
+++ b/test/test_batch_complex.cpp
@@ -176,6 +176,12 @@ struct batch_complex_test
         }
     }
 
+    void test_first_element() const
+    {
+        batch_type res = batch_lhs();
+        CHECK_EQ(res.first(), lhs[0]);
+    }
+
     void test_arithmetic() const
     {
         // +batch
@@ -674,6 +680,8 @@ TEST_CASE_TEMPLATE("[xsimd complex batches]", B, BATCH_COMPLEX_TYPES)
     }
 
     SUBCASE("access_operator") { Test.test_access_operator(); }
+
+    SUBCASE("first element") { Test.test_first_element(); }
 
     SUBCASE("arithmetic") { Test.test_arithmetic(); }
 


### PR DESCRIPTION
This pr implements new first() function for batch types. It is an improvement from the currently used self.get(0) as first() uses intrinsics to extract the first element. Addresses inefficiencies mentioned in [issue #1133](https://github.com/xtensor-stack/xsimd/issues/1133).
I have only implemented for SSE/AVX/AVX512F architectures @serge-sans-paille will implement for other architectures.
I also haven't replace any .get(0) functions with first(). That needs to be done as well