### PR TITLE
Fix static_assert on i8mm<neon64>

### DIFF
--- a/test/test_arch.cpp
+++ b/test/test_arch.cpp
@@ -26,7 +26,7 @@ static_assert(xsimd::all_architectures::contains<xsimd::default_arch>(), "defaul
 #endif
 
 #if !XSIMD_WITH_SVE
-static_assert((std::is_same<xsimd::default_arch, xsimd::neon64>::value || !xsimd::neon64::supported()), "on arm, without sve, the best we can do is neon64");
+static_assert((std::is_base_of<xsimd::neon64, xsimd::default_arch>::value || !xsimd::neon64::supported()), "on arm, without sve, the best we can do is neon64");
 #endif
 
 struct check_supported


### PR DESCRIPTION
This failed locally on ``i8mm<neon64>``.
Not sure this is the best way to express it.
