### PR TITLE
NEW API: Fixed shift, Rotation

### DIFF
--- a/docs/source/api/bitwise_operators_index.rst
+++ b/docs/source/api/bitwise_operators_index.rst
@@ -40,9 +40,9 @@ Bitwise operators
 +---------------------------------------+----------------------------------------------------+
 | :cpp:func:`bitwise_andnot`            | per slot bitwise and not                           |
 +---------------------------------------+----------------------------------------------------+
-| :cpp:func:`bitwise_lshift`            | per slot bitwise and                               |
+| :cpp:func:`bitwise_lshift`            | per slot bitwise left shift                        |
 +---------------------------------------+----------------------------------------------------+
-| :cpp:func:`bitwise_rshift`            | per slot bitwise and not                           |
+| :cpp:func:`bitwise_rshift`            | per slot bitwise right shift                       |
 +---------------------------------------+----------------------------------------------------+
 | :cpp:func:`rotr`                      | per slot rotate right                              |
 +---------------------------------------+----------------------------------------------------+

--- a/include/xsimd/arch/xsimd_avx512vbmi2.hpp
+++ b/include/xsimd/arch/xsimd_avx512vbmi2.hpp
@@ -67,6 +67,64 @@ namespace xsimd
         {
             return _mm512_maskz_expand_epi8(mask.mask(), self);
         }
+
+        // rotl
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> rotl(batch<T, A> const& self, int32_t other, requires_arch<avx512vbmi2>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return _mm512_shldv_epi16(self, self, _mm512_set1_epi16(static_cast<uint16_t>(other)));
+            }
+            else
+            {
+                return rotl(self, other, avx512bw {});
+            }
+        }
+
+        template <size_t count, class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> rotl(batch<T, A> const& self, requires_arch<avx512vbmi2>) noexcept
+        {
+            constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+            static_assert(count < bits, "Count must be less than the number of bits in T");
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return _mm512_shldi_epi16(self, self, count);
+            }
+            else
+            {
+                return rotl<count>(self, avx512bw {});
+            }
+        }
+
+        // rotr
+        template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> rotr(batch<T, A> const& self, int32_t other, requires_arch<avx512vbmi2>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return _mm512_shrdv_epi16(self, self, _mm512_set1_epi16(static_cast<uint16_t>(other)));
+            }
+            else
+            {
+                return rotr(self, other, avx512bw {});
+            }
+        }
+
+        template <size_t count, class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> rotr(batch<T, A> const& self, requires_arch<avx512vbmi2>) noexcept
+        {
+            constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+            static_assert(count < bits, "count must be less than the number of bits in T");
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
+            {
+                return _mm512_shrdi_epi16(self, self, count);
+            }
+            else
+            {
+                return rotr<count>(self, avx512bw {});
+            }
+        }
     }
 }
 

--- a/include/xsimd/arch/xsimd_common_fwd.hpp
+++ b/include/xsimd/arch/xsimd_common_fwd.hpp
@@ -26,8 +26,12 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> abs(batch<T, A> const& self, requires_arch<common>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
+        template <size_t shift, class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& self, requires_arch<common>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
+        template <size_t shift, class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
+        XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, requires_arch<common>) noexcept;
         template <class A, class T>
         XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_integral<T>::value, void>::type>
@@ -40,6 +44,14 @@ namespace xsimd
         XSIMD_INLINE T reduce_add(batch<T, A> const& self, requires_arch<common>) noexcept;
         template <class A, class T, class = typename std::enable_if<std::is_scalar<T>::value, void>::type>
         XSIMD_INLINE T reduce_mul(batch<T, A> const& self, requires_arch<common>) noexcept;
+        template <class A, class T, class STy>
+        XSIMD_INLINE batch<T, A> rotl(batch<T, A> const& self, STy other, requires_arch<common>) noexcept;
+        template <size_t count, class A, class T>
+        XSIMD_INLINE batch<T, A> rotl(batch<T, A> const& self, requires_arch<common>) noexcept;
+        template <class A, class T, class STy>
+        XSIMD_INLINE batch<T, A> rotr(batch<T, A> const& self, STy other, requires_arch<common>) noexcept;
+        template <size_t count, class A, class T>
+        XSIMD_INLINE batch<T, A> rotr(batch<T, A> const& self, requires_arch<common>) noexcept;
         // Forward declarations for pack-level helpers
         namespace detail
         {

--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -300,10 +300,27 @@ namespace xsimd
         return x << shift;
     }
 
