### PR TITLE
Update README after C++14 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ http://xsimd.readthedocs.io/
 |   9.x   |     ^0.7.0       |
 |   8.x   |     ^0.7.0       |
 
-The dependency on `xtl` is required if you want to support vectorization for `xtl::xcomplex`. In this case, you must build your project with C++14 support enabled.
+The dependency on `xtl` is required if you want to support vectorization for `xtl::xcomplex`.
 
 ## Usage
 


### PR DESCRIPTION
Removes the outdated note telling users to enable C++14 manually, since the requirement is now published through the CMake interface.