### PR TITLE
Generate a swizzle-friendly mask during generic reduction

### DIFF
--- a/include/xsimd/arch/common/xsimd_common_math.hpp
+++ b/include/xsimd/arch/common/xsimd_common_math.hpp
@@ -2110,7 +2110,7 @@ namespace xsimd
             {
                 static constexpr T get(T i, T)
                 {
-                    return i >= N ? (i % 2) : i + N;
+                    return i < N ? (i + N) : ((i % N) + N);
                 }
             };
 


### PR DESCRIPTION
It changes nothing for clang which has a nice shuffle optimizer, but it does help gcc a lot.

Somehow related to #1132