### PR TITLE
MSVC/arm64ec: Deassert XSIMD_WITH_SSE2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(xsimd)
 option(XSIMD_REFACTORING ON)
 

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -470,7 +470,7 @@
 
 #endif
 
-#if XSIMD_WITH_SSE3 || defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#if XSIMD_WITH_SSE3 || ((defined(_M_AMD64) || defined(_M_X64)) && !defined(_M_ARM64EC)) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
 #undef XSIMD_WITH_SSE2
 #define XSIMD_WITH_SSE2 1
 #endif


### PR DESCRIPTION
The ARM64EC ABI is designed to provide native ARM64 code into emulated x64 applications.
Long blog article about ARM64EC: http://www.emulators.com/docs/abc_arm64ec_explained.htm

For this goal, it *on purpose* needs to define both `_M_AMD64` and `_M_X64`, however it
does not define `__SSE2__`. SSE *should* be supported, but it fails to compile our
constant setting methods:
```
xsimd_sse2.hpp(1479): warning C4003: not enough arguments for function-like macro invocation '_mm_setr_ps'
xsimd_sse2.hpp(1479): error C2760: syntax error: '...' was unexpected here; expected ')'
```

I think this is likely a bug within their intrinsics, however not enabling SSE might still
be better on an emulated platform anyways.
NEON is still not enabled - but it doesn't compile neither. So in my opinion, the good behavior is to only enable stuff which at least compiles...
