### PR TITLE
IBM Z (s390x) fixes

### DIFF
--- a/.github/workflows/cross-s390x.yml
+++ b/.github/workflows/cross-s390x.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - { platform: 's390x',     dir: 's390x-linux-gnu',   flags: '-mzvector -march=z14', full: 'OFF' }
+          - { platform: 's390x',     dir: 's390x-linux-gnu',   full: 'OFF' }
         sys:
           - { compiler: 'gcc',   version: '14' }
     steps:
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Setup
       run: |
-        cmake -B _build \
+        cmake -B build/ \
               -DBUILD_TESTS=ON -DDOWNLOAD_DOCTEST=ON \
               -DBUILD_BENCHMARK=${{ matrix.target.full }} -DBUILD_EXAMPLES=${{ matrix.target.full }} \
               -DCMAKE_BUILD_TYPE=Release \
@@ -42,7 +42,14 @@ jobs:
               -DCMAKE_CXX_FLAGS="${{ matrix.target.flags }}" \
               -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/.github/toolchains/${{ matrix.sys.compiler }}-${{ matrix.target.dir }}.cmake
     - name: Build
-      run: cmake --build _build --verbose -j1
+      run: cmake --build build/ --verbose -j1
     - name: Testing xsimd
-      run: qemu-${{ matrix.target.platform }} -L /usr/${{ matrix.target.dir}}/ ./test/test_xsimd
-      working-directory: ${{ github.workspace }}/_build
+      run: |
+        # Set CPU feature test expectations, 0 is explicit absence of the feature
+        export XSIMD_TEST_CPU_ASSUME_SSE4_2="0"
+        export XSIMD_TEST_CPU_ASSUME_NEON64="0"
+        export XSIMD_TEST_CPU_ASSUME_RVV="0"
+        export XSIMD_TEST_CPU_ASSUME_VSX="0"
+        export XSIMD_TEST_CPU_ASSUME_VXE="1"
+
+        qemu-${{ matrix.target.platform }} -L /usr/${{ matrix.target.dir}}/ ./build/test/test_xsimd

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -124,6 +124,7 @@ jobs:
         export XSIMD_TEST_CPU_ASSUME_NEON64="0"
         export XSIMD_TEST_CPU_ASSUME_RVV="0"
         export XSIMD_TEST_CPU_ASSUME_VSX="0"
+        export XSIMD_TEST_CPU_ASSUME_VXE="0"
         cd _build/test
         if echo '${{ matrix.sys.flags }}' | grep -q 'avx512' ; then
           # Running with emulation, must have AVX512, lower tier are checked by implications in tests

--- a/include/xsimd/config/xsimd_arch.hpp
+++ b/include/xsimd/config/xsimd_arch.hpp
@@ -181,6 +181,7 @@ namespace xsimd
     using arm_arch = typename detail::supported<all_arm_architectures>::type::best;
     using power_arch = typename detail::supported<all_power_architectures>::type::best;
     using riscv_arch = typename detail::supported<all_riscv_architectures>::type::best;
+    using s390x_arch = typename detail::supported<all_s390x_architectures>::type::best;
     using best_arch = typename supported_architectures::best;
 
 #ifdef XSIMD_DEFAULT_ARCH

--- a/include/xsimd/config/xsimd_config.hpp
+++ b/include/xsimd/config/xsimd_config.hpp
@@ -538,7 +538,7 @@
 + * Set to 1 if s390x VXE is available at compile-time, to 0 otherwise.
 + * Float vectors have been introduced with VXE included with IBM z14.
 + */
-#if defined(__VEC__) && __VEC__ == 10305 && __ARCH__ >= 12
+#if defined(__VEC__) && __VEC__ >= 10304 && __ARCH__ >= 12
 #define XSIMD_WITH_VXE 1
 #else
 #define XSIMD_WITH_VXE 0

--- a/include/xsimd/config/xsimd_cpu_features.hpp
+++ b/include/xsimd/config/xsimd_cpu_features.hpp
@@ -37,7 +37,8 @@ namespace xsimd
      * @see xsimd::dispatch
      * @see xsimd::available_architectures
      */
-    class cpu_features : public ppc_cpu_features,
+    class cpu_features : public s390x_cpu_features,
+                         public ppc_cpu_features,
                          public riscv_cpu_features,
                          public arm_cpu_features,
                          public x86_cpu_features

--- a/include/xsimd/config/xsimd_cpuid.hpp
+++ b/include/xsimd/config/xsimd_cpuid.hpp
@@ -81,6 +81,8 @@ namespace xsimd
 
                 const auto cpu = xsimd::cpu_features();
 
+                vxe = cpu.vxe();
+
                 vsx = cpu.vsx();
 
                 rvv128 = cpu.rvv() && (cpu.rvv_size_bytes() >= (128 / 8));

--- a/test/test_cpu_features.cpp
+++ b/test/test_cpu_features.cpp
@@ -176,3 +176,10 @@ TEST_CASE("[cpu_features] ppc features from environment")
 
     CHECK_ENV_FEATURE("XSIMD_TEST_CPU_ASSUME_VSX", cpu.vsx());
 }
+
+TEST_CASE("[cpu_features] IBM Z (s390x) features from environment")
+{
+    xsimd::cpu_features cpu;
+
+    CHECK_ENV_FEATURE("XSIMD_TEST_CPU_ASSUME_VXE", cpu.vxe());
+}


### PR DESCRIPTION
- Fix an issue which so far prevented the full set of tests being compiled in when running in the github workflow.
- While doing this, align cross-s390x.yml with the latest cross-ppc.yml changes.
- Add a cpu_feature testcase for s390x VXE and add a few pieces which were still missing.

Tested with GCC and Clang on IBM z17. Workflow tested locally. It runs all the tests now successfully.
