### PR TITLE
Remove out-of-line definition of constexpr static data members in C++…

### DIFF
--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -273,8 +273,10 @@ namespace xsimd
         XSIMD_INLINE batch logical_or(batch const& other) const noexcept;
     };
 
+#if __cplusplus < 201703L
     template <class T, class A>
     constexpr std::size_t batch<T, A>::size;
+#endif
 
     /**
      * @brief batch of predicate over scalar or complex values.
@@ -348,8 +350,10 @@ namespace xsimd
         static XSIMD_INLINE register_type make_register(detail::index_sequence<>, V... v) noexcept;
     };
 
+#if __cplusplus < 201703L
     template <class T, class A>
     constexpr std::size_t batch_bool<T, A>::size;
+#endif
 
     /**
      * @brief batch of complex values.
@@ -482,8 +486,10 @@ namespace xsimd
         real_batch m_imag;
     };
 
+#if __cplusplus < 201703L
     template <class T, class A>
     constexpr std::size_t batch<std::complex<T>, A>::size;
+#endif
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
     template <typename T, bool i3ec, typename A>

--- a/include/xsimd/types/xsimd_traits.hpp
+++ b/include/xsimd/types/xsimd_traits.hpp
@@ -53,8 +53,10 @@ namespace xsimd
             static constexpr size_t size = 1;
         };
 
+#if __cplusplus < 201703L
         template <class T>
         constexpr size_t simd_traits_impl<T, false>::size;
+#endif
 
         template <class T>
         struct simd_traits_impl<T, true>
@@ -64,8 +66,10 @@ namespace xsimd
             static constexpr size_t size = type::size;
         };
 
+#if __cplusplus < 201703L
         template <class T>
         constexpr size_t simd_traits_impl<T, true>::size;
+#endif
 
         template <class T, class A>
         struct static_check_supported_config_emitter
@@ -128,8 +132,10 @@ namespace xsimd
         static constexpr size_t size = simd_traits<type>::size;
     };
 
+#if __cplusplus < 201703L
     template <class T>
     constexpr size_t revert_simd_traits<T>::size;
+#endif
 
     template <class T>
     struct revert_simd_traits<batch<T>>
@@ -138,8 +144,10 @@ namespace xsimd
         static constexpr size_t size = batch<T>::size;
     };
 
+#if __cplusplus < 201703L
     template <class T>
     constexpr size_t revert_simd_traits<batch<T>>::size;
+#endif
 
     template <class T>
     using simd_type = typename simd_traits<T>::type;


### PR DESCRIPTION
…17 and above

As we do support C++11 and C++14, keep the definition for those languages.