+    template <size_t shift, class T>
+    XSIMD_INLINE typename std::enable_if<std::is_integral<T>::value, T>::type
+    bitwise_lshift(T x) noexcept
+    {
+        constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+        static_assert(shift < bits, "Count must be less than the number of bits in T");
+        return x << shift;
+    }
+
     template <class T0, class T1>
     XSIMD_INLINE typename std::enable_if<std::is_integral<T0>::value && std::is_integral<T1>::value, T0>::type
     bitwise_rshift(T0 x, T1 shift) noexcept
     {
+        return x >> shift;
+    }
+    template <size_t shift, class T>
+    XSIMD_INLINE typename std::enable_if<std::is_integral<T>::value, T>::type
+    bitwise_rshift(T x) noexcept
+    {
+        constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+        static_assert(shift < bits, "Count must be less than the number of bits in T");
         return x >> shift;
     }
 
@@ -447,16 +464,32 @@ namespace xsimd
     XSIMD_INLINE typename std::enable_if<std::is_integral<T0>::value && std::is_integral<T1>::value, T0>::type
     rotl(T0 x, T1 shift) noexcept
     {
-        constexpr auto N = std::numeric_limits<T0>::digits;
-        return (x << shift) | (x >> (N - shift));
+        constexpr auto bits = std::numeric_limits<T0>::digits + std::numeric_limits<T0>::is_signed;
+        return (x << shift) | (x >> (bits - shift));
+    }
+    template <size_t count, class T>
+    XSIMD_INLINE typename std::enable_if<std::is_integral<T>::value, T>::type
+    rotl(T x) noexcept
+    {
+        constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+        static_assert(count < bits, "Count must be less than the number of bits in T");
+        return (x << count) | (x >> (bits - count));
     }
 
     template <class T0, class T1>
     XSIMD_INLINE typename std::enable_if<std::is_integral<T0>::value && std::is_integral<T1>::value, T0>::type
     rotr(T0 x, T1 shift) noexcept
     {
-        constexpr auto N = std::numeric_limits<T0>::digits;
-        return (x >> shift) | (x << (N - shift));
+        constexpr auto bits = std::numeric_limits<T0>::digits + std::numeric_limits<T0>::is_signed;
+        return (x >> shift) | (x << (bits - shift));
+    }
+    template <size_t count, class T>
+    XSIMD_INLINE typename std::enable_if<std::is_integral<T>::value, T>::type
+    rotr(T x) noexcept
+    {
+        constexpr auto bits = std::numeric_limits<T>::digits + std::numeric_limits<T>::is_signed;
+        static_assert(count < bits, "Count must be less than the number of bits in T");
+        return (x >> count) | (x << (bits - count));
     }
 
     template <class T>

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -373,6 +373,12 @@ namespace xsimd
         detail::static_check_supported_config<T, A>();
         return kernel::bitwise_lshift<A>(x, shift, A {});
     }
