### PR TITLE
DOC: Move 'count' to the batch-bool 'Reducers' section of the docs.

### DIFF
--- a/docs/source/api/reducer_index.rst
+++ b/docs/source/api/reducer_index.rst
@@ -41,6 +41,8 @@ Reduction operators
 | :cpp:func:`haddp`                     | horizontal sum across batches                      |
 +---------------------------------------+----------------------------------------------------+
 
+Also see the `batch_bool` :ref:`xsimd-batch-bool-reducers`.
+
 ----
 
 .. doxygengroup:: batch_reducers

--- a/docs/source/api/xsimd_batch_bool.rst
+++ b/docs/source/api/xsimd_batch_bool.rst
@@ -20,6 +20,8 @@ Logical operators
    :project: xsimd
    :content-only:
 
+.. _xsimd-batch-bool-reducers:
+
 Reducers
 --------
 

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -635,7 +635,7 @@ namespace xsimd
     }
 
     /**
-     * @ingroup batch_reducers
+     * @ingroup batch_bool_reducers
      *
      * Count the number of values set to true in the batch \c x
      * @param x boolean or batch of boolean


### PR DESCRIPTION
<strike>`count` is in the doxygen group `batch_reducers`, and it shows up below the table of reduction operators along with `reduce`, `reduce_add`, etc., in the generated HTML, so it might as well be in the table.</strike>

Updated the PR so now `count` is moved to the 'Reducers' section of the batch-bool docs.