### PR TITLE
perf: add native AVX2 uint64/int64 mul kernel

### DIFF
--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -912,6 +912,16 @@ namespace xsimd
             {
                 return _mm256_mullo_epi32(self, other);
             }
+            else XSIMD_IF_CONSTEXPR(sizeof(T) == 8)
+            {
+                return _mm256_add_epi64(
+                    _mm256_mul_epu32(self, other),
+                    _mm256_slli_epi64(
+                        _mm256_add_epi64(
+                            _mm256_mul_epu32(other, _mm256_shuffle_epi32(self, _MM_SHUFFLE(2, 3, 0, 1))),
+                            _mm256_mul_epu32(self, _mm256_shuffle_epi32(other, _MM_SHUFFLE(2, 3, 0, 1)))),
+                        32));
+            }
             else
             {
                 return mul(self, other, avx {});


### PR DESCRIPTION
Previously batch<[u]int64_t, avx2> mul fell through to AVX, which has no integer mul, which in turn fell through to SSE4.1 — splitting each 256-bit register into two 128-bit halves (vextracti128/vinserti128) and running the mul_epu32 sequence twice.

Add a sizeof(T)==8 specialization using _mm256_mul_epu32 directly, mirroring the SSE4.1 pattern with 256-bit intrinsics. Generates 8 ymm ops: 2 vpshufd, 3 vpmuludq, 2 vpaddq, 1 vpsllq — no lane splitting.

AVX512F (without DQ) also benefits since it forwards to the AVX2 kernel.