### PR TITLE
Fixes XSIMD_INLINE for compilers that don't have always_inline

### DIFF
--- a/include/xsimd/config/xsimd_inline.hpp
+++ b/include/xsimd/config/xsimd_inline.hpp
@@ -17,6 +17,8 @@
 #elif defined __has_attribute
 #if __has_attribute(always_inline)
 #define XSIMD_INLINE inline __attribute__((always_inline))
+#else
+#define XSIMD_INLINE inline
 #endif
 #elif defined(_MSC_VER)
 #define XSIMD_INLINE inline __forceinline


### PR DESCRIPTION
Small fix for compilers (and linters) that do not have the attribute always_inline. This avoids a cascade of false positives.

Clion nova seems to have a problem with this so many users might be affected: https://youtrack.jetbrains.com/issue/CPP-47004/hasattributealwaysinline-is-not-handled-properly