### PR TITLE
Fix build with Clang for Windows

### DIFF
--- a/include/xsimd/config/xsimd_inline.hpp
+++ b/include/xsimd/config/xsimd_inline.hpp
@@ -12,8 +12,10 @@
 #ifndef XSIMD_INLINE_HPP
 #define XSIMD_INLINE_HPP
 
-#if defined(__GNUC__)
+#if defined __has_attribute
+#if __has_attribute(always_inline)
 #define XSIMD_INLINE inline __attribute__((always_inline))
+#endif
 #elif defined(_MSC_VER)
 #define XSIMD_INLINE inline __forceinline
 #else


### PR DESCRIPTION
I am trying to compile and use xsimd with Clang on Windows.

I just discovered that Clang for Windows doesn't define `__GNUC__` but instead defines `_MSC_VER`. That makes the compiler choose a version of `XSIMD_INLINE` that it does not support.

 The only solution I found that do supports both platforms is by extending `#if defined(__GNUC__)` with `(defined(_MSC_VER) && defined(__clang__)`.