### PR TITLE
Fix SVE dynamic dispatch ODR violation

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -9,8 +9,11 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xsimd_benchmark.hpp"
+#include <iostream>
 #include <map>
+#include <string>
+
+#include "xsimd_benchmark.hpp"
 
 void benchmark_operation()
 {

--- a/benchmark/xsimd_benchmark.hpp
+++ b/benchmark/xsimd_benchmark.hpp
@@ -15,7 +15,6 @@
 #include "xsimd/arch/xsimd_scalar.hpp"
 #include "xsimd/xsimd.hpp"
 #include <chrono>
-#include <iostream>
 #include <string>
 #include <vector>
 

--- a/include/xsimd/arch/common/xsimd_common_swizzle.hpp
+++ b/include/xsimd/arch/common/xsimd_common_swizzle.hpp
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include <type_traits>
 
-#include "../../config/xsimd_inline.hpp"
+#include "../../config/xsimd_macros.hpp"
 
 namespace xsimd
 {

--- a/include/xsimd/arch/utils/shifts.hpp
+++ b/include/xsimd/arch/utils/shifts.hpp
@@ -13,7 +13,7 @@
 #ifndef XSIMD_UTILS_SHIFTS_HPP
 #define XSIMD_UTILS_SHIFTS_HPP
 
-#include "../../config/xsimd_inline.hpp"
+#include "../../config/xsimd_macros.hpp"
 #include "../../types/xsimd_batch.hpp"
 #include "../../types/xsimd_batch_constant.hpp"
 #include "../../types/xsimd_traits.hpp"

--- a/include/xsimd/arch/xsimd_rvv.hpp
+++ b/include/xsimd/arch/xsimd_rvv.hpp
@@ -369,12 +369,12 @@ namespace xsimd
             using as_float_relaxed_t = typename as_float_relaxed<sizeof(T)>::type;
 
             template <class T, class U>
-            rvv_reg_t<T, U::width> rvvreinterpret(U const& arg) noexcept
+            XSIMD_INLINE rvv_reg_t<T, U::width> rvvreinterpret(U const& arg) noexcept
             {
                 return rvv_reg_t<T, U::width>(arg, types::detail::XSIMD_RVV_BITCAST);
             }
             template <class T, class A, class U>
-            rvv_reg_t<T, A::width> rvvreinterpret(batch<U, A> const& arg) noexcept
+            XSIMD_INLINE rvv_reg_t<T, A::width> rvvreinterpret(batch<U, A> const& arg) noexcept
             {
                 typename batch<U, A>::register_type r = arg;
                 return rvvreinterpret<T>(r);
@@ -519,23 +519,23 @@ namespace xsimd
             XSIMD_RVV_OVERLOAD(rvvget_hi_, (__riscv_vget_ XSIMD_RVV_TSM), _DROP_1ST_CUSTOM_ARGS_NOVL, vec(T, wide_vec), args..., 1)
 
             template <class T, size_t W, std::enable_if_t<W >= types::detail::rvv_width_m1, int> = 0>
-            rvv_reg_t<T, W> rvvget_lo(rvv_reg_t<T, W * 2> const& vv) noexcept
+            XSIMD_INLINE rvv_reg_t<T, W> rvvget_lo(rvv_reg_t<T, W * 2> const& vv) noexcept
             {
                 typename rvv_reg_t<T, W>::register_type tmp = rvvget_lo_(T {}, vv);
                 return tmp;
             }
             template <class T, size_t W, std::enable_if_t<W >= types::detail::rvv_width_m1, int> = 0>
-            rvv_reg_t<T, W> rvvget_hi(rvv_reg_t<T, W * 2> const& vv) noexcept
+            XSIMD_INLINE rvv_reg_t<T, W> rvvget_hi(rvv_reg_t<T, W * 2> const& vv) noexcept
             {
                 typename rvv_reg_t<T, W>::register_type tmp = rvvget_hi_(T {}, vv);
                 return tmp;
             }
-            template <class T, size_t W, std::enable_if_t<W<types::detail::rvv_width_m1, int> = 0> rvv_reg_t<T, W> rvvget_lo(rvv_reg_t<T, W * 2> const& vv) noexcept
+            template <class T, size_t W, std::enable_if_t<W<types::detail::rvv_width_m1, int> = 0> XSIMD_INLINE rvv_reg_t<T, W> rvvget_lo(rvv_reg_t<T, W * 2> const& vv) noexcept
             {
                 typename rvv_reg_t<T, W>::register_type tmp = vv;
                 return tmp;
             }
-            template <class T, size_t W, std::enable_if_t<W<types::detail::rvv_width_m1, int> = 0> rvv_reg_t<T, W> rvvget_hi(rvv_reg_t<T, W * 2> const& vv) noexcept
+            template <class T, size_t W, std::enable_if_t<W<types::detail::rvv_width_m1, int> = 0> XSIMD_INLINE rvv_reg_t<T, W> rvvget_hi(rvv_reg_t<T, W * 2> const& vv) noexcept
             {
                 return __riscv_vslidedown(vv, vv.vl / 2, vv.vl);
             }

--- a/include/xsimd/arch/xsimd_scalar.hpp
+++ b/include/xsimd/arch/xsimd_scalar.hpp
@@ -20,7 +20,7 @@
 #include <limits>
 #include <type_traits>
 
-#include "xsimd/config/xsimd_inline.hpp"
+#include "xsimd/config/xsimd_macros.hpp"
 
 #ifdef XSIMD_ENABLE_XTL_COMPLEX
 #include "xtl/xcomplex.hpp"

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -32,1242 +32,1243 @@ namespace xsimd
 
     namespace kernel
     {
-        inline namespace XSIMD_SVE_NAMESPACE {
-        namespace detail_sve
+        inline namespace XSIMD_SVE_NAMESPACE
         {
-            using xsimd::index;
-            using xsimd::types::detail::sve_vector_type;
-
-            // predicate creation
-            XSIMD_INLINE svbool_t sve_ptrue_impl(index<1>) noexcept { return svptrue_b8(); }
-            XSIMD_INLINE svbool_t sve_ptrue_impl(index<2>) noexcept { return svptrue_b16(); }
-            XSIMD_INLINE svbool_t sve_ptrue_impl(index<4>) noexcept { return svptrue_b32(); }
-            XSIMD_INLINE svbool_t sve_ptrue_impl(index<8>) noexcept { return svptrue_b64(); }
-
-            template <class T>
-            XSIMD_INLINE svbool_t sve_ptrue() noexcept { return sve_ptrue_impl(index<sizeof(T)> {}); }
-
-            // predicate loading
-            template <bool M0, bool M1>
-            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b64(M0, M1); }
-            template <bool M0, bool M1, bool M2, bool M3>
-            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b32(M0, M1, M2, M3); }
-            template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7>
-            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b16(M0, M1, M2, M3, M4, M5, M6, M7); }
-            template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7,
-                      bool M8, bool M9, bool M10, bool M11, bool M12, bool M13, bool M14, bool M15>
-            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b8(M0, M1, M2, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15); }
-
-            // count active lanes in a predicate
-            XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<1>) noexcept { return svcntp_b8(p, p); }
-            XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<2>) noexcept { return svcntp_b16(p, p); }
-            XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<4>) noexcept { return svcntp_b32(p, p); }
-            XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<8>) noexcept { return svcntp_b64(p, p); }
-
-            template <class T>
-            XSIMD_INLINE uint64_t sve_pcount(svbool_t p) noexcept { return sve_pcount_impl(p, index<sizeof(T)> {}); }
-
-            // enable for signed integers
-            template <class T>
-            using sve_enable_signed_int_t = std::enable_if_t<std::is_integral<T>::value && std::is_signed<T>::value, int>;
-
-            // enable for unsigned integers
-            template <class T>
-            using sve_enable_unsigned_int_t = std::enable_if_t<std::is_integral<T>::value && !std::is_signed<T>::value, int>;
-
-            // enable for floating points
-            template <class T>
-            using sve_enable_floating_point_t = std::enable_if_t<std::is_floating_point<T>::value, int>;
-
-            // enable for signed integers or floating points
-            template <class T>
-            using sve_enable_signed_int_or_floating_point_t = std::enable_if_t<std::is_signed<T>::value, int>;
-
-            // enable for all SVE supported types
-            template <class T>
-            using sve_enable_all_t = std::enable_if_t<std::is_arithmetic<T>::value, int>;
-
-            // Trait describing the SVE types that correspond to a scalar,
-            // parameterised by (byte size, signedness, floating-point-ness).
-            //
-            // `scalar` is the matching fixed-width scalar (int8_t, ..., float,
-            // double). SVE load/store intrinsics are overloaded on these
-            // pointer types, so remapping integers through `scalar` avoids
-            // platform quirks such as darwin arm64's `long` vs `long long`
-            // distinction and rejects `char` as an element type.
-            //
-            // `sizeless` is the matching sizeless SVE type. xsimd stores SVE
-            // vectors as fixed-size attributed types (arm_sve_vector_bits),
-            // which clang treats as implicitly convertible to every sizeless
-            // SVE type — including multi-vector tuples — making the overloaded
-            // svreinterpret_*/svsel/etc. intrinsics ambiguous. Static-casting
-            // to `sizeless` first collapses the overload set to the single
-            // 1-vector candidate.
-            template <size_t N, bool Signed, bool FP>
-            struct sve_type;
-            template <>
-            struct sve_type<1, true, false>
+            namespace detail_sve
             {
-                using scalar = int8_t;
-                using sizeless = svint8_t;
-            };
-            template <>
-            struct sve_type<1, false, false>
-            {
-                using scalar = uint8_t;
-                using sizeless = svuint8_t;
-            };
-            template <>
-            struct sve_type<2, true, false>
-            {
-                using scalar = int16_t;
-                using sizeless = svint16_t;
-            };
-            template <>
-            struct sve_type<2, false, false>
-            {
-                using scalar = uint16_t;
-                using sizeless = svuint16_t;
-            };
-            template <>
-            struct sve_type<4, true, false>
-            {
-                using scalar = int32_t;
-                using sizeless = svint32_t;
-            };
-            template <>
-            struct sve_type<4, false, false>
-            {
-                using scalar = uint32_t;
-                using sizeless = svuint32_t;
-            };
-            template <>
-            struct sve_type<8, true, false>
-            {
-                using scalar = int64_t;
-                using sizeless = svint64_t;
-            };
-            template <>
-            struct sve_type<8, false, false>
-            {
-                using scalar = uint64_t;
-                using sizeless = svuint64_t;
-            };
-            template <>
-            struct sve_type<4, true, true>
-            {
-                using scalar = float;
-                using sizeless = svfloat32_t;
-            };
-            template <>
-            struct sve_type<8, true, true>
-            {
-                using scalar = double;
-                using sizeless = svfloat64_t;
-            };
-
-            template <class T>
-            using sve_type_for = sve_type<sizeof(T), std::is_signed<T>::value, std::is_floating_point<T>::value>;
-
-            template <class T>
-            using sve_sizeless_t = typename sve_type_for<T>::sizeless;
-
-            // Remap integer Ts to their matching fixed-width counterpart (via
-            // sve_type::scalar) so svld1/svst1 see the pointer type their
-            // overload set expects; pass non-integer Ts through unchanged.
-            template <class T, bool IsInt = std::is_integral<std::decay_t<T>>::value>
-            struct sve_fix_integer_impl
-            {
-                using type = T;
-            };
-            template <class T>
-            struct sve_fix_integer_impl<T, true>
-            {
-                using type = typename sve_type_for<std::decay_t<T>>::scalar;
-            };
-
-            template <class T>
-            using sve_fix_char_t = typename sve_fix_integer_impl<T>::type;
-        } // namespace detail_sve
-
-        /*********
-         * Load *
-         *********/
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> load_aligned(T const* src, convert<T>, requires_arch<sve>) noexcept
-        {
-            return svld1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(src));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<sve>) noexcept
-        {
-            return load_aligned<A>(src, convert<T>(), sve {});
-        }
-
-        // load_masked
-        template <class A, class T, bool... Values, class Mode, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<float, A, Values...>, Mode, requires_arch<sve>) noexcept
-        {
-            return svld1(detail_sve::sve_pmask<Values...>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(mem));
-        }
-
-        // load_complex
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<std::complex<T>, A> load_complex_aligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
-        {
-            const T* buf = reinterpret_cast<const T*>(mem);
-            const auto tmp = svld2(detail_sve::sve_ptrue<T>(), buf);
-            const auto real = svget2(tmp, 0);
-            const auto imag = svget2(tmp, 1);
-            return batch<std::complex<T>, A> { real, imag };
-        }
-
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<std::complex<T>, A> load_complex_unaligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
-        {
-            return load_complex_aligned<A>(mem, convert<std::complex<T>> {}, sve {});
-        }
-
-        /*********
-         * Store *
-         *********/
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE void store_aligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
-        {
-            svst1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T>*>(dst), src);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
-        {
-            store_aligned<A>(dst, src, sve {});
-        }
-
-        // store_complex
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE void store_complex_aligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
-        {
-            using v2type = std::conditional_t<(sizeof(T) == 4), svfloat32x2_t, svfloat64x2_t>;
-            v2type tmp {};
-            tmp = svset2(tmp, 0, src.real());
-            tmp = svset2(tmp, 1, src.imag());
-            T* buf = reinterpret_cast<T*>(dst);
-            svst2(detail_sve::sve_ptrue<T>(), buf, tmp);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE void store_complex_unaligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
-        {
-            store_complex_aligned(dst, src, sve {});
-        }
-
-        /******************
-         * scatter/gather *
-         ******************/
-
-        namespace detail_sve
-        {
-            template <class T, class U>
-            using sve_enable_sg_t = std::enable_if_t<(sizeof(T) == sizeof(U) && (sizeof(T) == 4 || sizeof(T) == 8)), int>;
-        }
-
-        // scatter
-        template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
-        XSIMD_INLINE void scatter(batch<T, A> const& src, T* dst, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
-        {
-            svst1_scatter_index(detail_sve::sve_ptrue<T>(), dst, index.data, src.data);
-        }
-
-        // gather
-        template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
-        XSIMD_INLINE batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
-        {
-            return svld1_gather_index(detail_sve::sve_ptrue<T>(), src, index.data);
-        }
-
-        /********************
-         * Scalar to vector *
-         ********************/
-
-        // broadcast
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_u8(uint8_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_signed_t<T, 1> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_s8(int8_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_u16(uint16_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_signed_t<T, 2> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_s16(int16_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_u32(uint32_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_signed_t<T, 4> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_s32(int32_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_u64(uint64_t(arg));
-        }
-
-        template <class A, class T, detail::enable_sized_signed_t<T, 8> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_s64(int64_t(arg));
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> broadcast(float arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_f32(arg);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> broadcast(double arg, requires_arch<sve>) noexcept
-        {
-            return svdup_n_f64(arg);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> broadcast(T val, requires_arch<sve>) noexcept
-        {
-            return broadcast<sve>(val, sve {});
-        }
-
-        /**************
-         * Arithmetic *
-         **************/
-
-        // add
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> add(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svadd_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // sadd
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> sadd(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svqadd(lhs, rhs);
-        }
-
-        // sub
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> sub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svsub_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // ssub
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> ssub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svqsub(lhs, rhs);
-        }
-
-        // mul
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> mul(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svmul_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // div
-        template <class A, class T, std::enable_if_t<sizeof(T) >= 4, int> = 0>
-        XSIMD_INLINE batch<T, A> div(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svdiv_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // max
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> max(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svmax_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // min
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> min(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svmin_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // neg
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
-        XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u8(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
-        XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u16(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
-        XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u32(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
-        }
-
-        template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
-        XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u64(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svneg_x(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        // abs
-        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
-        XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return arg;
-        }
-
-        template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svabs_x(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        // fma: x * y + z
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
-        {
-            return svmad_x(detail_sve::sve_ptrue<T>(), x, y, z);
-        }
-
-        // fnma: z - x * y
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
-        {
-            return svmsb_x(detail_sve::sve_ptrue<T>(), x, y, z);
-        }
-
-        // fms: x * y - z
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
-        {
-            return -fnma(x, y, z, sve {});
-        }
-
-        // fnms: - x * y - z
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
-        {
-            return -fma(x, y, z, sve {});
-        }
-
-        /**********************
-         * Logical operations *
-         **********************/
-
-        // bitwise_and
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_and(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svand_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> bitwise_and(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svand_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
-            return svreinterpret_f32(result_bits);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> bitwise_and(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svand_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
-            return svreinterpret_f64(result_bits);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> bitwise_and(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svand_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // bitwise_andnot
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_andnot(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svbic_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> bitwise_andnot(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svbic_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
-            return svreinterpret_f32(result_bits);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> bitwise_andnot(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svbic_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
-            return svreinterpret_f64(result_bits);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svbic_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // bitwise_or
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_or(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svorr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> bitwise_or(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svorr_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
-            return svreinterpret_f32(result_bits);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> bitwise_or(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svorr_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
-            return svreinterpret_f64(result_bits);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> bitwise_or(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svorr_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // bitwise_xor
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_xor(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return sveor_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> bitwise_xor(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = sveor_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
-            return svreinterpret_f32(result_bits);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> bitwise_xor(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = sveor_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
-            return svreinterpret_f64(result_bits);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // bitwise_not
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_not(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svnot_x(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<float, A> bitwise_not(batch<float, A> const& arg, requires_arch<sve>) noexcept
-        {
-            const auto arg_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(arg));
-            const auto result_bits = svnot_x(detail_sve::sve_ptrue<float>(), arg_bits);
-            return svreinterpret_f32(result_bits);
-        }
-
-        template <class A>
-        XSIMD_INLINE batch<double, A> bitwise_not(batch<double, A> const& arg, requires_arch<sve>) noexcept
-        {
-            const auto arg_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(arg));
-            const auto result_bits = svnot_x(detail_sve::sve_ptrue<double>(), arg_bits);
-            return svreinterpret_f64(result_bits);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> bitwise_not(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svnot_z(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        /**********
-         * Shifts *
-         **********/
-
-        namespace detail_sve
-        {
-            template <class A, class T, class U>
-            XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<1>) noexcept
-            {
-                return svreinterpret_u8(static_cast<sve_sizeless_t<T>>(arg));
-            }
-
-            template <class A, class T, class U>
-            XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<2>) noexcept
-            {
-                return svreinterpret_u16(static_cast<sve_sizeless_t<T>>(arg));
-            }
-
-            template <class A, class T, class U>
-            XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<4>) noexcept
-            {
-                return svreinterpret_u32(static_cast<sve_sizeless_t<T>>(arg));
-            }
-
-            template <class A, class T, class U>
-            XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<8>) noexcept
-            {
-                return svreinterpret_u64(static_cast<sve_sizeless_t<T>>(arg));
-            }
-
-            template <class A, class T, class U = as_unsigned_integer_t<T>>
-            XSIMD_INLINE batch<U, A> sve_to_unsigned_batch(batch<T, A> const& arg) noexcept
-            {
-                return sve_to_unsigned_batch_impl<A, T, U>(arg, index<sizeof(T)> {});
-            }
-        } // namespace detail_sve
-
-        // bitwise_lshift
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
-        {
-            constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
-            assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svlsl_x(detail_sve::sve_ptrue<T>(), arg, n);
-        }
-
-        template <class A, class T, detail::enable_integral_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svlsl_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
-        }
-
-        // bitwise_rshift
-        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
-        {
-            constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
-            assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svlsr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<T>(n));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svlsr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
-        {
-            constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
-            assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svasr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<as_unsigned_integer_t<T>>(n));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
-        XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svasr_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
-        }
-
-        /**************
-         * Reductions *
-         **************/
-
-        // reduce_add
-        template <class A, class T, class V = typename batch<T, A>::value_type, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE V reduce_add(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            // sve integer reduction results are promoted to 64 bits
-            return static_cast<V>(svaddv(detail_sve::sve_ptrue<T>(), arg));
-        }
-
-        // reduce_max
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE T reduce_max(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svmaxv(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        // reduce_min
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE T reduce_min(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svminv(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        // haddp
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> haddp(const batch<T, A>* row, requires_arch<sve>) noexcept
-        {
-            constexpr std::size_t size = batch<T, A>::size;
-            T sums[size];
-            for (std::size_t i = 0; i < size; ++i)
-            {
-                sums[i] = reduce_add(row[i], sve {});
-            }
-            return svld1(detail_sve::sve_ptrue<T>(), sums);
-        }
-
-        /***************
-         * Comparisons *
-         ***************/
-
-        // eq
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> eq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmpeq(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> eq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            const auto neq_result = sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-            return svnot_z(detail_sve::sve_ptrue<T>(), neq_result);
-        }
-
-        // neq
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> neq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmpne(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> neq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // lt
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> lt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmplt(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // le
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> le(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmple(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // gt
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmpgt(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        // ge
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> ge(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svcmpge(detail_sve::sve_ptrue<T>(), lhs, rhs);
-        }
-
-        /***************
-         * Permutation *
-         ***************/
-
-        //  rotate_left
-        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> rotate_left(batch<T, A> const& a, requires_arch<sve>) noexcept
-        {
-            return svext(a, a, N);
-        }
-
-        // swizzle (dynamic)
-        template <class A, class T, class I>
-        XSIMD_INLINE batch<T, A> swizzle(batch<T, A> const& arg, batch<I, A> indices, requires_arch<sve>) noexcept
-        {
-            return svtbl(arg, indices);
-        }
-
-        template <class A, class T, class I>
-        XSIMD_INLINE batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& self,
-                                                       batch<I, A> indices,
-                                                       requires_arch<sve>) noexcept
-        {
-            const auto real = swizzle(self.real(), indices, sve {});
-            const auto imag = swizzle(self.imag(), indices, sve {});
-            return batch<std::complex<T>>(real, imag);
-        }
-
-        // swizzle (static)
-        template <class A, class T, class I, I... idx>
-        XSIMD_INLINE batch<T, A> swizzle(batch<T, A> const& arg, batch_constant<I, A, idx...> indices, requires_arch<sve>) noexcept
-        {
-            static_assert(batch<T, A>::size == sizeof...(idx), "invalid swizzle indices");
-            return swizzle(arg, indices.as_batch(), sve {});
-        }
-
-        template <class A, class T, class I, I... idx>
-        XSIMD_INLINE batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& arg,
-                                                       batch_constant<I, A, idx...> indices,
-                                                       requires_arch<sve>) noexcept
-        {
-            static_assert(batch<std::complex<T>, A>::size == sizeof...(idx), "invalid swizzle indices");
-            return swizzle(arg, indices.as_batch(), sve {});
-        }
-
-        /*************
-         * Selection *
-         *************/
-
-        // extract_pair
-        namespace detail_sve
-        {
-            template <class A, class T>
-            XSIMD_INLINE batch<T, A> sve_extract_pair(batch<T, A> const&, batch<T, A> const& /*rhs*/, std::size_t, std::index_sequence<>) noexcept
-            {
-                assert(false && "extract_pair out of bounds");
-                return batch<T, A> {};
-            }
-
-            template <class A, class T, size_t I, size_t... Is>
-            XSIMD_INLINE batch<T, A> sve_extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, std::index_sequence<I, Is...>) noexcept
-            {
-                if (n == I)
+                using xsimd::index;
+                using xsimd::types::detail::sve_vector_type;
+
+                // predicate creation
+                XSIMD_INLINE svbool_t sve_ptrue_impl(index<1>) noexcept { return svptrue_b8(); }
+                XSIMD_INLINE svbool_t sve_ptrue_impl(index<2>) noexcept { return svptrue_b16(); }
+                XSIMD_INLINE svbool_t sve_ptrue_impl(index<4>) noexcept { return svptrue_b32(); }
+                XSIMD_INLINE svbool_t sve_ptrue_impl(index<8>) noexcept { return svptrue_b64(); }
+
+                template <class T>
+                XSIMD_INLINE svbool_t sve_ptrue() noexcept { return sve_ptrue_impl(index<sizeof(T)> {}); }
+
+                // predicate loading
+                template <bool M0, bool M1>
+                XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b64(M0, M1); }
+                template <bool M0, bool M1, bool M2, bool M3>
+                XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b32(M0, M1, M2, M3); }
+                template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7>
+                XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b16(M0, M1, M2, M3, M4, M5, M6, M7); }
+                template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7,
+                          bool M8, bool M9, bool M10, bool M11, bool M12, bool M13, bool M14, bool M15>
+                XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b8(M0, M1, M2, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15); }
+
+                // count active lanes in a predicate
+                XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<1>) noexcept { return svcntp_b8(p, p); }
+                XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<2>) noexcept { return svcntp_b16(p, p); }
+                XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<4>) noexcept { return svcntp_b32(p, p); }
+                XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<8>) noexcept { return svcntp_b64(p, p); }
+
+                template <class T>
+                XSIMD_INLINE uint64_t sve_pcount(svbool_t p) noexcept { return sve_pcount_impl(p, index<sizeof(T)> {}); }
+
+                // enable for signed integers
+                template <class T>
+                using sve_enable_signed_int_t = std::enable_if_t<std::is_integral<T>::value && std::is_signed<T>::value, int>;
+
+                // enable for unsigned integers
+                template <class T>
+                using sve_enable_unsigned_int_t = std::enable_if_t<std::is_integral<T>::value && !std::is_signed<T>::value, int>;
+
+                // enable for floating points
+                template <class T>
+                using sve_enable_floating_point_t = std::enable_if_t<std::is_floating_point<T>::value, int>;
+
+                // enable for signed integers or floating points
+                template <class T>
+                using sve_enable_signed_int_or_floating_point_t = std::enable_if_t<std::is_signed<T>::value, int>;
+
+                // enable for all SVE supported types
+                template <class T>
+                using sve_enable_all_t = std::enable_if_t<std::is_arithmetic<T>::value, int>;
+
+                // Trait describing the SVE types that correspond to a scalar,
+                // parameterised by (byte size, signedness, floating-point-ness).
+                //
+                // `scalar` is the matching fixed-width scalar (int8_t, ..., float,
+                // double). SVE load/store intrinsics are overloaded on these
+                // pointer types, so remapping integers through `scalar` avoids
+                // platform quirks such as darwin arm64's `long` vs `long long`
+                // distinction and rejects `char` as an element type.
+                //
+                // `sizeless` is the matching sizeless SVE type. xsimd stores SVE
+                // vectors as fixed-size attributed types (arm_sve_vector_bits),
+                // which clang treats as implicitly convertible to every sizeless
+                // SVE type — including multi-vector tuples — making the overloaded
+                // svreinterpret_*/svsel/etc. intrinsics ambiguous. Static-casting
+                // to `sizeless` first collapses the overload set to the single
+                // 1-vector candidate.
+                template <size_t N, bool Signed, bool FP>
+                struct sve_type;
+                template <>
+                struct sve_type<1, true, false>
                 {
-                    return svext(rhs, lhs, I);
-                }
-                else
+                    using scalar = int8_t;
+                    using sizeless = svint8_t;
+                };
+                template <>
+                struct sve_type<1, false, false>
                 {
-                    return sve_extract_pair(lhs, rhs, n, std::index_sequence<Is...>());
-                }
+                    using scalar = uint8_t;
+                    using sizeless = svuint8_t;
+                };
+                template <>
+                struct sve_type<2, true, false>
+                {
+                    using scalar = int16_t;
+                    using sizeless = svint16_t;
+                };
+                template <>
+                struct sve_type<2, false, false>
+                {
+                    using scalar = uint16_t;
+                    using sizeless = svuint16_t;
+                };
+                template <>
+                struct sve_type<4, true, false>
+                {
+                    using scalar = int32_t;
+                    using sizeless = svint32_t;
+                };
+                template <>
+                struct sve_type<4, false, false>
+                {
+                    using scalar = uint32_t;
+                    using sizeless = svuint32_t;
+                };
+                template <>
+                struct sve_type<8, true, false>
+                {
+                    using scalar = int64_t;
+                    using sizeless = svint64_t;
+                };
+                template <>
+                struct sve_type<8, false, false>
+                {
+                    using scalar = uint64_t;
+                    using sizeless = svuint64_t;
+                };
+                template <>
+                struct sve_type<4, true, true>
+                {
+                    using scalar = float;
+                    using sizeless = svfloat32_t;
+                };
+                template <>
+                struct sve_type<8, true, true>
+                {
+                    using scalar = double;
+                    using sizeless = svfloat64_t;
+                };
+
+                template <class T>
+                using sve_type_for = sve_type<sizeof(T), std::is_signed<T>::value, std::is_floating_point<T>::value>;
+
+                template <class T>
+                using sve_sizeless_t = typename sve_type_for<T>::sizeless;
+
+                // Remap integer Ts to their matching fixed-width counterpart (via
+                // sve_type::scalar) so svld1/svst1 see the pointer type their
+                // overload set expects; pass non-integer Ts through unchanged.
+                template <class T, bool IsInt = std::is_integral<std::decay_t<T>>::value>
+                struct sve_fix_integer_impl
+                {
+                    using type = T;
+                };
+                template <class T>
+                struct sve_fix_integer_impl<T, true>
+                {
+                    using type = typename sve_type_for<std::decay_t<T>>::scalar;
+                };
+
+                template <class T>
+                using sve_fix_char_t = typename sve_fix_integer_impl<T>::type;
+            } // namespace detail_sve
+
+            /*********
+             * Load *
+             *********/
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> load_aligned(T const* src, convert<T>, requires_arch<sve>) noexcept
+            {
+                return svld1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(src));
             }
 
-            template <class A, class T, size_t... Is>
-            XSIMD_INLINE batch<T, A> sve_extract_pair_impl(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, std::index_sequence<0, Is...>) noexcept
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<sve>) noexcept
             {
-                if (n == 0)
-                {
-                    return rhs;
-                }
-                else
-                {
-                    return sve_extract_pair(lhs, rhs, n, std::index_sequence<Is...>());
-                }
-            }
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, requires_arch<sve>) noexcept
-        {
-            constexpr std::size_t size = batch<T, A>::size;
-            assert(n < size && "index in bounds");
-            return detail_sve::sve_extract_pair_impl(lhs, rhs, n, std::make_index_sequence<size>());
-        }
-
-        // select
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& a, batch<T, A> const& b, requires_arch<sve>) noexcept
-        {
-            return svsel(cond, static_cast<detail_sve::sve_sizeless_t<T>>(a), static_cast<detail_sve::sve_sizeless_t<T>>(b));
-        }
-
-        template <class A, class T, bool... b>
-        XSIMD_INLINE batch<T, A> select(batch_bool_constant<T, A, b...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sve>) noexcept
-        {
-            return select(batch_bool<T, A> { b... }, true_br, false_br, sve {});
-        }
-
-        // zip_lo
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> zip_lo(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svzip1(lhs, rhs);
-        }
-
-        // zip_hi
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> zip_hi(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
-        {
-            return svzip2(lhs, rhs);
-        }
-
-        /*****************************
-         * Floating-point arithmetic *
-         *****************************/
-
-        // rsqrt
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> rsqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svrsqrte(arg);
-        }
-
-        // sqrt
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> sqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svsqrt_x(detail_sve::sve_ptrue<T>(), arg);
-        }
-
-        // reciprocal
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> reciprocal(const batch<T, A>& arg, requires_arch<sve>) noexcept
-        {
-            return svrecpe(arg);
-        }
-
-        /******************************
-         * Floating-point conversions *
-         ******************************/
-
-        // fast_cast
-        namespace detail_sve
-        {
-            template <class A, class T, detail::enable_sized_integral_t<T, 4> = 0>
-            XSIMD_INLINE batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
-            {
-                return svcvt_f32_x(detail_sve::sve_ptrue<T>(), arg);
+                return load_aligned<A>(src, convert<T>(), sve {});
             }
 
-            template <class A, class T, detail::enable_sized_integral_t<T, 8> = 0>
-            XSIMD_INLINE batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
+            // load_masked
+            template <class A, class T, bool... Values, class Mode, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<float, A, Values...>, Mode, requires_arch<sve>) noexcept
             {
-                return svcvt_f64_x(detail_sve::sve_ptrue<T>(), arg);
+                return svld1(detail_sve::sve_pmask<Values...>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(mem));
+            }
+
+            // load_complex
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<std::complex<T>, A> load_complex_aligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
+            {
+                const T* buf = reinterpret_cast<const T*>(mem);
+                const auto tmp = svld2(detail_sve::sve_ptrue<T>(), buf);
+                const auto real = svget2(tmp, 0);
+                const auto imag = svget2(tmp, 1);
+                return batch<std::complex<T>, A> { real, imag };
+            }
+
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<std::complex<T>, A> load_complex_unaligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
+            {
+                return load_complex_aligned<A>(mem, convert<std::complex<T>> {}, sve {});
+            }
+
+            /*********
+             * Store *
+             *********/
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE void store_aligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
+            {
+                svst1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T>*>(dst), src);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
+            {
+                store_aligned<A>(dst, src, sve {});
+            }
+
+            // store_complex
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE void store_complex_aligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
+            {
+                using v2type = std::conditional_t<(sizeof(T) == 4), svfloat32x2_t, svfloat64x2_t>;
+                v2type tmp {};
+                tmp = svset2(tmp, 0, src.real());
+                tmp = svset2(tmp, 1, src.imag());
+                T* buf = reinterpret_cast<T*>(dst);
+                svst2(detail_sve::sve_ptrue<T>(), buf, tmp);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE void store_complex_unaligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
+            {
+                store_complex_aligned(dst, src, sve {});
+            }
+
+            /******************
+             * scatter/gather *
+             ******************/
+
+            namespace detail_sve
+            {
+                template <class T, class U>
+                using sve_enable_sg_t = std::enable_if_t<(sizeof(T) == sizeof(U) && (sizeof(T) == 4 || sizeof(T) == 8)), int>;
+            }
+
+            // scatter
+            template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
+            XSIMD_INLINE void scatter(batch<T, A> const& src, T* dst, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
+            {
+                svst1_scatter_index(detail_sve::sve_ptrue<T>(), dst, index.data, src.data);
+            }
+
+            // gather
+            template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
+            XSIMD_INLINE batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
+            {
+                return svld1_gather_index(detail_sve::sve_ptrue<T>(), src, index.data);
+            }
+
+            /********************
+             * Scalar to vector *
+             ********************/
+
+            // broadcast
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_u8(uint8_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_signed_t<T, 1> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_s8(int8_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_u16(uint16_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_signed_t<T, 2> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_s16(int16_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_u32(uint32_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_signed_t<T, 4> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_s32(int32_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_u64(uint64_t(arg));
+            }
+
+            template <class A, class T, detail::enable_sized_signed_t<T, 8> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T arg, requires_arch<sve>) noexcept
+            {
+                return svdup_n_s64(int64_t(arg));
             }
 
             template <class A>
-            XSIMD_INLINE batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
+            XSIMD_INLINE batch<float, A> broadcast(float arg, requires_arch<sve>) noexcept
             {
-                return svcvt_s32_x(detail_sve::sve_ptrue<float>(), arg);
+                return svdup_n_f32(arg);
             }
 
             template <class A>
-            XSIMD_INLINE batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
+            XSIMD_INLINE batch<double, A> broadcast(double arg, requires_arch<sve>) noexcept
             {
-                return svcvt_u32_x(detail_sve::sve_ptrue<float>(), arg);
+                return svdup_n_f64(arg);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> broadcast(T val, requires_arch<sve>) noexcept
+            {
+                return broadcast<sve>(val, sve {});
+            }
+
+            /**************
+             * Arithmetic *
+             **************/
+
+            // add
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> add(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svadd_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // sadd
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> sadd(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svqadd(lhs, rhs);
+            }
+
+            // sub
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> sub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svsub_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // ssub
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> ssub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svqsub(lhs, rhs);
+            }
+
+            // mul
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> mul(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svmul_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // div
+            template <class A, class T, std::enable_if_t<sizeof(T) >= 4, int> = 0>
+            XSIMD_INLINE batch<T, A> div(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svdiv_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // max
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> max(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svmax_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // min
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> min(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svmin_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // neg
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
+            XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u8(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
+            XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u16(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
+            XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u32(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
+            }
+
+            template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
+            XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u64(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
+            }
+
+            template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svneg_x(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // abs
+            template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
+            XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return arg;
+            }
+
+            template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svabs_x(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // fma: x * y + z
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
+            {
+                return svmad_x(detail_sve::sve_ptrue<T>(), x, y, z);
+            }
+
+            // fnma: z - x * y
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
+            {
+                return svmsb_x(detail_sve::sve_ptrue<T>(), x, y, z);
+            }
+
+            // fms: x * y - z
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
+            {
+                return -fnma(x, y, z, sve {});
+            }
+
+            // fnms: - x * y - z
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
+            {
+                return -fma(x, y, z, sve {});
+            }
+
+            /**********************
+             * Logical operations *
+             **********************/
+
+            // bitwise_and
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_and(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svand_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
             }
 
             template <class A>
-            XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
+            XSIMD_INLINE batch<float, A> bitwise_and(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
             {
-                return svcvt_s64_x(detail_sve::sve_ptrue<double>(), arg);
+                const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+                const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+                const auto result_bits = svand_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
+                return svreinterpret_f32(result_bits);
             }
 
             template <class A>
-            XSIMD_INLINE batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
+            XSIMD_INLINE batch<double, A> bitwise_and(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
             {
-                return svcvt_u64_x(detail_sve::sve_ptrue<double>(), arg);
+                const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+                const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+                const auto result_bits = svand_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
+                return svreinterpret_f64(result_bits);
             }
-        }
 
-        /*********
-         * Miscs *
-         *********/
-
-        // set
-        template <class A, class T, class... Args>
-        XSIMD_INLINE batch<T, A> set(batch<T, A> const&, requires_arch<sve>, Args... args) noexcept
-        {
-            return detail_sve::sve_vector_type<T> { args... };
-        }
-
-        template <class A, class T, class... Args>
-        XSIMD_INLINE batch<std::complex<T>, A> set(batch<std::complex<T>, A> const&, requires_arch<sve>,
-                                                   Args... args_complex) noexcept
-        {
-            return batch<std::complex<T>>(detail_sve::sve_vector_type<T> { args_complex.real()... },
-                                          detail_sve::sve_vector_type<T> { args_complex.imag()... });
-        }
-
-        template <class A, class T, class... Args>
-        XSIMD_INLINE batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<sve>, Args... args) noexcept
-        {
-            using U = as_unsigned_integer_t<T>;
-            const auto values = detail_sve::sve_vector_type<U> { static_cast<U>(args)... };
-            const auto zero = broadcast<A, U>(static_cast<U>(0), sve {});
-            return svcmpne(detail_sve::sve_ptrue<T>(), values, zero);
-        }
-
-        // insert
-        namespace detail_sve
-        {
-            // generate index sequence (iota)
-            XSIMD_INLINE svuint8_t sve_iota_impl(index<1>) noexcept { return svindex_u8(0, 1); }
-            XSIMD_INLINE svuint16_t sve_iota_impl(index<2>) noexcept { return svindex_u16(0, 1); }
-            XSIMD_INLINE svuint32_t sve_iota_impl(index<4>) noexcept { return svindex_u32(0, 1); }
-            XSIMD_INLINE svuint64_t sve_iota_impl(index<8>) noexcept { return svindex_u64(0, 1); }
-
-            template <class T, class V = sve_vector_type<as_unsigned_integer_t<T>>>
-            XSIMD_INLINE V sve_iota() noexcept { return sve_iota_impl(index<sizeof(T)> {}); }
-        } // namespace detail_sve
-
-        template <class A, class T, size_t I, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> insert(batch<T, A> const& arg, T val, index<I>, requires_arch<sve>) noexcept
-        {
-            // create a predicate with only the I-th lane activated
-            const auto iota = detail_sve::sve_iota<T>();
-            const auto index_predicate = svcmpeq(detail_sve::sve_ptrue<T>(), iota, static_cast<as_unsigned_integer_t<T>>(I));
-            return svsel(index_predicate, static_cast<detail_sve::sve_sizeless_t<T>>(broadcast<A, T>(val, sve {})), static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        // first
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<sve>) noexcept
-        {
-            return self.data[0];
-        }
-
-        // all
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE bool all(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return detail_sve::sve_pcount<T>(arg) == batch_bool<T, A>::size;
-        }
-
-        // any
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE bool any(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svptest_any(arg, arg);
-        }
-
-        // bitwise_cast
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 1> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 1> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 2> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 2> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 4> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 4> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 8> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 8> = 0>
-        XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<float, A> bitwise_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_f32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<double, A> bitwise_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
-        {
-            return svreinterpret_f64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
-        }
-
-        // batch_bool_cast
-        template <class A, class T_out, class T_in, detail_sve::sve_enable_all_t<T_in> = 0>
-        XSIMD_INLINE batch_bool<T_out, A> batch_bool_cast(batch_bool<T_in, A> const& arg, batch_bool<T_out, A> const&, requires_arch<sve>) noexcept
-        {
-            return arg.data;
-        }
-
-        // from_bool
-        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> from_bool(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return select(arg, batch<T, A>(1), batch<T, A>(0));
-        }
-
-        // slide_left
-        namespace detail_sve
-        {
-            template <size_t N>
-            struct sve_slider_left
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> bitwise_and(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
             {
-                template <class A, class T>
-                XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                return svand_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // bitwise_andnot
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_andnot(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svbic_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<float, A> bitwise_andnot(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+                const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+                const auto result_bits = svbic_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
+                return svreinterpret_f32(result_bits);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<double, A> bitwise_andnot(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+                const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+                const auto result_bits = svbic_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
+                return svreinterpret_f64(result_bits);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svbic_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // bitwise_or
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_or(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svorr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<float, A> bitwise_or(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+                const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+                const auto result_bits = svorr_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
+                return svreinterpret_f32(result_bits);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<double, A> bitwise_or(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+                const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+                const auto result_bits = svorr_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
+                return svreinterpret_f64(result_bits);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> bitwise_or(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svorr_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // bitwise_xor
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_xor(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return sveor_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<float, A> bitwise_xor(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+                const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+                const auto result_bits = sveor_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
+                return svreinterpret_f32(result_bits);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<double, A> bitwise_xor(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+                const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+                const auto result_bits = sveor_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
+                return svreinterpret_f64(result_bits);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // bitwise_not
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_not(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svnot_x(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<float, A> bitwise_not(batch<float, A> const& arg, requires_arch<sve>) noexcept
+            {
+                const auto arg_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(arg));
+                const auto result_bits = svnot_x(detail_sve::sve_ptrue<float>(), arg_bits);
+                return svreinterpret_f32(result_bits);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<double, A> bitwise_not(batch<double, A> const& arg, requires_arch<sve>) noexcept
+            {
+                const auto arg_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(arg));
+                const auto result_bits = svnot_x(detail_sve::sve_ptrue<double>(), arg_bits);
+                return svreinterpret_f64(result_bits);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> bitwise_not(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svnot_z(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            /**********
+             * Shifts *
+             **********/
+
+            namespace detail_sve
+            {
+                template <class A, class T, class U>
+                XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<1>) noexcept
                 {
-                    using u8_vector = batch<uint8_t, A>;
-                    const auto left = svdup_n_u8(0);
-                    const auto right = bitwise_cast(arg, u8_vector {}, sve {}).data;
-                    const u8_vector result(svext(left, right, u8_vector::size - N));
-                    return bitwise_cast(result, batch<T, A> {}, sve {});
+                    return svreinterpret_u8(static_cast<sve_sizeless_t<T>>(arg));
                 }
-            };
 
-            template <>
-            struct sve_slider_left<0>
-            {
-                template <class A, class T>
-                XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                template <class A, class T, class U>
+                XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<2>) noexcept
                 {
-                    return arg;
+                    return svreinterpret_u16(static_cast<sve_sizeless_t<T>>(arg));
                 }
-            };
-        } // namespace detail_sve
 
-        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> slide_left(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return detail_sve::sve_slider_left<N>()(arg);
-        }
-
-        // slide_right
-        namespace detail_sve
-        {
-            template <size_t N>
-            struct sve_slider_right
-            {
-                template <class A, class T>
-                XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                template <class A, class T, class U>
+                XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<4>) noexcept
                 {
-                    using u8_vector = batch<uint8_t, A>;
-                    const auto left = bitwise_cast(arg, u8_vector {}, sve {}).data;
-                    const auto right = svdup_n_u8(0);
-                    const u8_vector result(svext(left, right, N));
-                    return bitwise_cast(result, batch<T, A> {}, sve {});
+                    return svreinterpret_u32(static_cast<sve_sizeless_t<T>>(arg));
                 }
-            };
 
-            template <>
-            struct sve_slider_right<batch<uint8_t, sve>::size>
+                template <class A, class T, class U>
+                XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<8>) noexcept
+                {
+                    return svreinterpret_u64(static_cast<sve_sizeless_t<T>>(arg));
+                }
+
+                template <class A, class T, class U = as_unsigned_integer_t<T>>
+                XSIMD_INLINE batch<U, A> sve_to_unsigned_batch(batch<T, A> const& arg) noexcept
+                {
+                    return sve_to_unsigned_batch_impl<A, T, U>(arg, index<sizeof(T)> {});
+                }
+            } // namespace detail_sve
+
+            // bitwise_lshift
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
+            {
+                constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
+                assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
+                return svlsl_x(detail_sve::sve_ptrue<T>(), arg, n);
+            }
+
+            template <class A, class T, detail::enable_integral_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svlsl_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
+            }
+
+            // bitwise_rshift
+            template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
+            {
+                constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
+                assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
+                return svlsr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<T>(n));
+            }
+
+            template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svlsr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
+            {
+                constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
+                assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
+                return svasr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<as_unsigned_integer_t<T>>(n));
+            }
+
+            template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
+            XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svasr_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
+            }
+
+            /**************
+             * Reductions *
+             **************/
+
+            // reduce_add
+            template <class A, class T, class V = typename batch<T, A>::value_type, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE V reduce_add(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                // sve integer reduction results are promoted to 64 bits
+                return static_cast<V>(svaddv(detail_sve::sve_ptrue<T>(), arg));
+            }
+
+            // reduce_max
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE T reduce_max(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svmaxv(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // reduce_min
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE T reduce_min(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svminv(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // haddp
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> haddp(const batch<T, A>* row, requires_arch<sve>) noexcept
+            {
+                constexpr std::size_t size = batch<T, A>::size;
+                T sums[size];
+                for (std::size_t i = 0; i < size; ++i)
+                {
+                    sums[i] = reduce_add(row[i], sve {});
+                }
+                return svld1(detail_sve::sve_ptrue<T>(), sums);
+            }
+
+            /***************
+             * Comparisons *
+             ***************/
+
+            // eq
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> eq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmpeq(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> eq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                const auto neq_result = sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+                return svnot_z(detail_sve::sve_ptrue<T>(), neq_result);
+            }
+
+            // neq
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> neq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmpne(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> neq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // lt
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> lt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmplt(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // le
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> le(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmple(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // gt
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmpgt(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            // ge
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> ge(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svcmpge(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            }
+
+            /***************
+             * Permutation *
+             ***************/
+
+            //  rotate_left
+            template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> rotate_left(batch<T, A> const& a, requires_arch<sve>) noexcept
+            {
+                return svext(a, a, N);
+            }
+
+            // swizzle (dynamic)
+            template <class A, class T, class I>
+            XSIMD_INLINE batch<T, A> swizzle(batch<T, A> const& arg, batch<I, A> indices, requires_arch<sve>) noexcept
+            {
+                return svtbl(arg, indices);
+            }
+
+            template <class A, class T, class I>
+            XSIMD_INLINE batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& self,
+                                                           batch<I, A> indices,
+                                                           requires_arch<sve>) noexcept
+            {
+                const auto real = swizzle(self.real(), indices, sve {});
+                const auto imag = swizzle(self.imag(), indices, sve {});
+                return batch<std::complex<T>>(real, imag);
+            }
+
+            // swizzle (static)
+            template <class A, class T, class I, I... idx>
+            XSIMD_INLINE batch<T, A> swizzle(batch<T, A> const& arg, batch_constant<I, A, idx...> indices, requires_arch<sve>) noexcept
+            {
+                static_assert(batch<T, A>::size == sizeof...(idx), "invalid swizzle indices");
+                return swizzle(arg, indices.as_batch(), sve {});
+            }
+
+            template <class A, class T, class I, I... idx>
+            XSIMD_INLINE batch<std::complex<T>, A> swizzle(batch<std::complex<T>, A> const& arg,
+                                                           batch_constant<I, A, idx...> indices,
+                                                           requires_arch<sve>) noexcept
+            {
+                static_assert(batch<std::complex<T>, A>::size == sizeof...(idx), "invalid swizzle indices");
+                return swizzle(arg, indices.as_batch(), sve {});
+            }
+
+            /*************
+             * Selection *
+             *************/
+
+            // extract_pair
+            namespace detail_sve
             {
                 template <class A, class T>
-                XSIMD_INLINE batch<T, A> operator()(batch<T, A> const&) noexcept
+                XSIMD_INLINE batch<T, A> sve_extract_pair(batch<T, A> const&, batch<T, A> const& /*rhs*/, std::size_t, std::index_sequence<>) noexcept
                 {
+                    assert(false && "extract_pair out of bounds");
                     return batch<T, A> {};
                 }
-            };
-        } // namespace detail_sve
 
-        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
-        XSIMD_INLINE batch<T, A> slide_right(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return detail_sve::sve_slider_right<N>()(arg);
-        }
+                template <class A, class T, size_t I, size_t... Is>
+                XSIMD_INLINE batch<T, A> sve_extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, std::index_sequence<I, Is...>) noexcept
+                {
+                    if (n == I)
+                    {
+                        return svext(rhs, lhs, I);
+                    }
+                    else
+                    {
+                        return sve_extract_pair(lhs, rhs, n, std::index_sequence<Is...>());
+                    }
+                }
 
-        // isnan
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch_bool<T, A> isnan(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return !(arg == arg);
-        }
+                template <class A, class T, size_t... Is>
+                XSIMD_INLINE batch<T, A> sve_extract_pair_impl(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, std::index_sequence<0, Is...>) noexcept
+                {
+                    if (n == 0)
+                    {
+                        return rhs;
+                    }
+                    else
+                    {
+                        return sve_extract_pair(lhs, rhs, n, std::index_sequence<Is...>());
+                    }
+                }
+            }
 
-        // nearbyint
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> nearbyint(batch<T, A> const& arg, requires_arch<sve>) noexcept
-        {
-            return svrintx_x(detail_sve::sve_ptrue<T>(), arg);
-        }
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, requires_arch<sve>) noexcept
+            {
+                constexpr std::size_t size = batch<T, A>::size;
+                assert(n < size && "index in bounds");
+                return detail_sve::sve_extract_pair_impl(lhs, rhs, n, std::make_index_sequence<size>());
+            }
 
-        // nearbyint_as_int
-        template <class A>
-        XSIMD_INLINE batch<int32_t, A> nearbyint_as_int(batch<float, A> const& arg, requires_arch<sve>) noexcept
-        {
-            const auto nearest = svrintx_x(detail_sve::sve_ptrue<float>(), arg);
-            return svcvt_s32_x(detail_sve::sve_ptrue<float>(), nearest);
-        }
+            // select
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& a, batch<T, A> const& b, requires_arch<sve>) noexcept
+            {
+                return svsel(cond, static_cast<detail_sve::sve_sizeless_t<T>>(a), static_cast<detail_sve::sve_sizeless_t<T>>(b));
+            }
 
-        template <class A>
-        XSIMD_INLINE batch<int64_t, A> nearbyint_as_int(batch<double, A> const& arg, requires_arch<sve>) noexcept
-        {
-            const auto nearest = svrintx_x(detail_sve::sve_ptrue<double>(), arg);
-            return svcvt_s64_x(detail_sve::sve_ptrue<double>(), nearest);
-        }
+            template <class A, class T, bool... b>
+            XSIMD_INLINE batch<T, A> select(batch_bool_constant<T, A, b...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<sve>) noexcept
+            {
+                return select(batch_bool<T, A> { b... }, true_br, false_br, sve {});
+            }
 
-        // ldexp
-        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
-        XSIMD_INLINE batch<T, A> ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& exp, requires_arch<sve>) noexcept
-        {
-            return svscale_x(detail_sve::sve_ptrue<T>(), x, exp);
-        }
+            // zip_lo
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> zip_lo(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svzip1(lhs, rhs);
+            }
 
-    } // namespace XSIMD_SVE_NAMESPACE
+            // zip_hi
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> zip_hi(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
+            {
+                return svzip2(lhs, rhs);
+            }
+
+            /*****************************
+             * Floating-point arithmetic *
+             *****************************/
+
+            // rsqrt
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> rsqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svrsqrte(arg);
+            }
+
+            // sqrt
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> sqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svsqrt_x(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // reciprocal
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> reciprocal(const batch<T, A>& arg, requires_arch<sve>) noexcept
+            {
+                return svrecpe(arg);
+            }
+
+            /******************************
+             * Floating-point conversions *
+             ******************************/
+
+            // fast_cast
+            namespace detail_sve
+            {
+                template <class A, class T, detail::enable_sized_integral_t<T, 4> = 0>
+                XSIMD_INLINE batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_f32_x(detail_sve::sve_ptrue<T>(), arg);
+                }
+
+                template <class A, class T, detail::enable_sized_integral_t<T, 8> = 0>
+                XSIMD_INLINE batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_f64_x(detail_sve::sve_ptrue<T>(), arg);
+                }
+
+                template <class A>
+                XSIMD_INLINE batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_s32_x(detail_sve::sve_ptrue<float>(), arg);
+                }
+
+                template <class A>
+                XSIMD_INLINE batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_u32_x(detail_sve::sve_ptrue<float>(), arg);
+                }
+
+                template <class A>
+                XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_s64_x(detail_sve::sve_ptrue<double>(), arg);
+                }
+
+                template <class A>
+                XSIMD_INLINE batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
+                {
+                    return svcvt_u64_x(detail_sve::sve_ptrue<double>(), arg);
+                }
+            }
+
+            /*********
+             * Miscs *
+             *********/
+
+            // set
+            template <class A, class T, class... Args>
+            XSIMD_INLINE batch<T, A> set(batch<T, A> const&, requires_arch<sve>, Args... args) noexcept
+            {
+                return detail_sve::sve_vector_type<T> { args... };
+            }
+
+            template <class A, class T, class... Args>
+            XSIMD_INLINE batch<std::complex<T>, A> set(batch<std::complex<T>, A> const&, requires_arch<sve>,
+                                                       Args... args_complex) noexcept
+            {
+                return batch<std::complex<T>>(detail_sve::sve_vector_type<T> { args_complex.real()... },
+                                              detail_sve::sve_vector_type<T> { args_complex.imag()... });
+            }
+
+            template <class A, class T, class... Args>
+            XSIMD_INLINE batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<sve>, Args... args) noexcept
+            {
+                using U = as_unsigned_integer_t<T>;
+                const auto values = detail_sve::sve_vector_type<U> { static_cast<U>(args)... };
+                const auto zero = broadcast<A, U>(static_cast<U>(0), sve {});
+                return svcmpne(detail_sve::sve_ptrue<T>(), values, zero);
+            }
+
+            // insert
+            namespace detail_sve
+            {
+                // generate index sequence (iota)
+                XSIMD_INLINE svuint8_t sve_iota_impl(index<1>) noexcept { return svindex_u8(0, 1); }
+                XSIMD_INLINE svuint16_t sve_iota_impl(index<2>) noexcept { return svindex_u16(0, 1); }
+                XSIMD_INLINE svuint32_t sve_iota_impl(index<4>) noexcept { return svindex_u32(0, 1); }
+                XSIMD_INLINE svuint64_t sve_iota_impl(index<8>) noexcept { return svindex_u64(0, 1); }
+
+                template <class T, class V = sve_vector_type<as_unsigned_integer_t<T>>>
+                XSIMD_INLINE V sve_iota() noexcept { return sve_iota_impl(index<sizeof(T)> {}); }
+            } // namespace detail_sve
+
+            template <class A, class T, size_t I, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> insert(batch<T, A> const& arg, T val, index<I>, requires_arch<sve>) noexcept
+            {
+                // create a predicate with only the I-th lane activated
+                const auto iota = detail_sve::sve_iota<T>();
+                const auto index_predicate = svcmpeq(detail_sve::sve_ptrue<T>(), iota, static_cast<as_unsigned_integer_t<T>>(I));
+                return svsel(index_predicate, static_cast<detail_sve::sve_sizeless_t<T>>(broadcast<A, T>(val, sve {})), static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            // first
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<sve>) noexcept
+            {
+                return self.data[0];
+            }
+
+            // all
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE bool all(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return detail_sve::sve_pcount<T>(arg) == batch_bool<T, A>::size;
+            }
+
+            // any
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE bool any(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svptest_any(arg, arg);
+            }
+
+            // bitwise_cast
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 1> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 1> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 2> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 2> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 4> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 4> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 8> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 8> = 0>
+            XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<float, A> bitwise_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_f32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<double, A> bitwise_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
+            {
+                return svreinterpret_f64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
+            }
+
+            // batch_bool_cast
+            template <class A, class T_out, class T_in, detail_sve::sve_enable_all_t<T_in> = 0>
+            XSIMD_INLINE batch_bool<T_out, A> batch_bool_cast(batch_bool<T_in, A> const& arg, batch_bool<T_out, A> const&, requires_arch<sve>) noexcept
+            {
+                return arg.data;
+            }
+
+            // from_bool
+            template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> from_bool(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return select(arg, batch<T, A>(1), batch<T, A>(0));
+            }
+
+            // slide_left
+            namespace detail_sve
+            {
+                template <size_t N>
+                struct sve_slider_left
+                {
+                    template <class A, class T>
+                    XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                    {
+                        using u8_vector = batch<uint8_t, A>;
+                        const auto left = svdup_n_u8(0);
+                        const auto right = bitwise_cast(arg, u8_vector {}, sve {}).data;
+                        const u8_vector result(svext(left, right, u8_vector::size - N));
+                        return bitwise_cast(result, batch<T, A> {}, sve {});
+                    }
+                };
+
+                template <>
+                struct sve_slider_left<0>
+                {
+                    template <class A, class T>
+                    XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                    {
+                        return arg;
+                    }
+                };
+            } // namespace detail_sve
+
+            template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> slide_left(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return detail_sve::sve_slider_left<N>()(arg);
+            }
+
+            // slide_right
+            namespace detail_sve
+            {
+                template <size_t N>
+                struct sve_slider_right
+                {
+                    template <class A, class T>
+                    XSIMD_INLINE batch<T, A> operator()(batch<T, A> const& arg) noexcept
+                    {
+                        using u8_vector = batch<uint8_t, A>;
+                        const auto left = bitwise_cast(arg, u8_vector {}, sve {}).data;
+                        const auto right = svdup_n_u8(0);
+                        const u8_vector result(svext(left, right, N));
+                        return bitwise_cast(result, batch<T, A> {}, sve {});
+                    }
+                };
+
+                template <>
+                struct sve_slider_right<batch<uint8_t, sve>::size>
+                {
+                    template <class A, class T>
+                    XSIMD_INLINE batch<T, A> operator()(batch<T, A> const&) noexcept
+                    {
+                        return batch<T, A> {};
+                    }
+                };
+            } // namespace detail_sve
+
+            template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
+            XSIMD_INLINE batch<T, A> slide_right(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return detail_sve::sve_slider_right<N>()(arg);
+            }
+
+            // isnan
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch_bool<T, A> isnan(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return !(arg == arg);
+            }
+
+            // nearbyint
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> nearbyint(batch<T, A> const& arg, requires_arch<sve>) noexcept
+            {
+                return svrintx_x(detail_sve::sve_ptrue<T>(), arg);
+            }
+
+            // nearbyint_as_int
+            template <class A>
+            XSIMD_INLINE batch<int32_t, A> nearbyint_as_int(batch<float, A> const& arg, requires_arch<sve>) noexcept
+            {
+                const auto nearest = svrintx_x(detail_sve::sve_ptrue<float>(), arg);
+                return svcvt_s32_x(detail_sve::sve_ptrue<float>(), nearest);
+            }
+
+            template <class A>
+            XSIMD_INLINE batch<int64_t, A> nearbyint_as_int(batch<double, A> const& arg, requires_arch<sve>) noexcept
+            {
+                const auto nearest = svrintx_x(detail_sve::sve_ptrue<double>(), arg);
+                return svcvt_s64_x(detail_sve::sve_ptrue<double>(), nearest);
+            }
+
+            // ldexp
+            template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
+            XSIMD_INLINE batch<T, A> ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& exp, requires_arch<sve>) noexcept
+            {
+                return svscale_x(detail_sve::sve_ptrue<T>(), x, exp);
+            }
+
+        } // namespace XSIMD_SVE_NAMESPACE
     } // namespace kernel
 } // namespace xsimd
 

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -16,7 +16,14 @@
 #include <complex>
 #include <type_traits>
 
+#include "../config/xsimd_macros.hpp"
 #include "../types/xsimd_sve_register.hpp"
+
+// Define a inline namespace with the explicit SVE vector size to avoid ODR violation
+// When dynamically dispatching between different SVE sizes.
+// While most code is safe from ODR violation as the size is already encoded in the
+// register (and hence batch) types, utilities can quickly fall prone to this issue.
+#define XSIMD_SVE_NAMESPACE XSIMD_CONCAT(sve, XSIMD_SVE_BITS)
 
 namespace xsimd
 {
@@ -25,7 +32,8 @@ namespace xsimd
 
     namespace kernel
     {
-        namespace detail
+        inline namespace XSIMD_SVE_NAMESPACE {
+        namespace detail_sve
         {
             using xsimd::index;
             using xsimd::types::detail::sve_vector_type;
@@ -180,43 +188,43 @@ namespace xsimd
 
             template <class T>
             using sve_fix_char_t = typename sve_fix_integer_impl<T>::type;
-        } // namespace detail
+        } // namespace detail_sve
 
         /*********
          * Load *
          *********/
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> load_aligned(T const* src, convert<T>, requires_arch<sve>) noexcept
         {
-            return svld1(detail::sve_ptrue<T>(), reinterpret_cast<detail::sve_fix_char_t<T> const*>(src));
+            return svld1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(src));
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<sve>) noexcept
         {
             return load_aligned<A>(src, convert<T>(), sve {});
         }
 
         // load_masked
-        template <class A, class T, bool... Values, class Mode, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, bool... Values, class Mode, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<float, A, Values...>, Mode, requires_arch<sve>) noexcept
         {
-            return svld1(detail::sve_pmask<Values...>(), reinterpret_cast<detail::sve_fix_char_t<T> const*>(mem));
+            return svld1(detail_sve::sve_pmask<Values...>(), reinterpret_cast<detail_sve::sve_fix_char_t<T> const*>(mem));
         }
 
         // load_complex
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<std::complex<T>, A> load_complex_aligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
         {
             const T* buf = reinterpret_cast<const T*>(mem);
-            const auto tmp = svld2(detail::sve_ptrue<T>(), buf);
+            const auto tmp = svld2(detail_sve::sve_ptrue<T>(), buf);
             const auto real = svget2(tmp, 0);
             const auto imag = svget2(tmp, 1);
             return batch<std::complex<T>, A> { real, imag };
         }
 
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<std::complex<T>, A> load_complex_unaligned(std::complex<T> const* mem, convert<std::complex<T>>, requires_arch<sve>) noexcept
         {
             return load_complex_aligned<A>(mem, convert<std::complex<T>> {}, sve {});
@@ -226,20 +234,20 @@ namespace xsimd
          * Store *
          *********/
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE void store_aligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
         {
-            svst1(detail::sve_ptrue<T>(), reinterpret_cast<detail::sve_fix_char_t<T>*>(dst), src);
+            svst1(detail_sve::sve_ptrue<T>(), reinterpret_cast<detail_sve::sve_fix_char_t<T>*>(dst), src);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
         {
             store_aligned<A>(dst, src, sve {});
         }
 
         // store_complex
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE void store_complex_aligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
         {
             using v2type = std::conditional_t<(sizeof(T) == 4), svfloat32x2_t, svfloat64x2_t>;
@@ -247,10 +255,10 @@ namespace xsimd
             tmp = svset2(tmp, 0, src.real());
             tmp = svset2(tmp, 1, src.imag());
             T* buf = reinterpret_cast<T*>(dst);
-            svst2(detail::sve_ptrue<T>(), buf, tmp);
+            svst2(detail_sve::sve_ptrue<T>(), buf, tmp);
         }
 
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE void store_complex_unaligned(std::complex<T>* dst, batch<std::complex<T>, A> const& src, requires_arch<sve>) noexcept
         {
             store_complex_aligned(dst, src, sve {});
@@ -260,24 +268,24 @@ namespace xsimd
          * scatter/gather *
          ******************/
 
-        namespace detail
+        namespace detail_sve
         {
             template <class T, class U>
             using sve_enable_sg_t = std::enable_if_t<(sizeof(T) == sizeof(U) && (sizeof(T) == 4 || sizeof(T) == 8)), int>;
         }
 
         // scatter
-        template <class A, class T, class U, detail::sve_enable_sg_t<T, U> = 0>
+        template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
         XSIMD_INLINE void scatter(batch<T, A> const& src, T* dst, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
         {
-            svst1_scatter_index(detail::sve_ptrue<T>(), dst, index.data, src.data);
+            svst1_scatter_index(detail_sve::sve_ptrue<T>(), dst, index.data, src.data);
         }
 
         // gather
-        template <class A, class T, class U, detail::sve_enable_sg_t<T, U> = 0>
+        template <class A, class T, class U, detail_sve::sve_enable_sg_t<T, U> = 0>
         XSIMD_INLINE batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index, kernel::requires_arch<sve>) noexcept
         {
-            return svld1_gather_index(detail::sve_ptrue<T>(), src, index.data);
+            return svld1_gather_index(detail_sve::sve_ptrue<T>(), src, index.data);
         }
 
         /********************
@@ -345,7 +353,7 @@ namespace xsimd
             return svdup_n_f64(arg);
         }
 
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> broadcast(T val, requires_arch<sve>) noexcept
         {
             return broadcast<sve>(val, sve {});
@@ -356,10 +364,10 @@ namespace xsimd
          **************/
 
         // add
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> add(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svadd_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svadd_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // sadd
@@ -370,10 +378,10 @@ namespace xsimd
         }
 
         // sub
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> sub(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svsub_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svsub_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // ssub
@@ -384,100 +392,100 @@ namespace xsimd
         }
 
         // mul
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> mul(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svmul_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svmul_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // div
         template <class A, class T, std::enable_if_t<sizeof(T) >= 4, int> = 0>
         XSIMD_INLINE batch<T, A> div(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svdiv_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svdiv_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // max
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> max(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svmax_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svmax_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // min
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> min(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svmin_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svmin_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // neg
         template <class A, class T, detail::enable_sized_unsigned_t<T, 1> = 0>
         XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u8(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s8(static_cast<detail::sve_sizeless_t<T>>(arg))));
+            return svreinterpret_u8(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 2> = 0>
         XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u16(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s16(static_cast<detail::sve_sizeless_t<T>>(arg))));
+            return svreinterpret_u16(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 4> = 0>
         XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u32(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s32(static_cast<detail::sve_sizeless_t<T>>(arg))));
+            return svreinterpret_u32(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
         }
 
         template <class A, class T, detail::enable_sized_unsigned_t<T, 8> = 0>
         XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u64(svneg_x(detail::sve_ptrue<T>(), svreinterpret_s64(static_cast<detail::sve_sizeless_t<T>>(arg))));
+            return svreinterpret_u64(svneg_x(detail_sve::sve_ptrue<T>(), svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg))));
         }
 
-        template <class A, class T, detail::sve_enable_signed_int_or_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> neg(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svneg_x(detail::sve_ptrue<T>(), arg);
+            return svneg_x(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // abs
-        template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
         XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return arg;
         }
 
-        template <class A, class T, detail::sve_enable_signed_int_or_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_signed_int_or_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> abs(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svabs_x(detail::sve_ptrue<T>(), arg);
+            return svabs_x(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // fma: x * y + z
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> fma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
-            return svmad_x(detail::sve_ptrue<T>(), x, y, z);
+            return svmad_x(detail_sve::sve_ptrue<T>(), x, y, z);
         }
 
         // fnma: z - x * y
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> fnma(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
-            return svmsb_x(detail::sve_ptrue<T>(), x, y, z);
+            return svmsb_x(detail_sve::sve_ptrue<T>(), x, y, z);
         }
 
         // fms: x * y - z
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> fms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
             return -fnma(x, y, z, sve {});
         }
 
         // fnms: - x * y - z
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> fnms(batch<T, A> const& x, batch<T, A> const& y, batch<T, A> const& z, requires_arch<sve>) noexcept
         {
             return -fma(x, y, z, sve {});
@@ -491,160 +499,160 @@ namespace xsimd
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_and(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svand_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svand_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
         XSIMD_INLINE batch<float, A> bitwise_and(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svand_x(detail::sve_ptrue<float>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+            const auto result_bits = svand_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
             return svreinterpret_f32(result_bits);
         }
 
         template <class A>
         XSIMD_INLINE batch<double, A> bitwise_and(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svand_x(detail::sve_ptrue<double>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+            const auto result_bits = svand_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
             return svreinterpret_f64(result_bits);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> bitwise_and(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svand_z(detail::sve_ptrue<T>(), lhs, rhs);
+            return svand_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_andnot
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_andnot(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svbic_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svbic_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
         XSIMD_INLINE batch<float, A> bitwise_andnot(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svbic_x(detail::sve_ptrue<float>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+            const auto result_bits = svbic_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
             return svreinterpret_f32(result_bits);
         }
 
         template <class A>
         XSIMD_INLINE batch<double, A> bitwise_andnot(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svbic_x(detail::sve_ptrue<double>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+            const auto result_bits = svbic_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
             return svreinterpret_f64(result_bits);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> bitwise_andnot(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svbic_z(detail::sve_ptrue<T>(), lhs, rhs);
+            return svbic_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_or
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_or(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svorr_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svorr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
         XSIMD_INLINE batch<float, A> bitwise_or(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = svorr_x(detail::sve_ptrue<float>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+            const auto result_bits = svorr_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
             return svreinterpret_f32(result_bits);
         }
 
         template <class A>
         XSIMD_INLINE batch<double, A> bitwise_or(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = svorr_x(detail::sve_ptrue<double>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+            const auto result_bits = svorr_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
             return svreinterpret_f64(result_bits);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> bitwise_or(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svorr_z(detail::sve_ptrue<T>(), lhs, rhs);
+            return svorr_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_xor
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_xor(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return sveor_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return sveor_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         template <class A>
         XSIMD_INLINE batch<float, A> bitwise_xor(batch<float, A> const& lhs, batch<float, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(lhs));
-            const auto rhs_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(rhs));
-            const auto result_bits = sveor_x(detail::sve_ptrue<float>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(lhs));
+            const auto rhs_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(rhs));
+            const auto result_bits = sveor_x(detail_sve::sve_ptrue<float>(), lhs_bits, rhs_bits);
             return svreinterpret_f32(result_bits);
         }
 
         template <class A>
         XSIMD_INLINE batch<double, A> bitwise_xor(batch<double, A> const& lhs, batch<double, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto lhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(lhs));
-            const auto rhs_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(rhs));
-            const auto result_bits = sveor_x(detail::sve_ptrue<double>(), lhs_bits, rhs_bits);
+            const auto lhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(lhs));
+            const auto rhs_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(rhs));
+            const auto result_bits = sveor_x(detail_sve::sve_ptrue<double>(), lhs_bits, rhs_bits);
             return svreinterpret_f64(result_bits);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> bitwise_xor(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
+            return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // bitwise_not
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_not(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svnot_x(detail::sve_ptrue<T>(), arg);
+            return svnot_x(detail_sve::sve_ptrue<T>(), arg);
         }
 
         template <class A>
         XSIMD_INLINE batch<float, A> bitwise_not(batch<float, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto arg_bits = svreinterpret_u32(static_cast<detail::sve_sizeless_t<float>>(arg));
-            const auto result_bits = svnot_x(detail::sve_ptrue<float>(), arg_bits);
+            const auto arg_bits = svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<float>>(arg));
+            const auto result_bits = svnot_x(detail_sve::sve_ptrue<float>(), arg_bits);
             return svreinterpret_f32(result_bits);
         }
 
         template <class A>
         XSIMD_INLINE batch<double, A> bitwise_not(batch<double, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto arg_bits = svreinterpret_u64(static_cast<detail::sve_sizeless_t<double>>(arg));
-            const auto result_bits = svnot_x(detail::sve_ptrue<double>(), arg_bits);
+            const auto arg_bits = svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<double>>(arg));
+            const auto result_bits = svnot_x(detail_sve::sve_ptrue<double>(), arg_bits);
             return svreinterpret_f64(result_bits);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> bitwise_not(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svnot_z(detail::sve_ptrue<T>(), arg);
+            return svnot_z(detail_sve::sve_ptrue<T>(), arg);
         }
 
         /**********
          * Shifts *
          **********/
 
-        namespace detail
+        namespace detail_sve
         {
             template <class A, class T, class U>
             XSIMD_INLINE batch<U, A> sve_to_unsigned_batch_impl(batch<T, A> const& arg, index<1>) noexcept
@@ -675,7 +683,7 @@ namespace xsimd
             {
                 return sve_to_unsigned_batch_impl<A, T, U>(arg, index<sizeof(T)> {});
             }
-        } // namespace detail
+        } // namespace detail_sve
 
         // bitwise_lshift
         template <class A, class T, detail::enable_integral_t<T> = 0>
@@ -683,42 +691,42 @@ namespace xsimd
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svlsl_x(detail::sve_ptrue<T>(), arg, n);
+            return svlsl_x(detail_sve::sve_ptrue<T>(), arg, n);
         }
 
         template <class A, class T, detail::enable_integral_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_lshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svlsl_x(detail::sve_ptrue<T>(), lhs, detail::sve_to_unsigned_batch<A, T>(rhs));
+            return svlsl_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
         }
 
         // bitwise_rshift
-        template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svlsr_x(detail::sve_ptrue<T>(), arg, static_cast<T>(n));
+            return svlsr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<T>(n));
         }
 
-        template <class A, class T, detail::sve_enable_unsigned_int_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_unsigned_int_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svlsr_x(detail::sve_ptrue<T>(), lhs, rhs);
+            return svlsr_x(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
-        template <class A, class T, detail::sve_enable_signed_int_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& arg, int n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = sizeof(typename batch<T, A>::value_type) * 8;
             assert(0 <= n && static_cast<std::size_t>(n) < size && "index in bounds");
-            return svasr_x(detail::sve_ptrue<T>(), arg, static_cast<as_unsigned_integer_t<T>>(n));
+            return svasr_x(detail_sve::sve_ptrue<T>(), arg, static_cast<as_unsigned_integer_t<T>>(n));
         }
 
-        template <class A, class T, detail::sve_enable_signed_int_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_signed_int_t<T> = 0>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svasr_x(detail::sve_ptrue<T>(), lhs, detail::sve_to_unsigned_batch<A, T>(rhs));
+            return svasr_x(detail_sve::sve_ptrue<T>(), lhs, detail_sve::sve_to_unsigned_batch<A, T>(rhs));
         }
 
         /**************
@@ -726,29 +734,29 @@ namespace xsimd
          **************/
 
         // reduce_add
-        template <class A, class T, class V = typename batch<T, A>::value_type, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, class V = typename batch<T, A>::value_type, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE V reduce_add(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             // sve integer reduction results are promoted to 64 bits
-            return static_cast<V>(svaddv(detail::sve_ptrue<T>(), arg));
+            return static_cast<V>(svaddv(detail_sve::sve_ptrue<T>(), arg));
         }
 
         // reduce_max
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE T reduce_max(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svmaxv(detail::sve_ptrue<T>(), arg);
+            return svmaxv(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // reduce_min
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE T reduce_min(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svminv(detail::sve_ptrue<T>(), arg);
+            return svminv(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // haddp
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> haddp(const batch<T, A>* row, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
@@ -757,7 +765,7 @@ namespace xsimd
             {
                 sums[i] = reduce_add(row[i], sve {});
             }
-            return svld1(detail::sve_ptrue<T>(), sums);
+            return svld1(detail_sve::sve_ptrue<T>(), sums);
         }
 
         /***************
@@ -765,58 +773,58 @@ namespace xsimd
          ***************/
 
         // eq
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> eq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmpeq(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmpeq(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> eq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            const auto neq_result = sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
-            return svnot_z(detail::sve_ptrue<T>(), neq_result);
+            const auto neq_result = sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
+            return svnot_z(detail_sve::sve_ptrue<T>(), neq_result);
         }
 
         // neq
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> neq(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmpne(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmpne(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> neq(batch_bool<T, A> const& lhs, batch_bool<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return sveor_z(detail::sve_ptrue<T>(), lhs, rhs);
+            return sveor_z(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // lt
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> lt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmplt(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmplt(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // le
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> le(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmple(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmple(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // gt
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmpgt(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmpgt(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         // ge
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> ge(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
-            return svcmpge(detail::sve_ptrue<T>(), lhs, rhs);
+            return svcmpge(detail_sve::sve_ptrue<T>(), lhs, rhs);
         }
 
         /***************
@@ -824,7 +832,7 @@ namespace xsimd
          ***************/
 
         //  rotate_left
-        template <size_t N, class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> rotate_left(batch<T, A> const& a, requires_arch<sve>) noexcept
         {
             return svext(a, a, N);
@@ -869,7 +877,7 @@ namespace xsimd
          *************/
 
         // extract_pair
-        namespace detail
+        namespace detail_sve
         {
             template <class A, class T>
             XSIMD_INLINE batch<T, A> sve_extract_pair(batch<T, A> const&, batch<T, A> const& /*rhs*/, std::size_t, std::index_sequence<>) noexcept
@@ -905,19 +913,19 @@ namespace xsimd
             }
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> extract_pair(batch<T, A> const& lhs, batch<T, A> const& rhs, std::size_t n, requires_arch<sve>) noexcept
         {
             constexpr std::size_t size = batch<T, A>::size;
             assert(n < size && "index in bounds");
-            return detail::sve_extract_pair_impl(lhs, rhs, n, std::make_index_sequence<size>());
+            return detail_sve::sve_extract_pair_impl(lhs, rhs, n, std::make_index_sequence<size>());
         }
 
         // select
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> select(batch_bool<T, A> const& cond, batch<T, A> const& a, batch<T, A> const& b, requires_arch<sve>) noexcept
         {
-            return svsel(cond, static_cast<detail::sve_sizeless_t<T>>(a), static_cast<detail::sve_sizeless_t<T>>(b));
+            return svsel(cond, static_cast<detail_sve::sve_sizeless_t<T>>(a), static_cast<detail_sve::sve_sizeless_t<T>>(b));
         }
 
         template <class A, class T, bool... b>
@@ -927,14 +935,14 @@ namespace xsimd
         }
 
         // zip_lo
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> zip_lo(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svzip1(lhs, rhs);
         }
 
         // zip_hi
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> zip_hi(batch<T, A> const& lhs, batch<T, A> const& rhs, requires_arch<sve>) noexcept
         {
             return svzip2(lhs, rhs);
@@ -945,21 +953,21 @@ namespace xsimd
          *****************************/
 
         // rsqrt
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> rsqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svrsqrte(arg);
         }
 
         // sqrt
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> sqrt(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svsqrt_x(detail::sve_ptrue<T>(), arg);
+            return svsqrt_x(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // reciprocal
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> reciprocal(const batch<T, A>& arg, requires_arch<sve>) noexcept
         {
             return svrecpe(arg);
@@ -970,42 +978,42 @@ namespace xsimd
          ******************************/
 
         // fast_cast
-        namespace detail
+        namespace detail_sve
         {
             template <class A, class T, detail::enable_sized_integral_t<T, 4> = 0>
             XSIMD_INLINE batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_f32_x(detail::sve_ptrue<T>(), arg);
+                return svcvt_f32_x(detail_sve::sve_ptrue<T>(), arg);
             }
 
             template <class A, class T, detail::enable_sized_integral_t<T, 8> = 0>
             XSIMD_INLINE batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_f64_x(detail::sve_ptrue<T>(), arg);
+                return svcvt_f64_x(detail_sve::sve_ptrue<T>(), arg);
             }
 
             template <class A>
             XSIMD_INLINE batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_s32_x(detail::sve_ptrue<float>(), arg);
+                return svcvt_s32_x(detail_sve::sve_ptrue<float>(), arg);
             }
 
             template <class A>
             XSIMD_INLINE batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_u32_x(detail::sve_ptrue<float>(), arg);
+                return svcvt_u32_x(detail_sve::sve_ptrue<float>(), arg);
             }
 
             template <class A>
             XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_s64_x(detail::sve_ptrue<double>(), arg);
+                return svcvt_s64_x(detail_sve::sve_ptrue<double>(), arg);
             }
 
             template <class A>
             XSIMD_INLINE batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
             {
-                return svcvt_u64_x(detail::sve_ptrue<double>(), arg);
+                return svcvt_u64_x(detail_sve::sve_ptrue<double>(), arg);
             }
         }
 
@@ -1017,28 +1025,28 @@ namespace xsimd
         template <class A, class T, class... Args>
         XSIMD_INLINE batch<T, A> set(batch<T, A> const&, requires_arch<sve>, Args... args) noexcept
         {
-            return detail::sve_vector_type<T> { args... };
+            return detail_sve::sve_vector_type<T> { args... };
         }
 
         template <class A, class T, class... Args>
         XSIMD_INLINE batch<std::complex<T>, A> set(batch<std::complex<T>, A> const&, requires_arch<sve>,
                                                    Args... args_complex) noexcept
         {
-            return batch<std::complex<T>>(detail::sve_vector_type<T> { args_complex.real()... },
-                                          detail::sve_vector_type<T> { args_complex.imag()... });
+            return batch<std::complex<T>>(detail_sve::sve_vector_type<T> { args_complex.real()... },
+                                          detail_sve::sve_vector_type<T> { args_complex.imag()... });
         }
 
         template <class A, class T, class... Args>
         XSIMD_INLINE batch_bool<T, A> set(batch_bool<T, A> const&, requires_arch<sve>, Args... args) noexcept
         {
             using U = as_unsigned_integer_t<T>;
-            const auto values = detail::sve_vector_type<U> { static_cast<U>(args)... };
+            const auto values = detail_sve::sve_vector_type<U> { static_cast<U>(args)... };
             const auto zero = broadcast<A, U>(static_cast<U>(0), sve {});
-            return svcmpne(detail::sve_ptrue<T>(), values, zero);
+            return svcmpne(detail_sve::sve_ptrue<T>(), values, zero);
         }
 
         // insert
-        namespace detail
+        namespace detail_sve
         {
             // generate index sequence (iota)
             XSIMD_INLINE svuint8_t sve_iota_impl(index<1>) noexcept { return svindex_u8(0, 1); }
@@ -1048,115 +1056,115 @@ namespace xsimd
 
             template <class T, class V = sve_vector_type<as_unsigned_integer_t<T>>>
             XSIMD_INLINE V sve_iota() noexcept { return sve_iota_impl(index<sizeof(T)> {}); }
-        } // namespace detail
+        } // namespace detail_sve
 
-        template <class A, class T, size_t I, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, size_t I, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> insert(batch<T, A> const& arg, T val, index<I>, requires_arch<sve>) noexcept
         {
             // create a predicate with only the I-th lane activated
-            const auto iota = detail::sve_iota<T>();
-            const auto index_predicate = svcmpeq(detail::sve_ptrue<T>(), iota, static_cast<as_unsigned_integer_t<T>>(I));
-            return svsel(index_predicate, static_cast<detail::sve_sizeless_t<T>>(broadcast<A, T>(val, sve {})), static_cast<detail::sve_sizeless_t<T>>(arg));
+            const auto iota = detail_sve::sve_iota<T>();
+            const auto index_predicate = svcmpeq(detail_sve::sve_ptrue<T>(), iota, static_cast<as_unsigned_integer_t<T>>(I));
+            return svsel(index_predicate, static_cast<detail_sve::sve_sizeless_t<T>>(broadcast<A, T>(val, sve {})), static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
         // first
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE T first(batch<T, A> const& self, requires_arch<sve>) noexcept
         {
             return self.data[0];
         }
 
         // all
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE bool all(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return detail::sve_pcount<T>(arg) == batch_bool<T, A>::size;
+            return detail_sve::sve_pcount<T>(arg) == batch_bool<T, A>::size;
         }
 
         // any
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE bool any(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return svptest_any(arg, arg);
         }
 
         // bitwise_cast
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 1> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 1> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u8(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_u8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 1> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 1> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_s8(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_s8(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 2> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 2> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u16(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_u16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 2> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 2> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_s16(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_s16(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 4> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 4> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u32(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_u32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 4> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 4> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_s32(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_s32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 8> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_unsigned_t<R, 8> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_u64(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_u64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, class R, detail::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 8> = 0>
+        template <class A, class T, class R, detail_sve::sve_enable_all_t<T> = 0, detail::enable_sized_signed_t<R, 8> = 0>
         XSIMD_INLINE batch<R, A> bitwise_cast(batch<T, A> const& arg, batch<R, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_s64(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_s64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<float, A> bitwise_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_f32(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_f32(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<double, A> bitwise_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
         {
-            return svreinterpret_f64(static_cast<detail::sve_sizeless_t<T>>(arg));
+            return svreinterpret_f64(static_cast<detail_sve::sve_sizeless_t<T>>(arg));
         }
 
         // batch_bool_cast
-        template <class A, class T_out, class T_in, detail::sve_enable_all_t<T_in> = 0>
+        template <class A, class T_out, class T_in, detail_sve::sve_enable_all_t<T_in> = 0>
         XSIMD_INLINE batch_bool<T_out, A> batch_bool_cast(batch_bool<T_in, A> const& arg, batch_bool<T_out, A> const&, requires_arch<sve>) noexcept
         {
             return arg.data;
         }
 
         // from_bool
-        template <class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> from_bool(batch_bool<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return select(arg, batch<T, A>(1), batch<T, A>(0));
         }
 
         // slide_left
-        namespace detail
+        namespace detail_sve
         {
             template <size_t N>
             struct sve_slider_left
@@ -1181,16 +1189,16 @@ namespace xsimd
                     return arg;
                 }
             };
-        } // namespace detail
+        } // namespace detail_sve
 
-        template <size_t N, class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> slide_left(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return detail::sve_slider_left<N>()(arg);
+            return detail_sve::sve_slider_left<N>()(arg);
         }
 
         // slide_right
-        namespace detail
+        namespace detail_sve
         {
             template <size_t N>
             struct sve_slider_right
@@ -1215,50 +1223,51 @@ namespace xsimd
                     return batch<T, A> {};
                 }
             };
-        } // namespace detail
+        } // namespace detail_sve
 
-        template <size_t N, class A, class T, detail::sve_enable_all_t<T> = 0>
+        template <size_t N, class A, class T, detail_sve::sve_enable_all_t<T> = 0>
         XSIMD_INLINE batch<T, A> slide_right(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return detail::sve_slider_right<N>()(arg);
+            return detail_sve::sve_slider_right<N>()(arg);
         }
 
         // isnan
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch_bool<T, A> isnan(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
             return !(arg == arg);
         }
 
         // nearbyint
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> nearbyint(batch<T, A> const& arg, requires_arch<sve>) noexcept
         {
-            return svrintx_x(detail::sve_ptrue<T>(), arg);
+            return svrintx_x(detail_sve::sve_ptrue<T>(), arg);
         }
 
         // nearbyint_as_int
         template <class A>
         XSIMD_INLINE batch<int32_t, A> nearbyint_as_int(batch<float, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto nearest = svrintx_x(detail::sve_ptrue<float>(), arg);
-            return svcvt_s32_x(detail::sve_ptrue<float>(), nearest);
+            const auto nearest = svrintx_x(detail_sve::sve_ptrue<float>(), arg);
+            return svcvt_s32_x(detail_sve::sve_ptrue<float>(), nearest);
         }
 
         template <class A>
         XSIMD_INLINE batch<int64_t, A> nearbyint_as_int(batch<double, A> const& arg, requires_arch<sve>) noexcept
         {
-            const auto nearest = svrintx_x(detail::sve_ptrue<double>(), arg);
-            return svcvt_s64_x(detail::sve_ptrue<double>(), nearest);
+            const auto nearest = svrintx_x(detail_sve::sve_ptrue<double>(), arg);
+            return svcvt_s64_x(detail_sve::sve_ptrue<double>(), nearest);
         }
 
         // ldexp
-        template <class A, class T, detail::sve_enable_floating_point_t<T> = 0>
+        template <class A, class T, detail_sve::sve_enable_floating_point_t<T> = 0>
         XSIMD_INLINE batch<T, A> ldexp(const batch<T, A>& x, const batch<as_integer_t<T>, A>& exp, requires_arch<sve>) noexcept
         {
-            return svscale_x(detail::sve_ptrue<T>(), x, exp);
+            return svscale_x(detail_sve::sve_ptrue<T>(), x, exp);
         }
 
+    } // namespace XSIMD_SVE_NAMESPACE
     } // namespace kernel
 } // namespace xsimd
 

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -37,18 +37,18 @@ namespace xsimd
             XSIMD_INLINE svbool_t sve_ptrue_impl(index<8>) noexcept { return svptrue_b64(); }
 
             template <class T>
-            svbool_t sve_ptrue() noexcept { return sve_ptrue_impl(index<sizeof(T)> {}); }
+            XSIMD_INLINE svbool_t sve_ptrue() noexcept { return sve_ptrue_impl(index<sizeof(T)> {}); }
 
             // predicate loading
             template <bool M0, bool M1>
-            svbool_t sve_pmask() noexcept { return svdupq_b64(M0, M1); }
+            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b64(M0, M1); }
             template <bool M0, bool M1, bool M2, bool M3>
-            svbool_t sve_pmask() noexcept { return svdupq_b32(M0, M1, M2, M3); }
+            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b32(M0, M1, M2, M3); }
             template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7>
-            svbool_t sve_pmask() noexcept { return svdupq_b16(M0, M1, M2, M3, M4, M5, M6, M7); }
+            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b16(M0, M1, M2, M3, M4, M5, M6, M7); }
             template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7,
                       bool M8, bool M9, bool M10, bool M11, bool M12, bool M13, bool M14, bool M15>
-            svbool_t sve_pmask() noexcept { return svdupq_b8(M0, M1, M2, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15); }
+            XSIMD_INLINE svbool_t sve_pmask() noexcept { return svdupq_b8(M0, M1, M2, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15); }
 
             // count active lanes in a predicate
             XSIMD_INLINE uint64_t sve_pcount_impl(svbool_t p, index<1>) noexcept { return svcntp_b8(p, p); }

--- a/include/xsimd/config/xsimd_cpuid.hpp
+++ b/include/xsimd/config/xsimd_cpuid.hpp
@@ -14,7 +14,7 @@
 
 #include "../types/xsimd_all_registers.hpp"
 #include "./xsimd_cpu_features.hpp"
-#include "./xsimd_inline.hpp"
+#include "./xsimd_macros.hpp"
 
 namespace xsimd
 {

--- a/include/xsimd/config/xsimd_macros.hpp
+++ b/include/xsimd/config/xsimd_macros.hpp
@@ -9,8 +9,8 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#ifndef XSIMD_INLINE_HPP
-#define XSIMD_INLINE_HPP
+#ifndef XSIMD_MACROS_HPP
+#define XSIMD_MACROS_HPP
 
 #if defined(__VEC__)
 #define XSIMD_INLINE inline
@@ -25,5 +25,8 @@
 #else
 #define XSIMD_INLINE inline
 #endif
+
+#define XSIMD_CONCAT_INNER(a, b) a##b
+#define XSIMD_CONCAT(a, b) XSIMD_CONCAT_INNER(a, b)
 
 #endif

--- a/include/xsimd/types/xsimd_register.hpp
+++ b/include/xsimd/types/xsimd_register.hpp
@@ -14,7 +14,7 @@
 
 #include <type_traits>
 
-#include "../config/xsimd_inline.hpp"
+#include "../config/xsimd_macros.hpp"
 
 namespace xsimd
 {

--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -57,7 +57,7 @@
 #endif
 
 #include "config/xsimd_config.hpp"
-#include "config/xsimd_inline.hpp"
+#include "config/xsimd_macros.hpp"
 
 #include "arch/xsimd_scalar.hpp"
 #include "memory/xsimd_aligned_allocator.hpp"

--- a/test/test_power.cpp
+++ b/test/test_power.cpp
@@ -13,7 +13,6 @@
 #ifndef XSIMD_NO_SUPPORTED_ARCHITECTURE
 
 #include "test_utils.hpp"
-#include <iostream>
 
 template <class B>
 struct power_test


### PR DESCRIPTION
Bug found when adding dynamic dispatch with both SVE128 and SVE256.
The issue is found was on:

```cpp
svbool_t sve_ptrue() noexcept { return sve_ptrue_impl(index<sizeof(T)> {}); }
```

Without `XSIMD_INLINE`, in debug mode, two inline symbols were created and the linker picked
one (the one with `-msve-vector-length=16`) and applied it everywhere.

What changed:
- `xsimd_inline.hpp` was renamed `xsimd_macros.hpp` to extend it with other macros required here.
- This PR applied `XSIMD_INLINE` liberally, but because this is fragile, it also adds an
`inline namespace` to SVE to prevent future (and unfound) violations.
- Working with `inline namespace` is more tricky than I thought, so I had to rename all
`detail` to `detail_sve` inside the header to avoid confusion.

Notes:
- ⚠️ This is an ABI break
- I haven't yet applied the formatter as doing so will make it hard to review (I'll do
  it right before merging when there is a approval).
- I will send a similar PR for RVV which potentailly suffers from the same issue.

@serge-sans-paille @JohanMabille 