### PR TITLE
Add Avx2 constant mask swizzle 8/16 and improve 32/64

### DIFF
--- a/include/xsimd/arch/xsimd_common_fwd.hpp
+++ b/include/xsimd/arch/xsimd_common_fwd.hpp
@@ -60,15 +60,15 @@ namespace xsimd
             template <typename T, class A, T... Vs>
             XSIMD_INLINE constexpr bool is_identity(batch_constant<T, A, Vs...>) noexcept;
             template <typename T, class A, T... Vs>
-            XSIMD_INLINE constexpr bool is_all_different(batch_constant<T, A, Vs...>) noexcept;
-            template <typename T, class A, T... Vs>
             XSIMD_INLINE constexpr bool is_dup_lo(batch_constant<T, A, Vs...>) noexcept;
             template <typename T, class A, T... Vs>
             XSIMD_INLINE constexpr bool is_dup_hi(batch_constant<T, A, Vs...>) noexcept;
             template <typename T, class A, T... Vs>
             XSIMD_INLINE constexpr bool is_cross_lane(batch_constant<T, A, Vs...>) noexcept;
             template <typename T, class A, T... Vs>
-            XSIMD_INLINE constexpr bool no_duplicates(batch_constant<T, A, Vs...>) noexcept;
+            XSIMD_INLINE constexpr bool is_only_from_lo(batch_constant<T, A, Vs...>) noexcept;
+            template <typename T, class A, T... Vs>
+            XSIMD_INLINE constexpr bool is_only_from_hi(batch_constant<T, A, Vs...>) noexcept;
 
         }
     }

--- a/test/test_batch_manip.cpp
+++ b/test/test_batch_manip.cpp
@@ -26,8 +26,7 @@ namespace xsimd
             //  compile-time tests (identity, all-different, dup-lo, dup-hi)
             //  8-lane identity
             static_assert(is_identity<std::uint32_t, 0, 1, 2, 3, 4, 5, 6, 7>(), "identity failed");
-            // 8-lane reverse is all-different but not identity
-            static_assert(is_all_different<std::uint32_t, 7, 6, 5, 4, 3, 2, 1, 0>(), "all-diff failed");
+            // 8-lane reverse is not identity
             static_assert(!is_identity<std::uint32_t, 7, 6, 5, 4, 3, 2, 1, 0>(), "identity on reverse");
             // 8-lane dup-lo (repeat 0..3 twice)
             static_assert(is_dup_lo<std::uint32_t, 0, 1, 2, 3, 0, 1, 2, 3>(), "dup_lo failed");
@@ -35,11 +34,16 @@ namespace xsimd
             // 8-lane dup-hi (repeat 4..7 twice)
             static_assert(is_dup_hi<std::uint32_t, 4, 5, 6, 7, 4, 5, 6, 7>(), "dup_hi failed");
             static_assert(!is_dup_lo<std::uint32_t, 4, 5, 6, 7, 4, 5, 6, 7>(), "dup_lo on dup_hi");
+            // 8-lane is-only-from-hi (repeat 4..7 twice)
+            static_assert(is_only_from_hi<std::uint32_t, 4, 5, 6, 7, 7, 7, 7, 7>(), "only_from_hi on hi");
+            static_assert(!is_only_from_hi<std::uint32_t, 4, 5, 6, 7, 7, 1, 7, 7>(), "only_from_hi failed");
+            // 8-lane is-only-from-lo (repeat 4..7 twice)
+            static_assert(is_only_from_lo<std::uint32_t, 0, 1, 2, 3, 3, 2, 1, 0>(), "only_from_lo on lo");
+            static_assert(!is_only_from_lo<std::uint32_t, 0, 1, 2, 7, 3, 2, 1, 0>(), "only_from_lo failed");
             // ────────────────────────────────────────────────────────────────────────
             //  4-lane identity
             static_assert(is_identity<std::uint32_t, 0, 1, 2, 3>(), "4-lane identity failed");
-            // 4-lane reverse all-different but not identity
-            static_assert(is_all_different<std::uint32_t, 3, 2, 1, 0>(), "4-lane all-diff failed");
+            // 4-lane reverse is not identity
             static_assert(!is_identity<std::uint32_t, 3, 2, 1, 0>(), "4-lane identity on reverse");
             // 4-lane dup-lo (repeat 0..1 twice)
             static_assert(is_dup_lo<std::uint32_t, 0, 1, 0, 1>(), "4-lane dup_lo failed");
@@ -53,12 +57,6 @@ namespace xsimd
             static_assert(is_cross_lane<0, 3, 3, 3>(), "one low + rest high → crossing");
             static_assert(!is_cross_lane<1, 0, 2, 3>(), "mixed low/high → no crossing");
             static_assert(!is_cross_lane<0, 1, 2, 3>(), "mixed low/high → no crossing");
-
-            static_assert(no_duplicates_v<0, 1, 2, 3>(), "N=4: [0,1,2,3] → distinct");
-            static_assert(!no_duplicates_v<0, 1, 2, 2>(), "N=4: [0,1,2,2] → dup");
-
-            static_assert(no_duplicates_v<0, 1, 2, 3, 4, 5, 6, 7>(), "N=8: [0..7] → distinct");
-            static_assert(!no_duplicates_v<0, 1, 2, 3, 4, 5, 6, 0>(), "N=8: last repeats 0");
         }
     }
 }


### PR DESCRIPTION
- Add AVX2 implementation of constant mask swizzle for `uint8_t` `uint16_t`
- Remove `all_different` limitation to `uint32_t` version, add `is_identity` case
- No significative changes for `uint64_t`. Making it closer the `uint32_t` implementation.
- Remove unused utility functions (`is_all_different`, `is_no_duplicates`).

Similar to the dynamic version, all functions are implemented for a sized `uint`, and other types forward to the proper size.