### PR TITLE
[test] Add some default initialization in shuffle_test to please gcc …

### DIFF
--- a/test/test_shuffle.cpp
+++ b/test/test_shuffle.cpp
@@ -620,10 +620,10 @@ struct shuffle_test
     void transpose()
     {
         B b_lhs = B::load_unaligned(lhs.data());
-        std::array<B, size> b_matrix;
+        alignas(arch_type::alignment()) std::array<B, size> b_matrix = {};
         for (size_t i = 0; i < size; ++i)
             b_matrix[i] = b_lhs;
-        std::array<value_type, size * size> ref_matrix;
+        alignas(arch_type::alignment()) std::array<value_type, size * size> ref_matrix = {};
         for (size_t i = 0; i < size; ++i)
             for (size_t j = 0; j < size; ++j)
                 ref_matrix[i * size + j] = lhs[i];


### PR DESCRIPTION
…static analysis

The extra initialization is redundant with the call to std::fill, but GCC 13 seems to ignore it. And it's just tests so not performance critical.

Just to test if the CI failure is legit.