+    template <size_t shift, class T, class A>
+    XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& x) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::bitwise_lshift<shift, A>(x, A {});
+    }
 
     /**
      * @ingroup batch_bitwise
@@ -451,6 +457,12 @@ namespace xsimd
     {
         detail::static_check_supported_config<T, A>();
         return kernel::bitwise_rshift<A>(x, shift, A {});
+    }
+    template <size_t shift, class T, class A>
+    XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& x) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::bitwise_rshift<shift, A>(x, A {});
     }
 
     /**
@@ -1980,6 +1992,12 @@ namespace xsimd
         detail::static_check_supported_config<T, A>();
         return kernel::rotl<A>(x, shift, A {});
     }
+    template <size_t count, class T, class A>
+    XSIMD_INLINE batch<T, A> rotl(batch<T, A> const& x) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::rotl<count, A>(x, A {});
+    }
 
     /**
      * @ingroup batch_bitwise
@@ -2001,6 +2019,12 @@ namespace xsimd
     {
         detail::static_check_supported_config<T, A>();
         return kernel::rotr<A>(x, shift, A {});
+    }
+    template <size_t count, class T, class A>
+    XSIMD_INLINE batch<T, A> rotr(batch<T, A> const& x) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::rotr<count, A>(x, A {});
     }
 
     /**

--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -353,18 +353,28 @@ struct xsimd_api_integral_types_functions
 
     void test_bitwise_lshift()
     {
+        constexpr int shift = 3;
         value_type val0(12);
-        value_type val1(3);
+        value_type val1(shift);
         value_type r = val0 << val1;
+        value_type ir = val0 << shift;
+        value_type cr = xsimd::bitwise_lshift<shift>(val0);
         CHECK_EQ(extract(xsimd::bitwise_lshift(T(val0), T(val1))), r);
+        CHECK_EQ(extract(ir), r);
+        CHECK_EQ(extract(cr), r);
     }
 
     void test_bitwise_rshift()
     {
+        constexpr int shift = 3;
         value_type val0(12);
-        value_type val1(3);
+        value_type val1(shift);
         value_type r = val0 >> val1;
+        value_type ir = val0 >> shift;
+        value_type cr = xsimd::bitwise_rshift<shift>(val0);
         CHECK_EQ(extract(xsimd::bitwise_rshift(T(val0), T(val1))), r);
+        CHECK_EQ(extract(ir), r);
+        CHECK_EQ(extract(cr), r);
     }
 
     void test_mod()
@@ -376,20 +386,26 @@ struct xsimd_api_integral_types_functions
 
     void test_rotl()
     {
-        constexpr auto N = std::numeric_limits<value_type>::digits;
+        constexpr auto N = std::numeric_limits<value_type>::digits + std::numeric_limits<value_type>::is_signed;
+        constexpr int count = 3;
         value_type val0(12);
-        value_type val1(3);
+        value_type val1(count);
         value_type r = (val0 << val1) | (val0 >> (N - val1));
+        value_type cr = xsimd::rotl<count>(val0);
         CHECK_EQ(extract(xsimd::rotl(T(val0), T(val1))), r);
+        CHECK_EQ(extract(cr), r);
     }
 
     void test_rotr()
     {
-        constexpr auto N = std::numeric_limits<value_type>::digits;
+        constexpr auto N = std::numeric_limits<value_type>::digits + std::numeric_limits<value_type>::is_signed;
+        constexpr int count = 3;
         value_type val0(12);
-        value_type val1(3);
+        value_type val1(count);
         value_type r = (val0 >> val1) | (val0 << (N - val1));
+        value_type cr = xsimd::rotr<3>(val0);
         CHECK_EQ(extract(xsimd::rotr(T(val0), T(val1))), r);
+        CHECK_EQ(extract(cr), r);
     }
 
     void test_sadd()


### PR DESCRIPTION
1. adds the API bitwise_[l|r]shift<N>(...) and rot[l|r]<N>(...)
2. updates the test to use the API
3. fixes documentation

I implemente xoshiro (vecotrized) the current API looks like this:
```cpp
    const auto result = xsimd::rotl(m_state[0] + m_state[3], 23) + m_state[0];
    const auto t = m_state[1] << 17;

    m_state[2] ^= m_state[0];
    m_state[3] ^= m_state[1];
    m_state[2] ^= t;

    m_state[3] = xsimd::rotl(m_state[3], 45);

    return result;
```
and with AVX2 achieves `393.06 M samples/s`
The new API is:
```cpp
    const auto result = xsimd::rotl<23>(m_state[0] + m_state[3]) + m_state[0];
    const auto t = xsimd::bitwise_lshift<17>(m_state[1]);

    m_state[2] ^= m_state[0];
    m_state[3] ^= m_state[1];
    m_state[1] ^= m_state[2];
    m_state[0] ^= m_state[3];

    m_state[2] ^= t;

    m_state[3] = xsimd::rotl<45>(m_state[3]);

    return result;
```
and with AVX2 achieves `423.76 M samples/s`

With this change causing a 7% speed increase, xoshiro is the fastest RNG among the ones I tested. Othwewise, PCG64 beats it.