### PR TITLE
Simplify load implementation from #1172

### DIFF
--- a/include/xsimd/arch/xsimd_avx512vbmi2.hpp
+++ b/include/xsimd/arch/xsimd_avx512vbmi2.hpp
@@ -28,12 +28,12 @@ namespace xsimd
         template <class A>
         XSIMD_INLINE batch<int16_t, A> compress(batch<int16_t, A> const& self, batch_bool<int16_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept
         {
-            return _mm512_maskz_compress_epi16(mask.mask(), self);
+            return _mm512_maskz_compress_epi16((__mmask32)mask.mask(), self);
         }
         template <class A>
         XSIMD_INLINE batch<uint16_t, A> compress(batch<uint16_t, A> const& self, batch_bool<uint16_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept
         {
-            return _mm512_maskz_compress_epi16(mask.mask(), self);
+            return _mm512_maskz_compress_epi16((__mmask32)mask.mask(), self);
         }
         template <class A>
         XSIMD_INLINE batch<int8_t, A> compress(batch<int8_t, A> const& self, batch_bool<int8_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept
@@ -50,12 +50,12 @@ namespace xsimd
         template <class A>
         XSIMD_INLINE batch<int16_t, A> expand(batch<int16_t, A> const& self, batch_bool<int16_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept
         {
-            return _mm512_maskz_expand_epi16(mask.mask(), self);
+            return _mm512_maskz_expand_epi16((__mmask32)mask.mask(), self);
         }
         template <class A>
         XSIMD_INLINE batch<uint16_t, A> expand(batch<uint16_t, A> const& self, batch_bool<uint16_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept
         {
-            return _mm512_maskz_expand_epi16(mask.mask(), self);
+            return _mm512_maskz_expand_epi16((__mmask32)mask.mask(), self);
         }
         template <class A>
         XSIMD_INLINE batch<int8_t, A> expand(batch<int8_t, A> const& self, batch_bool<int8_t, A> const& mask, requires_arch<avx512vbmi2>) noexcept

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -1043,6 +1043,26 @@ namespace xsimd
             return _mm_loadu_pd(mem);
         }
 
+        // load batch_bool
+
+        template <class A>
+        XSIMD_INLINE batch_bool<char, A> load_unaligned(bool const* mem, batch_bool<char, A>, requires_arch<sse2>) noexcept
+        {
+            return _mm_sub_epi8(_mm_set1_epi8(0), _mm_loadu_si128((__m128i const*)mem));
+        }
+
+        template <class A>
+        XSIMD_INLINE batch_bool<unsigned char, A> load_unaligned(bool const* mem, batch_bool<unsigned char, A>, requires_arch<sse2> r) noexcept
+        {
+            return { load_unaligned(mem, batch_bool<char, A> {}, r).data };
+        }
+
+        template <class A>
+        XSIMD_INLINE batch_bool<signed char, A> load_unaligned(bool const* mem, batch_bool<signed char, A>, requires_arch<sse2> r) noexcept
+        {
+            return { load_unaligned(mem, batch_bool<char, A> {}, r).data };
+        }
+
         // load_complex
         namespace detail
         {


### PR DESCRIPTION
- Split some implementation that lived in sse4_1 while sse2 was a good home
- Avoid auxiliary function