### PR TITLE
Fix VSX rounding

### DIFF
--- a/include/xsimd/arch/xsimd_vsx.hpp
+++ b/include/xsimd/arch/xsimd_vsx.hpp
@@ -605,8 +605,18 @@ namespace xsimd
         }
 
         // round
-        template <class A, class T, class = std::enable_if_t<std::is_floating_point<T>::value>>
-        XSIMD_INLINE batch<T, A> round(batch<T, A> const& self, requires_arch<vsx>) noexcept
+
+        // vec_round exists also for float vectors but is mapped to vrfin instruction which uses the wrong rounding mode
+#if defined __has_builtin && __has_builtin(__builtin_vsx_xvrspi)
+        template <class A>
+        XSIMD_INLINE batch<float, A> round(batch<float, A> const& self, requires_arch<vsx>) noexcept
+        {
+            return __builtin_vsx_xvrspi(self.data);
+        }
+#endif
+        // For double vectors vec_round uses xvrdpi which does the right thing
+        template <class A>
+        XSIMD_INLINE batch<double, A> round(batch<double, A> const& self, requires_arch<vsx>) noexcept
         {
             return vec_round(self.data);
         }


### PR DESCRIPTION
This fixes a problem with rounding in the VSX support revealed by #1318 

vec_round on Power unfortunately behaves inconsistently across different data types:

For float vectors vec_round is implemented by vrfin. vrfin uses "round to nearest with ties to even" which does NOT match the std::round rounding mode (ties away form zero)

For double vectors however, vec_round is implemented by xvrdpi which uses the std::round rounding mode.

So far this went unnoticed because test_rounding only tested the first four input values for float vectors. For these four values the rounding mode difference doesn't change anything. test_rounding fails with #1318 and with this PR it is clean again on IBM Power. Tested on a Power10 system.