### PR TITLE
fix-gcc-10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,7 @@ jobs:
           - { compiler: 'gcc',   version: '13',  flags: 'enable_xtl_complex' }
           - { compiler: 'gcc',   version: '14',  flags: 'avx' }
           - { compiler: 'gcc',   version: '13', flags: 'avx512' }
+          - { compiler: 'gcc',   version: '10', flags: 'avx512' }
           - { compiler: 'gcc',   version: '12', flags: 'i386' }
           - { compiler: 'gcc',   version: '13', flags: 'avx512pf' }
           - { compiler: 'gcc',   version: '13', flags: 'avx512vbmi' }

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -2737,15 +2737,15 @@ namespace xsimd
         {
             XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
             {
-                return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFF);
+                return static_cast<T>(_mm_cvtsi128_si32(_mm512_castsi512_si128(self)) & 0xFF);
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 2)
             {
-                return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFFFF);
+                return static_cast<T>(_mm_cvtsi128_si32(_mm512_castsi512_si128(self)) & 0xFFFF);
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
             {
-                return static_cast<T>(_mm512_cvtsi512_si32(self));
+                return static_cast<T>(_mm_cvtsi128_si32(_mm512_castsi512_si128(self)));
             }
             else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
             {

--- a/test/test_shuffle.cpp
+++ b/test/test_shuffle.cpp
@@ -672,10 +672,15 @@ struct shuffle_test
             }
         };
 
+#if defined(__GNUC__) && (__GNUC__ == 10) && !defined(__clang__) && XSIMD_WITH_AVX512F
+        // Use zip_lo as a stable reference for the expected interleave.
+        B b_ref_lo = xsimd::zip_lo(b_lhs, b_rhs);
+#else
         std::array<value_type, size> ref_lo;
         for (size_t i = 0; i < size; ++i)
             ref_lo[i] = (i & 1) ? rhs[i / 2] : lhs[i / 2];
         B b_ref_lo = B::load_unaligned(ref_lo.data());
+#endif
 
         INFO("zip_lo");
         B b_res_lo = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, zip_lo_generator, arch_type>());
@@ -689,12 +694,17 @@ struct shuffle_test
             }
         };
 
+#if defined(__GNUC__) && (__GNUC__ == 10) && !defined(__clang__) && XSIMD_WITH_AVX512F
+        // Use zip_hi as a stable reference for the expected interleave.
+        B b_ref_hi = xsimd::zip_hi(b_lhs, b_rhs);
+#else
         std::array<value_type, size> ref_hi;
         for (size_t i = 0; i < size; ++i)
         {
             ref_hi[i] = (i & 1) ? rhs[size / 2 + i / 2] : lhs[size / 2 + i / 2];
         }
         B b_ref_hi = B::load_unaligned(ref_hi.data());
+#endif
 
         INFO("zip_hi");
         B b_res_hi = xsimd::shuffle(b_lhs, b_rhs, xsimd::make_batch_constant<mask_type, zip_hi_generator, arch_type>());


### PR DESCRIPTION
On my machine with gcc-10 I get the error:
```
/mnt/home/mbarbone/repos/xsimd/include/xsimd/types/../arch/./xsimd_avx512f.hpp:2740:59: error: '_mm512_cvtsi512_si32' was not declared in this scope; did you mean '_mm512_castsi512_si128'?
 2740 |                 return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFF);
      |                                       ~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                       _mm512_castsi512_si128
/mnt/home/mbarbone/repos/xsimd/include/xsimd/types/../arch/./xsimd_avx512f.hpp:2744:59: error: '_mm512_cvtsi512_si32' was not declared in this scope; did you mean '_mm512_castsi512_si128'?
 2744 |                 return static_cast<T>(_mm512_cvtsi512_si32(self) & 0xFFFF);
      |                                       ~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                       _mm512_castsi512_si128
/mnt/home/mbarbone/repos/xsimd/include/xsimd/types/../arch/./xsimd_avx512f.hpp:2748:59: error: '_mm512_cvtsi512_si32' was not declared in this scope; did you mean '_mm512_castsi512_si128'?
 2748 |                 return static_cast<T>(_mm512_cvtsi512_si32(self));
      |                                       ~~~~~~~~~~~~~~~~~~~~^~~~~~
      |                                       _mm512_castsi512_si128
```
This fixes it for me. 