### PR TITLE
AVX runtime float/double swizzle small improvement

### DIFF
--- a/test/test_batch_manip.cpp
+++ b/test/test_batch_manip.cpp
@@ -247,6 +247,7 @@ struct swizzle_test
         using idx_t = typename xsimd::as_index<value_type>::type;
         auto idx_batch = xsimd::make_batch_constant<idx_t, Pattern<idx_t>, arch_type>();
 
+        CAPTURE(idx_batch.as_batch());
         CHECK_BATCH_EQ(xsimd::swizzle(b_lhs, idx_batch), b_expect);
         CHECK_BATCH_EQ(xsimd::swizzle(b_lhs,
                                       static_cast<xsimd::batch<idx_t, arch_type>>(idx_batch)),


### PR DESCRIPTION
I have a number of of swizzle improvements to suggest, but I am starting small to get better accustomed to xsimd.

What do you make of the following change? My motivation was that `_mm256_permute2f128_ps` is the most expensive operation (though not sure if that's a problem in a CPU pipeline) so this PR suggest using it only once.

It also replaces modulo with a select mask to make sure this is properly optimized. 
