### PR TITLE
Slighly less pessimistic detection of neon64

### DIFF
--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -346,23 +346,23 @@
 /**
  * @ingroup xsimd_config_macro
  *
- * Set to 1 if NEON is available at compile-time, to 0 otherwise.
- */
-#if defined(__ARM_NEON) && __ARM_ARCH >= 7
-#define XSIMD_WITH_NEON 1
-#else
-#define XSIMD_WITH_NEON 0
-#endif
-
-/**
- * @ingroup xsimd_config_macro
- *
  * Set to 1 if NEON64 is available at compile-time, to 0 otherwise.
  */
 #if defined(__aarch64__) || defined(_M_ARM64)
 #define XSIMD_WITH_NEON64 1
 #else
 #define XSIMD_WITH_NEON64 0
+#endif
+
+/**
+ * @ingroup xsimd_config_macro
+ *
+ * Set to 1 if NEON is available at compile-time, to 0 otherwise.
+ */
+#if (defined(__ARM_NEON) && __ARM_ARCH >= 7) || XSIMD_WITH_NEON64
+#define XSIMD_WITH_NEON 1
+#else
+#define XSIMD_WITH_NEON 0
 #endif
 
 /**


### PR DESCRIPTION
- Detect Neon 64 even without `__ARM_NEON` since arm v8 is sufficient
- Remove hard to track nested `#if #else`