### PR TITLE
fix(neon): unsigned bitwise shifts are never called

### DIFF
--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -2374,14 +2374,12 @@ namespace xsimd
             }
 
             template <class A, class T>
-            XSIMD_INLINE bool all_positive(batch<T, A> const& b) noexcept
+            XSIMD_INLINE bool shifts_all_positive(batch<T, A> const& b) noexcept
             {
-                for (std::size_t k = 0; k < b.size; ++k)
-                {
-                    if (b.get(k) < 0)
-                        return false;
-                }
-                return true;
+                std::array<T, batch<T, A>::size> tmp = {};
+                b.store_unaligned(tmp.begin());
+                return std::all_of(tmp.begin(), tmp.end(), [](T x)
+                                   { return x >= 0; });
             }
         }
 
@@ -2397,7 +2395,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u8(lhs, vreinterpretq_s8_u8(rhs));
         }
 
@@ -2411,7 +2409,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u16(lhs, vreinterpretq_s16_u16(rhs));
         }
 
@@ -2425,7 +2423,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u32(lhs, vreinterpretq_s32_u32(rhs));
         }
 
@@ -2439,7 +2437,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u64(lhs, vreinterpretq_s64_u64(rhs));
         }
 
@@ -2641,7 +2639,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u8(lhs, vnegq_s8(vreinterpretq_s8_u8(rhs)));
         }
 
@@ -2655,7 +2653,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u16(lhs, vnegq_s16(vreinterpretq_s16_u16(rhs)));
         }
 
@@ -2669,7 +2667,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u32(lhs, vnegq_s32(vreinterpretq_s32_u32(rhs)));
         }
 
@@ -2683,7 +2681,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon> req) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             using S = std::make_signed_t<T>;
             return vshlq_u64(lhs, neg(batch<S, A>(vreinterpretq_s64_u64(rhs)), req).data);
         }

--- a/include/xsimd/arch/xsimd_neon64.hpp
+++ b/include/xsimd/arch/xsimd_neon64.hpp
@@ -1213,7 +1213,7 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<neon64>) noexcept
         {
             // Blindly converting to signed since out of bounds shifts are UB anyways
-            assert(detail::all_positive(rhs));
+            assert(detail::shifts_all_positive(rhs));
             return vshlq_u64(lhs, vnegq_s64(vreinterpretq_s64_u64(rhs)));
         }
 


### PR DESCRIPTION
Shift public API expects the same type for data and shifts:

https://github.com/xtensor-stack/xsimd/blob/c3a8d37db2777c65c889e49143af36f32746d3da/include/xsimd/types/xsimd_api.hpp#L371

However, the neon implementations for unsigned data take the shifts as signed (likely because the underlying intrinsict use signed shifts).

https://github.com/xtensor-stack/xsimd/blob/c3a8d37db2777c65c889e49143af36f32746d3da/include/xsimd/arch/xsimd_neon.hpp#L2385

As a result the neon overload is never selected, falling back on `common` scalar implementation.

## Example

```cpp
#include <cstdint>
#include <xsimd/xsimd.hpp>

auto f(xsimd::batch<std::uint16_t> const& a, xsimd::batch<std::uint16_t> const& b)
{
    return xsimd::bitwise_rshift(a, b);
}
```


Before:
```asm
ldr     q0, [x0]
ldr     q1, [x1]
ushll.4s        v2, v0, #0
ushll2.4s       v0, v0, #0
ushll.4s        v3, v1, #0
movi.2d v4, #0000000000000000
usubw2.4s       v1, v4, v1
ushl.4s v0, v0, v1
neg.4s  v1, v3
ushl.4s v1, v2, v1
uzp1.8h v0, v1, v0
ret
```

After:
```asm
ldr     q0, [x0]
ldr     q1, [x1]
neg.8h  v1, v1
ushl.8h v0, v0, v1
ret
```

I also grep with `-O0` and the assembly was previously pointing to `common` as a `requires_arch` in the third parameter.
