### PR TITLE
Factor macros (avoid cyclic symbols requirements)

### DIFF
--- a/include/xsimd/arch/xsimd_rvv.hpp
+++ b/include/xsimd/arch/xsimd_rvv.hpp
@@ -13,9 +13,10 @@
 #include <complex>
 #include <type_traits>
 
+#include "../config/xsimd_macros.hpp"
 #include "../types/xsimd_batch_constant.hpp"
 #include "../types/xsimd_rvv_register.hpp"
-#include "xsimd_constants.hpp"
+#include "./xsimd_constants.hpp"
 
 // This set of macros allows the synthesis of identifiers using a template and
 // variable macro arguments.  A single template can then be used by multiple
@@ -24,11 +25,9 @@
 //
 // First some logic to paste text together...
 //
-#define XSIMD_RVV_JOIN_(x, y) x##y
-#define XSIMD_RVV_JOIN(x, y) XSIMD_RVV_JOIN_(x, y)
-#define XSIMD_RVV_PREFIX_T(T, S, then) XSIMD_RVV_JOIN(T, then)
-#define XSIMD_RVV_PREFIX_S(T, S, then) XSIMD_RVV_JOIN(S, then)
-#define XSIMD_RVV_PREFIX_M(T, S, then) XSIMD_RVV_JOIN(m1, then)
+#define XSIMD_RVV_PREFIX_T(T, S, then) XSIMD_CONCAT(T, then)
+#define XSIMD_RVV_PREFIX_S(T, S, then) XSIMD_CONCAT(S, then)
+#define XSIMD_RVV_PREFIX_M(T, S, then) XSIMD_CONCAT(m1, then)
 #define XSIMD_RVV_PREFIX(T, S, then) then
 //
 // XSIMD_RVV_IDENTIFIER accepts type and size parameters, and a template for
@@ -39,15 +38,15 @@
 // join two or more variables together.
 //
 #define XSIMD_RVV_IDENTIFIER9(T, S, t, ...) t
-#define XSIMD_RVV_IDENTIFIER8(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER9(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER7(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER8(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER6(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER7(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER5(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER6(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER4(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER5(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER3(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER4(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER2(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER3(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER1(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER2(T, S, __VA_ARGS__)))
-#define XSIMD_RVV_IDENTIFIER0(T, S, t, p, ...) XSIMD_RVV_JOIN(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER1(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER8(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER9(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER7(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER8(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER6(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER7(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER5(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER6(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER4(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER5(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER3(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER4(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER2(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER3(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER1(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER2(T, S, __VA_ARGS__)))
+#define XSIMD_RVV_IDENTIFIER0(T, S, t, p, ...) XSIMD_CONCAT(t, XSIMD_RVV_PREFIX##p(T, S, XSIMD_RVV_IDENTIFIER1(T, S, __VA_ARGS__)))
 //
 // UNBRACKET and REPARSE force the preprocessor to handle expansion in a
 // specific order.  XSIMD_RVV_UNBRACKET strips the parentheses from the template

--- a/include/xsimd/config/xsimd_macros.hpp
+++ b/include/xsimd/config/xsimd_macros.hpp
@@ -29,4 +29,48 @@
 #define XSIMD_CONCAT_INNER(a, b) a##b
 #define XSIMD_CONCAT(a, b) XSIMD_CONCAT_INNER(a, b)
 
