### PR TITLE
[ci] Update macosx worker list

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - 13
           - 14
+          - 15
+          - 15-intel
     runs-on: macos-${{ matrix.os }}
     name: 'macos-${{ matrix.os }}'
     steps:

--- a/test/test_xsimd_api.cpp
+++ b/test/test_xsimd_api.cpp
@@ -484,7 +484,11 @@ struct xsimd_api_float_types_functions
     void test_asin()
     {
         value_type val(1);
+#if defined(__APPLE__)
+        CHECK_EQ(extract(xsimd::asin(T(val))), doctest::Approx(std::asin(val)));
+#else
         CHECK_EQ(extract(xsimd::asin(T(val))), std::asin(val));
+#endif
     }
     void test_asinh()
     {


### PR DESCRIPTION
Supported github workers are now 14, 15 and 15-intel. 13 is deprecated.