### PR TITLE
avx512f: implement slide_left and slide_right.

### DIFF
--- a/test/test_shuffle.cpp
+++ b/test/test_shuffle.cpp
@@ -166,7 +166,6 @@ namespace
     };
 }
 
-#if !XSIMD_WITH_AVX512F || XSIMD_WITH_AVX512BW
 template <class B>
 struct slide_test : public init_slide_base<typename B::value_type, B::size>
 {
@@ -269,8 +268,6 @@ TEST_CASE_TEMPLATE("[slide]", B, BATCH_INT_TYPES)
         Test.slide_right();
     }
 }
-
-#endif
 
 template <class B>
 struct compress_test


### PR DESCRIPTION
With a fast path for N = 4*i and a split version else (inspired from avx512bw).

As the vpermd actually has the lower latency on some intel cpus compared to vpermw / vpermb, also use it instead of the avx512bw and avx512vbmi implementations if trivially possible.

Also reverse the order of the slow path for lower latency. It used to be:
```
SLR -> PERM ->
               OR -> PERM
SLL         ->
```

Now the latency is reduced to:
```
SLR -> PERM ->
               OR
SLL -> PERM ->
```

And it should now generate even better code on avx512bw with N=63 with only one PERM (as already done for N=1).

For N=16,32,48, it prefers vshufi32x4 over vpermd for lower latency on Zen4 and decreased register usage.