+#if defined(__FAST_MATH__)
+#define XSIMD_NO_DENORMALS
+#define XSIMD_NO_INFINITIES
+#define XSIMD_NO_NANS
+#endif
+
+#if defined(__has_cpp_attribute)
+// if this check passes, then the compiler supports feature test macros
+#if __has_cpp_attribute(nodiscard) >= 201603L
+// if this check passes, then the compiler supports [[nodiscard]] without a message
+#define XSIMD_NO_DISCARD [[nodiscard]]
+#endif
+#endif
+
+#if !defined(XSIMD_NO_DISCARD) && __cplusplus >= 201703L
+// this means that the previous tests failed, but we are using C++17 or higher
+#define XSIMD_NO_DISCARD [[nodiscard]]
+#endif
+
+#if !defined(XSIMD_NO_DISCARD) && (defined(__GNUC__) || defined(__clang__))
+// this means that the previous checks failed, but we are using GCC or Clang
+#define XSIMD_NO_DISCARD __attribute__((warn_unused_result))
+#endif
+
+#if !defined(XSIMD_NO_DISCARD)
+// this means that all the previous checks failed, so we fallback to doing nothing
+#define XSIMD_NO_DISCARD
+#endif
+
+#ifdef __cpp_if_constexpr
+// this means that the compiler supports the `if constexpr` construct
+#define XSIMD_IF_CONSTEXPR if constexpr
+#endif
+
+#if !defined(XSIMD_IF_CONSTEXPR) && __cplusplus >= 201703L
+// this means that the previous test failed, but we are using C++17 or higher
+#define XSIMD_IF_CONSTEXPR if constexpr
+#endif
+
+#if !defined(XSIMD_IF_CONSTEXPR)
+// this means that all the previous checks failed, so we fallback to a normal `if`
+#define XSIMD_IF_CONSTEXPR if
+#endif
+
 #endif

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -16,6 +16,7 @@
 #include <complex>
 
 #include "../config/xsimd_arch.hpp"
+#include "../config/xsimd_macros.hpp"
 #include "../memory/xsimd_alignment.hpp"
 #include "./xsimd_utils.hpp"
 

--- a/include/xsimd/xsimd.hpp
+++ b/include/xsimd/xsimd.hpp
@@ -12,50 +12,6 @@
 #ifndef XSIMD_HPP
 #define XSIMD_HPP
 
-#if defined(__FAST_MATH__)
-#define XSIMD_NO_DENORMALS
-#define XSIMD_NO_INFINITIES
-#define XSIMD_NO_NANS
-#endif
-
-#if defined(__has_cpp_attribute)
-// if this check passes, then the compiler supports feature test macros
-#if __has_cpp_attribute(nodiscard) >= 201603L
-// if this check passes, then the compiler supports [[nodiscard]] without a message
-#define XSIMD_NO_DISCARD [[nodiscard]]
-#endif
-#endif
-
-#if !defined(XSIMD_NO_DISCARD) && __cplusplus >= 201703L
-// this means that the previous tests failed, but we are using C++17 or higher
-#define XSIMD_NO_DISCARD [[nodiscard]]
-#endif
-
-#if !defined(XSIMD_NO_DISCARD) && (defined(__GNUC__) || defined(__clang__))
-// this means that the previous checks failed, but we are using GCC or Clang
-#define XSIMD_NO_DISCARD __attribute__((warn_unused_result))
-#endif
-
-#if !defined(XSIMD_NO_DISCARD)
-// this means that all the previous checks failed, so we fallback to doing nothing
-#define XSIMD_NO_DISCARD
-#endif
-
-#ifdef __cpp_if_constexpr
-// this means that the compiler supports the `if constexpr` construct
-#define XSIMD_IF_CONSTEXPR if constexpr
-#endif
-
-#if !defined(XSIMD_IF_CONSTEXPR) && __cplusplus >= 201703L
-// this means that the previous test failed, but we are using C++17 or higher
-#define XSIMD_IF_CONSTEXPR if constexpr
-#endif
-
-#if !defined(XSIMD_IF_CONSTEXPR)
-// this means that all the previous checks failed, so we fallback to a normal `if`
-#define XSIMD_IF_CONSTEXPR if
-#endif
-
 #include "config/xsimd_config.hpp"
 #include "config/xsimd_macros.hpp"
 


### PR DESCRIPTION
- **Use XSIMD_CONCAT**
- **Move macros to macro header**
