### PR TITLE
feat: add runtime batch_bool mask overloads for load_masked/store_masked

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install dependencies
-      run: sudo apt install doxygen python3-breathe python3-sphinx-rtd-theme
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen python3-breathe python3-sphinx-rtd-theme
     - name: Render
       run: make -C docs

--- a/docs/source/api/data_transfer.rst
+++ b/docs/source/api/data_transfer.rst
@@ -12,7 +12,7 @@ Data Transfers
 From memory:
 
 +---------------------------------------+----------------------------------------------------+
-| :cpp:func:`load`                      | load values from memory (optionally masked)        |
+| :cpp:func:`load`                      | load values from memory (optionally masked) [#m]_  |
 +---------------------------------------+----------------------------------------------------+
 | :cpp:func:`load_aligned`              | load values from aligned memory                    |
 +---------------------------------------+----------------------------------------------------+
@@ -32,7 +32,7 @@ From a scalar:
 To memory:
 
 +---------------------------------------+----------------------------------------------------+
-| :cpp:func:`store`                     | store values to memory (optionally masked)         |
+| :cpp:func:`store`                     | store values to memory (optionally masked) [#m]_   |
 +---------------------------------------+----------------------------------------------------+
 | :cpp:func:`store_aligned`             | store values to aligned memory                     |
 +---------------------------------------+----------------------------------------------------+
@@ -84,3 +84,11 @@ The following empty types are used for tag dispatching:
 
 .. doxygenstruct:: xsimd::unaligned_mode
    :project: xsimd
+
+.. rubric:: Footnotes
+
+.. [#m] Masked ``load`` / ``store`` come in two flavours. The
+   :cpp:class:`batch_bool_constant` overload encodes the mask in the type and
+   is resolved at compile time. The runtime :cpp:class:`batch_bool` overload
+   accepts a mask computed at runtime. Prefer the compile-time mask whenever
+   the selection is known at compile time.

--- a/docs/source/api/data_transfer.rst
+++ b/docs/source/api/data_transfer.rst
@@ -90,5 +90,5 @@ The following empty types are used for tag dispatching:
 .. [#m] Masked ``load`` / ``store`` come in two flavours. The
    :cpp:class:`batch_bool_constant` overload encodes the mask in the type and
    is resolved at compile time. The runtime :cpp:class:`batch_bool` overload
-   accepts a mask computed at runtime. Prefer the compile-time mask whenever
-   the selection is known at compile time.
+   accepts a mask computed at runtime. For performance reasons, prefer the
+   compile-time mask whenever possible.

--- a/include/xsimd/arch/common/xsimd_common_memory.hpp
+++ b/include/xsimd/arch/common/xsimd_common_memory.hpp
@@ -441,12 +441,8 @@ namespace xsimd
         XSIMD_INLINE batch<T, A>
         load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<common>) noexcept
         {
-            // Per-lane validity contract: only active lanes of ``mem`` are
-            // required to be addressable. An unconditional whole-vector load
-            // would touch inactive lanes and trip ASan/Valgrind on partial
-            // buffers, so stay scalar. Arches with hardware predicated loads
-            // (AVX2 32/64-bit, AVX-512, SVE, RVV) override this with a single
-            // intrinsic that suppresses inactive-lane reads in hardware.
+            // Scalar fallback: only active lanes are touched. Arches with
+            // hardware predicated loads override this.
             constexpr std::size_t size = batch<T, A>::size;
             alignas(A::alignment()) std::array<T, size> buffer;
             for (std::size_t i = 0; i < size; ++i)
@@ -465,12 +461,8 @@ namespace xsimd
         XSIMD_INLINE void
         store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<common>) noexcept
         {
-            // Per-lane validity contract (matches native masked-store APIs):
-            // only active lanes of ``mem`` are touched. A load+select+store
-            // RMW would both read and write inactive bytes, breaking that
-            // contract — stay scalar. Arches with hardware predicated stores
-            // override this with a single intrinsic that suppresses inactive
-            // lanes in hardware.
+            // Scalar fallback: only active lanes are touched. Arches with
+            // hardware predicated stores override this.
             constexpr std::size_t size = batch<T, A>::size;
             alignas(A::alignment()) std::array<T, size> src_buf;
             src.store_aligned(src_buf.data());

--- a/include/xsimd/arch/common/xsimd_common_memory.hpp
+++ b/include/xsimd/arch/common/xsimd_common_memory.hpp
@@ -437,11 +437,46 @@ namespace xsimd
             return detail::load_masked_common(mem, mask, cvt, mode, detail::masked_memory_uses_fp_bitcast<A, T_in, T_out> {});
         }
 
+        template <class A, class T, class Mode>
+        XSIMD_INLINE batch<T, A>
+        load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<common>) noexcept
+        {
+            // Per-lane validity contract: only active lanes of ``mem`` are
+            // required to be addressable. An unconditional whole-vector load
+            // would touch inactive lanes and trip ASan/Valgrind on partial
+            // buffers, so stay scalar. Arches with hardware predicated loads
+            // (AVX2 32/64-bit, AVX-512, SVE, RVV) override this with a single
+            // intrinsic that suppresses inactive-lane reads in hardware.
+            constexpr std::size_t size = batch<T, A>::size;
+            alignas(A::alignment()) std::array<T, size> buffer;
+            for (std::size_t i = 0; i < size; ++i)
+                buffer[i] = mask.get(i) ? mem[i] : T(0);
+            return batch<T, A>::load_aligned(buffer.data());
+        }
+
         template <class A, class T_in, class T_out, bool... Values, class alignment>
         XSIMD_INLINE void
         store_masked(T_out* mem, batch<T_in, A> const& src, batch_bool_constant<T_in, A, Values...> mask, alignment mode, requires_arch<common>) noexcept
         {
             detail::store_masked_common(mem, src, mask, mode, detail::masked_memory_uses_fp_bitcast<A, T_in, T_out> {});
+        }
+
+        template <class A, class T, class Mode>
+        XSIMD_INLINE void
+        store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<common>) noexcept
+        {
+            // Per-lane validity contract (matches native masked-store APIs):
+            // only active lanes of ``mem`` are touched. A load+select+store
+            // RMW would both read and write inactive bytes, breaking that
+            // contract — stay scalar. Arches with hardware predicated stores
+            // override this with a single intrinsic that suppresses inactive
+            // lanes in hardware.
+            constexpr std::size_t size = batch<T, A>::size;
+            alignas(A::alignment()) std::array<T, size> src_buf;
+            src.store_aligned(src_buf.data());
+            for (std::size_t i = 0; i < size; ++i)
+                if (mask.get(i))
+                    mem[i] = src_buf[i];
         }
 
         template <class A, class T_in, class T_out>

--- a/include/xsimd/arch/common/xsimd_common_memory.hpp
+++ b/include/xsimd/arch/common/xsimd_common_memory.hpp
@@ -442,7 +442,7 @@ namespace xsimd
         load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<common>) noexcept
         {
             // Scalar fallback: only active lanes are touched. Arches with
-            // hardware predicated loads override this.
+            // hardware predicated loads should override this.
             constexpr std::size_t size = batch<T, A>::size;
             alignas(A::alignment()) std::array<T, size> buffer;
             for (std::size_t i = 0; i < size; ++i)
@@ -462,7 +462,7 @@ namespace xsimd
         store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<common>) noexcept
         {
             // Scalar fallback: only active lanes are touched. Arches with
-            // hardware predicated stores override this.
+            // hardware predicated stores should override this.
             constexpr std::size_t size = batch<T, A>::size;
             alignas(A::alignment()) std::array<T, size> src_buf;
             src.store_aligned(src_buf.data());

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -987,6 +987,23 @@ namespace xsimd
             }
         }
 
+        // Runtime-mask load for float/double on AVX. Both aligned_mode and
+        // unaligned_mode map to _mm256_maskload_* — the intrinsic does not fault
+        // on masked-off lanes, so partial loads across page boundaries are safe.
+        template <class A, class Mode>
+        XSIMD_INLINE batch<float, A>
+        load_masked(float const* mem, batch_bool<float, A> mask, convert<float>, Mode, requires_arch<avx>) noexcept
+        {
+            return _mm256_maskload_ps(mem, _mm256_castps_si256(mask));
+        }
+
+        template <class A, class Mode>
+        XSIMD_INLINE batch<double, A>
+        load_masked(double const* mem, batch_bool<double, A> mask, convert<double>, Mode, requires_arch<avx>) noexcept
+        {
+            return _mm256_maskload_pd(mem, _mm256_castpd_si256(mask));
+        }
+
         // load_masked (single overload for float/double)
         template <class A, class T, bool... Values, class Mode, class = std::enable_if_t<std::is_floating_point<T>::value>>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx>) noexcept
@@ -1068,6 +1085,22 @@ namespace xsimd
             {
                 detail::maskstore(mem, mask.as_batch_bool(), src);
             }
+        }
+
+        // Runtime-mask store for float/double on AVX. Same fault-suppression
+        // semantics as the masked loads above; alignment mode is irrelevant.
+        template <class A, class Mode>
+        XSIMD_INLINE void
+        store_masked(float* mem, batch<float, A> const& src, batch_bool<float, A> mask, Mode, requires_arch<avx>) noexcept
+        {
+            detail::maskstore(mem, mask, src);
+        }
+
+        template <class A, class Mode>
+        XSIMD_INLINE void
+        store_masked(double* mem, batch<double, A> const& src, batch_bool<double, A> mask, Mode, requires_arch<avx>) noexcept
+        {
+            detail::maskstore(mem, mask, src);
         }
 
         // lt

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -987,9 +987,7 @@ namespace xsimd
             }
         }
 
-        // Runtime-mask load for float/double on AVX. Both aligned_mode and
-        // unaligned_mode map to _mm256_maskload_* — the intrinsic does not fault
-        // on masked-off lanes, so partial loads across page boundaries are safe.
+        // Runtime-mask load (float/double).
         template <class A, class Mode>
         XSIMD_INLINE batch<float, A>
         load_masked(float const* mem, batch_bool<float, A> mask, convert<float>, Mode, requires_arch<avx>) noexcept
@@ -1036,12 +1034,8 @@ namespace xsimd
         // store_masked
         namespace detail
         {
-            // True when batch_bool<T, A> is the legacy VEX vector mask, i.e. it is stored
-            // in the same register as the data (__m256 / __m256d) rather than in an EVEX
-            // k-register (__mmask8) as on the avx512vl architectures. The _mm256_cast*_si256
-            // path below is only well-formed for the vector-mask representation. This names
-            // no architecture — it tests the mask's representation, in the spirit of
-            // detail::masked_memory_uses_fp_bitcast.
+            // True when batch_bool<T, A> shares the data register (__m256/__m256d) rather
+            // than an EVEX k-register; the _mm256_cast*_si256 path below needs the former.
             template <class T, class A>
             using uses_vector_mask = std::is_same<typename batch_bool<T, A>::register_type,
                                                   typename batch<T, A>::register_type>;
@@ -1087,8 +1081,7 @@ namespace xsimd
             }
         }
 
-        // Runtime-mask store for float/double on AVX. Same fault-suppression
-        // semantics as the masked loads above; alignment mode is irrelevant.
+        // Runtime-mask store (float/double).
         template <class A, class Mode>
         XSIMD_INLINE void
         store_masked(float* mem, batch<float, A> const& src, batch_bool<float, A> mask, Mode, requires_arch<avx>) noexcept

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1002,6 +1002,21 @@ namespace xsimd
             return _mm256_maskload_pd(mem, _mm256_castpd_si256(mask));
         }
 
+        // 4/8-byte ints: bitcast to same-width float, reuse the vmaskmov path.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
+        load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                return bitwise_cast<T>(batch<float, A>(_mm256_maskload_ps(reinterpret_cast<float const*>(mem), __m256i(mask))));
+            }
+            else
+            {
+                return bitwise_cast<T>(batch<double, A>(_mm256_maskload_pd(reinterpret_cast<double const*>(mem), __m256i(mask))));
+            }
+        }
+
         // load_masked (single overload for float/double)
         template <class A, class T, bool... Values, class Mode, class = std::enable_if_t<std::is_floating_point<T>::value>>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx>) noexcept
@@ -1094,6 +1109,21 @@ namespace xsimd
         store_masked(double* mem, batch<double, A> const& src, batch_bool<double, A> mask, Mode, requires_arch<avx>) noexcept
         {
             detail::maskstore(mem, mask, src);
+        }
+
+        // 4/8-byte ints: bitcast to same-width float, reuse the vmaskmov path.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
+        store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                _mm256_maskstore_ps(reinterpret_cast<float*>(mem), __m256i(mask), bitwise_cast<float>(src));
+            }
+            else
+            {
+                _mm256_maskstore_pd(reinterpret_cast<double*>(mem), __m256i(mask), bitwise_cast<double>(src));
+            }
         }
 
         // lt

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -126,10 +126,12 @@ namespace xsimd
             {
                 XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
                 {
+                    static_assert(sizeof(int) == 4, "_mm256_maskload_epi32 requires a 4-byte int");
                     return _mm256_maskload_epi32(reinterpret_cast<int const*>(mem), mask);
                 }
                 else
                 {
+                    static_assert(sizeof(long long) == 8, "_mm256_maskload_epi64 requires an 8-byte long long");
                     return _mm256_maskload_epi64(reinterpret_cast<long long const*>(mem), mask);
                 }
             }
@@ -139,10 +141,12 @@ namespace xsimd
             {
                 XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
                 {
+                    static_assert(sizeof(int) == 4, "_mm256_maskstore_epi32 requires a 4-byte int");
                     _mm256_maskstore_epi32(reinterpret_cast<int*>(mem), mask, src);
                 }
                 else
                 {
+                    static_assert(sizeof(long long) == 8, "_mm256_maskstore_epi64 requires an 8-byte long long");
                     _mm256_maskstore_epi64(reinterpret_cast<long long*>(mem), mask, src);
                 }
             }
@@ -153,11 +157,12 @@ namespace xsimd
             }
         }
 
+        // no half-split shortcut for load; forward to runtime
         template <class A, class T, bool... Values, class Mode>
         XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
         load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx2>) noexcept
         {
-            return detail::maskload(mem, mask.as_batch());
+            return load_masked(mem, mask.as_batch_bool(), convert<T> {}, Mode {}, avx2 {});
         }
 
         template <class A, class T, class Mode>

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -174,6 +174,17 @@ namespace xsimd
             return bitwise_cast<uint64_t>(r);
         }
 
+        // Runtime-mask load for 32/64-bit integers on AVX2; narrower widths fall
+        // back to the scalar common path. Aligned and unaligned share the same
+        // intrinsic — masked-off lanes do not fault regardless of alignment.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
+        load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx2>) noexcept
+        {
+            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
+            return detail::maskload(reinterpret_cast<const int_t*>(mem), __m256i(mask));
+        }
+
         // store_masked
         namespace detail
         {
@@ -230,6 +241,17 @@ namespace xsimd
         {
             const auto s64 = bitwise_cast<int64_t>(src);
             store_masked<A>(reinterpret_cast<int64_t*>(mem), s64, batch_bool_constant<int64_t, A, Values...> {}, Mode {}, avx2 {});
+        }
+
+        // Runtime-mask store for 32/64-bit integers on AVX2; narrower widths fall
+        // back to the scalar common path. Same fault-suppression semantics as the
+        // masked loads above; alignment mode is irrelevant.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
+        store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx2>) noexcept
+        {
+            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, int64_t>;
+            detail::maskstore<int_t, A>(reinterpret_cast<int_t*>(mem), __m256i(mask), __m256i(src));
         }
 
         // load_stream

--- a/include/xsimd/arch/xsimd_avx2.hpp
+++ b/include/xsimd/arch/xsimd_avx2.hpp
@@ -117,18 +117,34 @@ namespace xsimd
             }
         }
 
-        // load_masked
-        // AVX2 low-level helpers (operate on raw SIMD registers)
+        // load_masked / store_masked: AVX2 has _mm256_maskload/maskstore_epi{32,64};
+        // 8/16-bit integers fall back to the common scalar path.
         namespace detail
         {
-            XSIMD_INLINE __m256i maskload(const int32_t* mem, __m256i mask) noexcept
+            template <class T>
+            XSIMD_INLINE __m256i maskload(T const* mem, __m256i mask) noexcept
             {
-                return _mm256_maskload_epi32(mem, mask);
+                XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+                {
+                    return _mm256_maskload_epi32(reinterpret_cast<int const*>(mem), mask);
+                }
+                else
+                {
+                    return _mm256_maskload_epi64(reinterpret_cast<long long const*>(mem), mask);
+                }
             }
 
-            XSIMD_INLINE __m256i maskload(const long long* mem, __m256i mask) noexcept
+            template <class T>
+            XSIMD_INLINE void maskstore(T* mem, __m256i mask, __m256i src) noexcept
             {
-                return _mm256_maskload_epi64(reinterpret_cast<long long const*>(mem), mask);
+                XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+                {
+                    _mm256_maskstore_epi32(reinterpret_cast<int*>(mem), mask, src);
+                }
+                else
+                {
+                    _mm256_maskstore_epi64(reinterpret_cast<long long*>(mem), mask, src);
+                }
             }
 
             XSIMD_INLINE __m256i zero_extend(__m128i hi) noexcept
@@ -137,72 +153,22 @@ namespace xsimd
             }
         }
 
-        // single templated implementation for integer masked loads (32/64-bit)
         template <class A, class T, bool... Values, class Mode>
-        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) >= 4), batch<T, A>>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
         load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx2>) noexcept
         {
-            static_assert(sizeof(T) == 4 || sizeof(T) == 8, "load_masked supports only 32/64-bit integers on AVX2");
-            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
-            // Use the raw register-level maskload helpers for the remaining cases.
-            return detail::maskload(reinterpret_cast<const int_t*>(mem), mask.as_batch());
+            return detail::maskload(mem, mask.as_batch());
         }
 
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<int32_t, A> load_masked(int32_t const* mem, batch_bool_constant<int32_t, A, Values...> mask, convert<int32_t>, Mode, requires_arch<avx2>) noexcept
-        {
-            return load_masked<A, int32_t>(mem, mask, convert<int32_t> {}, Mode {}, avx2 {});
-        }
-
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<uint32_t, A> load_masked(uint32_t const* mem, batch_bool_constant<uint32_t, A, Values...>, convert<uint32_t>, Mode, requires_arch<avx2>) noexcept
-        {
-            const auto r = load_masked<A, int32_t>(reinterpret_cast<int32_t const*>(mem), batch_bool_constant<int32_t, A, Values...> {}, convert<int32_t> {}, Mode {}, avx2 {});
-            return bitwise_cast<uint32_t>(r);
-        }
-
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<int64_t, A> load_masked(int64_t const* mem, batch_bool_constant<int64_t, A, Values...> mask, convert<int64_t>, Mode, requires_arch<avx2>) noexcept
-        {
-            return load_masked<A, int64_t>(mem, mask, convert<int64_t> {}, Mode {}, avx2 {});
-        }
-
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<uint64_t, A> load_masked(uint64_t const* mem, batch_bool_constant<uint64_t, A, Values...>, convert<uint64_t>, Mode, requires_arch<avx2>) noexcept
-        {
-            const auto r = load_masked<A, int64_t>(reinterpret_cast<int64_t const*>(mem), batch_bool_constant<int64_t, A, Values...> {}, convert<int64_t> {}, Mode {}, avx2 {});
-            return bitwise_cast<uint64_t>(r);
-        }
-
-        // Runtime-mask load for 32/64-bit integers on AVX2; narrower widths fall
-        // back to the scalar common path. Aligned and unaligned share the same
-        // intrinsic — masked-off lanes do not fault regardless of alignment.
         template <class A, class T, class Mode>
         XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
         load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx2>) noexcept
         {
-            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
-            return detail::maskload(reinterpret_cast<const int_t*>(mem), __m256i(mask));
-        }
-
-        // store_masked
-        namespace detail
-        {
-            template <class T, class A>
-            XSIMD_INLINE void maskstore(int32_t* mem, __m256i mask, __m256i src) noexcept
-            {
-                _mm256_maskstore_epi32(reinterpret_cast<int*>(mem), mask, src);
-            }
-
-            template <class T, class A>
-            XSIMD_INLINE void maskstore(int64_t* mem, __m256i mask, __m256i src) noexcept
-            {
-                _mm256_maskstore_epi64(reinterpret_cast<long long*>(mem), mask, src);
-            }
+            return detail::maskload(mem, __m256i(mask));
         }
 
         template <class A, class T, bool... Values, class Mode,
-                  typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) >= 4)>>
+                  typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
         XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode, requires_arch<avx2>) noexcept
         {
             constexpr size_t lanes_per_half = batch<T, A>::size / 2;
@@ -225,33 +191,15 @@ namespace xsimd
             }
             else
             {
-                detail::maskstore<T, A>(mem, mask.as_batch(), src);
+                detail::maskstore(mem, mask.as_batch(), src);
             }
         }
 
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(uint32_t* mem, batch<uint32_t, A> const& src, batch_bool_constant<uint32_t, A, Values...>, Mode, requires_arch<avx2>) noexcept
-        {
-            const auto s32 = bitwise_cast<int32_t>(src);
-            store_masked<A>(reinterpret_cast<int32_t*>(mem), s32, batch_bool_constant<int32_t, A, Values...> {}, Mode {}, avx2 {});
-        }
-
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(uint64_t* mem, batch<uint64_t, A> const& src, batch_bool_constant<uint64_t, A, Values...>, Mode, requires_arch<avx2>) noexcept
-        {
-            const auto s64 = bitwise_cast<int64_t>(src);
-            store_masked<A>(reinterpret_cast<int64_t*>(mem), s64, batch_bool_constant<int64_t, A, Values...> {}, Mode {}, avx2 {});
-        }
-
-        // Runtime-mask store for 32/64-bit integers on AVX2; narrower widths fall
-        // back to the scalar common path. Same fault-suppression semantics as the
-        // masked loads above; alignment mode is irrelevant.
         template <class A, class T, class Mode>
         XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
         store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx2>) noexcept
         {
-            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, int64_t>;
-            detail::maskstore<int_t, A>(reinterpret_cast<int_t*>(mem), __m256i(mask), __m256i(src));
+            detail::maskstore(mem, __m256i(mask), __m256i(src));
         }
 
         // load_stream

--- a/include/xsimd/arch/xsimd_avx2_128.hpp
+++ b/include/xsimd/arch/xsimd_avx2_128.hpp
@@ -137,6 +137,45 @@ namespace xsimd
             return _mm_maskstore_epi64(reinterpret_cast<long long*>(mem), mask.as_batch(), src);
         }
 
+        // Runtime-mask path for 32/64-bit integers; narrower widths fall back to
+        // the common scalar path. Aligned and unaligned share the same intrinsic
+        // — masked-off lanes do not fault regardless of alignment.
+        namespace detail
+        {
+            XSIMD_INLINE __m128i maskload_128(int32_t const* mem, __m128i mask) noexcept
+            {
+                return _mm_maskload_epi32(mem, mask);
+            }
+            XSIMD_INLINE __m128i maskload_128(long long const* mem, __m128i mask) noexcept
+            {
+                return _mm_maskload_epi64(mem, mask);
+            }
+            XSIMD_INLINE void maskstore_128(int32_t* mem, __m128i mask, __m128i src) noexcept
+            {
+                _mm_maskstore_epi32(mem, mask, src);
+            }
+            XSIMD_INLINE void maskstore_128(long long* mem, __m128i mask, __m128i src) noexcept
+            {
+                _mm_maskstore_epi64(mem, mask, src);
+            }
+        }
+
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
+        load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx2_128>) noexcept
+        {
+            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
+            return detail::maskload_128(reinterpret_cast<int_t const*>(mem), __m128i(mask));
+        }
+
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
+        store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx2_128>) noexcept
+        {
+            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
+            detail::maskstore_128(reinterpret_cast<int_t*>(mem), __m128i(mask), __m128i(src));
+        }
+
         // gather
         template <class T, class A, class U, detail::enable_sized_integral_t<T, 4> = 0, detail::enable_sized_integral_t<U, 4> = 0>
         XSIMD_INLINE batch<T, A> gather(batch<T, A> const&, T const* src, batch<U, A> const& index,

--- a/include/xsimd/arch/xsimd_avx2_128.hpp
+++ b/include/xsimd/arch/xsimd_avx2_128.hpp
@@ -89,91 +89,65 @@ namespace xsimd
             }
         }
 
-        // load_masked — native 128-bit integer masked loads. Tagged on avx2_128
-        // because the vpmaskmov* intrinsics require AVX2; an AVX1-only build routes
-        // integer masked memory through the float path in xsimd_common_memory.hpp.
-        // Any arch with a native masked path provides its own exact-tag overload that
-        // out-ranks this one, so no cross-arch exclusion is needed here.
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<int32_t, A> load_masked(int32_t const* mem, batch_bool_constant<int32_t, A, Values...> mask, convert<int32_t>, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskload_epi32(mem, mask.as_batch());
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<uint32_t, A> load_masked(uint32_t const* mem, batch_bool_constant<uint32_t, A, Values...> mask, convert<uint32_t>, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskload_epi32(reinterpret_cast<int32_t const*>(mem), mask.as_batch());
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<int64_t, A> load_masked(int64_t const* mem, batch_bool_constant<int64_t, A, Values...> mask, convert<int64_t>, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskload_epi64(reinterpret_cast<long long const*>(mem), mask.as_batch());
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<uint64_t, A> load_masked(uint64_t const* mem, batch_bool_constant<uint64_t, A, Values...> mask, convert<uint64_t>, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskload_epi64(reinterpret_cast<long long const*>(mem), mask.as_batch());
-        }
-
-        // store_masked — native 128-bit integer masked stores (see load note above).
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(int32_t* mem, batch<int32_t, A> const& src, batch_bool_constant<int32_t, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskstore_epi32(mem, mask.as_batch(), src);
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(uint32_t* mem, batch<uint32_t, A> const& src, batch_bool_constant<uint32_t, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskstore_epi32(reinterpret_cast<int32_t*>(mem), mask.as_batch(), src);
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(int64_t* mem, batch<int64_t, A> const& src, batch_bool_constant<int64_t, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskstore_epi64(reinterpret_cast<long long*>(mem), mask.as_batch(), src);
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(uint64_t* mem, batch<uint64_t, A> const& src, batch_bool_constant<uint64_t, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
-        {
-            return _mm_maskstore_epi64(reinterpret_cast<long long*>(mem), mask.as_batch(), src);
-        }
-
-        // Runtime-mask path for 32/64-bit integers; narrower widths fall back to
-        // the common scalar path. Aligned and unaligned share the same intrinsic
-        // — masked-off lanes do not fault regardless of alignment.
+        // load_masked / store_masked: native 128-bit integer masked memory.
+        // Tagged on avx2_128 because vpmaskmov* needs AVX2; an AVX1-only build
+        // routes integer masked memory through the float path in
+        // xsimd_common_memory.hpp. 8/16-bit fall back to the common scalar path.
         namespace detail
         {
-            XSIMD_INLINE __m128i maskload_128(int32_t const* mem, __m128i mask) noexcept
+            template <class T>
+            XSIMD_INLINE __m128i maskload_avx2_128(T const* mem, __m128i mask) noexcept
             {
-                return _mm_maskload_epi32(mem, mask);
+                XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+                {
+                    return _mm_maskload_epi32(reinterpret_cast<int const*>(mem), mask);
+                }
+                else
+                {
+                    return _mm_maskload_epi64(reinterpret_cast<long long const*>(mem), mask);
+                }
             }
-            XSIMD_INLINE __m128i maskload_128(long long const* mem, __m128i mask) noexcept
+
+            template <class T>
+            XSIMD_INLINE void maskstore_avx2_128(T* mem, __m128i mask, __m128i src) noexcept
             {
-                return _mm_maskload_epi64(mem, mask);
+                XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+                {
+                    _mm_maskstore_epi32(reinterpret_cast<int*>(mem), mask, src);
+                }
+                else
+                {
+                    _mm_maskstore_epi64(reinterpret_cast<long long*>(mem), mask, src);
+                }
             }
-            XSIMD_INLINE void maskstore_128(int32_t* mem, __m128i mask, __m128i src) noexcept
-            {
-                _mm_maskstore_epi32(mem, mask, src);
-            }
-            XSIMD_INLINE void maskstore_128(long long* mem, __m128i mask, __m128i src) noexcept
-            {
-                _mm_maskstore_epi64(mem, mask, src);
-            }
+        }
+
+        template <class A, class T, bool... Values, class Mode,
+                  typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx2_128>) noexcept
+        {
+            return detail::maskload_avx2_128(mem, mask.as_batch());
+        }
+
+        template <class A, class T, bool... Values, class Mode,
+                  typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
+        {
+            detail::maskstore_avx2_128(mem, mask.as_batch(), __m128i(src));
         }
 
         template <class A, class T, class Mode>
         XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
         load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx2_128>) noexcept
         {
-            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
-            return detail::maskload_128(reinterpret_cast<int_t const*>(mem), __m128i(mask));
+            return detail::maskload_avx2_128(mem, __m128i(mask));
         }
 
         template <class A, class T, class Mode>
         XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
         store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx2_128>) noexcept
         {
-            using int_t = std::conditional_t<sizeof(T) == 4, int32_t, long long>;
-            detail::maskstore_128(reinterpret_cast<int_t*>(mem), __m128i(mask), __m128i(src));
+            detail::maskstore_avx2_128(mem, __m128i(mask), __m128i(src));
         }
 
         // gather

--- a/include/xsimd/arch/xsimd_avx2_128.hpp
+++ b/include/xsimd/arch/xsimd_avx2_128.hpp
@@ -24,6 +24,25 @@ namespace xsimd
     {
         using namespace types;
 
+        // Defined in xsimd_avx512vl_128.hpp (included after this header). The
+        // masked load/store half-fold below forwards to the 128-bit sized-batch
+        // arch, which is avx512vl_128 when the 256-bit one stays in the AVX2
+        // lineage (e.g. avxvnni). That unqualified dependent call resolves by
+        // ordinary lookup here, so the avx512vl_128 overloads must be visible at
+        // this point; declarations only, never instantiated unless AVX512VL is on.
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, V...> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept;
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept;
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept;
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512vl_128>) noexcept;
+
         // select
         template <class A, class T, bool... Values, class = std::enable_if_t<std::is_integral<T>::value>>
         XSIMD_INLINE batch<T, A> select(batch_bool_constant<T, A, Values...> const&, batch<T, A> const& true_br, batch<T, A> const& false_br, requires_arch<avx2_128>) noexcept
@@ -122,18 +141,19 @@ namespace xsimd
             }
         }
 
+        // constant masks gain nothing on a single register; forward to runtime
         template <class A, class T, bool... Values, class Mode,
                   typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx2_128>) noexcept
         {
-            return detail::maskload_avx2_128(mem, mask.as_batch());
+            return load_masked(mem, mask.as_batch_bool(), convert<T> {}, Mode {}, avx2_128 {});
         }
 
         template <class A, class T, bool... Values, class Mode,
                   typename = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
         XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode, requires_arch<avx2_128>) noexcept
         {
-            detail::maskstore_avx2_128(mem, mask.as_batch(), __m128i(src));
+            store_masked(mem, src, mask.as_batch_bool(), Mode {}, avx2_128 {});
         }
 
         template <class A, class T, class Mode>

--- a/include/xsimd/arch/xsimd_avx512bw.hpp
+++ b/include/xsimd/arch/xsimd_avx512bw.hpp
@@ -378,6 +378,53 @@ namespace xsimd
             }
         }
 
+        // load_masked / store_masked: native vmovdqu8 / vmovdqu16 predication for
+        // 8/16-bit, replacing the common scalar fallback. No aligned masked 8/16
+        // intrinsic exists and masked moves never fault, so loadu fits both modes.
+        template <class A, class T, class Mode,
+                  class = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 1 || sizeof(T) == 2)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512bw>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
+            {
+                return _mm512_maskz_loadu_epi8((__mmask64)mask.mask(), mem);
+            }
+            else
+            {
+                return _mm512_maskz_loadu_epi16((__mmask32)mask.mask(), mem);
+            }
+        }
+
+        template <class A, class T, class Mode,
+                  class = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 1 || sizeof(T) == 2)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512bw>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 1)
+            {
+                _mm512_mask_storeu_epi8((void*)mem, (__mmask64)mask.mask(), src);
+            }
+            else
+            {
+                _mm512_mask_storeu_epi16((void*)mem, (__mmask32)mask.mask(), src);
+            }
+        }
+
+        // Constant masks reuse the runtime overloads; as_batch_bool() also avoids
+        // batch_bool_constant::mask() truncating a 64-lane int8 mask to int.
+        template <class A, class T, bool... Values, class Mode,
+                  class = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 1 || sizeof(T) == 2)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx512bw>) noexcept
+        {
+            return load_masked(mem, mask.as_batch_bool(), convert<T> {}, Mode {}, avx512bw {});
+        }
+
+        template <class A, class T, bool... Values, class Mode,
+                  class = std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 1 || sizeof(T) == 2)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode, requires_arch<avx512bw>) noexcept
+        {
+            store_masked(mem, src, mask.as_batch_bool(), Mode {}, avx512bw {});
+        }
+
         // max
         template <class A, class T, class = std::enable_if_t<std::is_integral<T>::value>>
         XSIMD_INLINE batch<T, A> max(batch<T, A> const& self, batch<T, A> const& other, requires_arch<avx512bw>) noexcept

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -356,7 +356,8 @@ namespace xsimd
 
         // Runtime-mask load/store: same native k-register path as the constant
         // overloads above, minus the compile-time half-forwarding. 8/16-bit
-        // elements fall back to the common scalar path.
+        // elements are handled natively by avx512bw (vmovdqu8 / vmovdqu16);
+        // without AVX512BW they fall back to the common scalar path.
         template <class A, class T, class Mode,
                   typename = std::enable_if_t<(sizeof(T) >= 4)>>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512f>) noexcept

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -354,6 +354,23 @@ namespace xsimd
             }
         }
 
+        // Runtime-mask load/store: same native k-register path as the constant
+        // overloads above, minus the compile-time half-forwarding. 8/16-bit
+        // elements fall back to the common scalar path.
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<(sizeof(T) >= 4)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512f>) noexcept
+        {
+            return detail::load_masked(mem, mask.mask(), Mode {});
+        }
+
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<(sizeof(T) >= 4)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512f>) noexcept
+        {
+            detail::store_masked(mem, src, mask.mask(), Mode {});
+        }
+
         // abs
         template <class A>
         XSIMD_INLINE batch<float, A> abs(batch<float, A> const& self, requires_arch<avx512f>) noexcept

--- a/include/xsimd/arch/xsimd_avx512vl_128.hpp
+++ b/include/xsimd/arch/xsimd_avx512vl_128.hpp
@@ -26,6 +26,14 @@ namespace xsimd
 
         namespace detail
         {
+            // Defined in xsimd_avx512f.hpp. This header is included before it so
+            // that avx512f.hpp's masked load/store forwarder can resolve the
+            // avx512vl_128 overloads below by ordinary lookup; forward-declare
+            // the two helpers it borrows from there.
+            XSIMD_INLINE uint32_t morton(uint16_t x, uint16_t y) noexcept;
+            template <size_t N>
+            XSIMD_INLINE unsigned char tobitset(unsigned char unpacked[N]);
+
             template <class A, class T, int Cmp>
             XSIMD_INLINE batch_bool<T, A> compare_int_avx512vl_128(batch<T, A> const& self, batch<T, A> const& other) noexcept
             {
@@ -188,125 +196,111 @@ namespace xsimd
             return _mm_abs_epi64(self);
         }
 
-        // Per-type masked load/store — partial ordering picks these over the
-        // avx2 bridges this arch inherits. Unsigned overloads reinterpret to
-        // the signed EVEX intrinsic.
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<int32_t, A> load_masked(int32_t const* mem, batch_bool_constant<int32_t, A, V...> mask, convert<int32_t>, Mode, requires_arch<avx512vl_128>) noexcept
+        // Masked load/store: native 128-bit EVEX predication shared by the
+        // constant (batch_bool_constant) and runtime (batch_bool) overloads.
+        // Partial ordering picks the avx512vl_128 tag over the avx2_128 bridges
+        // this arch inherits — crucial because the k-register mask cannot feed
+        // the avx2 vpmaskmov path. 8/16-bit elements fall back to the common
+        // scalar path. Unsigned element types reinterpret to the signed EVEX
+        // intrinsic.
+        namespace detail
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            // One core per native register type; signed and unsigned integrals
+            // share an overload (the EVEX intrinsic is sign-agnostic). Mode
+            // selects aligned vs unaligned.
+            template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
+            XSIMD_INLINE __m128i maskload128(T const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_load_epi32(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm_maskz_load_epi32((__mmask8)m, mem);
+                else
+                    return _mm_maskz_loadu_epi32((__mmask8)m, mem);
             }
-            else
+            template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
+            XSIMD_INLINE __m128i maskload128(T const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_loadu_epi32(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm_maskz_load_epi64((__mmask8)m, mem);
+                else
+                    return _mm_maskz_loadu_epi64((__mmask8)m, mem);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<uint32_t, A> load_masked(uint32_t const* mem, batch_bool_constant<uint32_t, A, V...>, convert<uint32_t>, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            return bitwise_cast<uint32_t>(load_masked(reinterpret_cast<int32_t const*>(mem), batch_bool_constant<int32_t, A, V...> {}, convert<int32_t> {}, Mode {}, avx512vl_128 {}));
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<int64_t, A> load_masked(int64_t const* mem, batch_bool_constant<int64_t, A, V...> mask, convert<int64_t>, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            template <class Mode>
+            XSIMD_INLINE __m128 maskload128(float const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_load_epi64(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm_maskz_load_ps((__mmask8)m, mem);
+                else
+                    return _mm_maskz_loadu_ps((__mmask8)m, mem);
             }
-            else
+            template <class Mode>
+            XSIMD_INLINE __m128d maskload128(double const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_loadu_epi64(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm_maskz_load_pd((__mmask8)m, mem);
+                else
+                    return _mm_maskz_loadu_pd((__mmask8)m, mem);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<uint64_t, A> load_masked(uint64_t const* mem, batch_bool_constant<uint64_t, A, V...>, convert<uint64_t>, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            return bitwise_cast<uint64_t>(load_masked(reinterpret_cast<int64_t const*>(mem), batch_bool_constant<int64_t, A, V...> {}, convert<int64_t> {}, Mode {}, avx512vl_128 {}));
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<float, A> load_masked(float const* mem, batch_bool_constant<float, A, V...> mask, convert<float>, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+
+            template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
+            XSIMD_INLINE void maskstore128(T* mem, __m128i src, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_load_ps(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm_mask_store_epi32(mem, (__mmask8)m, src);
+                else
+                    _mm_mask_storeu_epi32(mem, (__mmask8)m, src);
             }
-            else
+            template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
+            XSIMD_INLINE void maskstore128(T* mem, __m128i src, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_loadu_ps(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm_mask_store_epi64(mem, (__mmask8)m, src);
+                else
+                    _mm_mask_storeu_epi64(mem, (__mmask8)m, src);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<double, A> load_masked(double const* mem, batch_bool_constant<double, A, V...> mask, convert<double>, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            template <class Mode>
+            XSIMD_INLINE void maskstore128(float* mem, __m128 src, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_load_pd(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm_mask_store_ps(mem, (__mmask8)m, src);
+                else
+                    _mm_mask_storeu_ps(mem, (__mmask8)m, src);
             }
-            else
+            template <class Mode>
+            XSIMD_INLINE void maskstore128(double* mem, __m128d src, uint64_t m, Mode) noexcept
             {
-                return _mm_maskz_loadu_pd(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm_mask_store_pd(mem, (__mmask8)m, src);
+                else
+                    _mm_mask_storeu_pd(mem, (__mmask8)m, src);
             }
         }
 
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(int32_t* mem, batch<int32_t, A> const& src, batch_bool_constant<int32_t, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, V...> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm_mask_store_epi32(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm_mask_storeu_epi32(mem, mask.mask(), src);
-            }
+            return detail::maskload128(mem, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(uint32_t* mem, batch<uint32_t, A> const& src, batch_bool_constant<uint32_t, A, V...>, Mode, requires_arch<avx512vl_128>) noexcept
+
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept
         {
-            store_masked(reinterpret_cast<int32_t*>(mem), bitwise_cast<int32_t>(src), batch_bool_constant<int32_t, A, V...> {}, Mode {}, avx512vl_128 {});
+            return detail::maskload128(mem, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(int64_t* mem, batch<int64_t, A> const& src, batch_bool_constant<int64_t, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
+
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm_mask_store_epi64(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm_mask_storeu_epi64(mem, mask.mask(), src);
-            }
+            detail::maskstore128(mem, src, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(uint64_t* mem, batch<uint64_t, A> const& src, batch_bool_constant<uint64_t, A, V...>, Mode, requires_arch<avx512vl_128>) noexcept
+
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512vl_128>) noexcept
         {
-            store_masked(reinterpret_cast<int64_t*>(mem), bitwise_cast<int64_t>(src), batch_bool_constant<int64_t, A, V...> {}, Mode {}, avx512vl_128 {});
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(float* mem, batch<float, A> const& src, batch_bool_constant<float, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm_mask_store_ps(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm_mask_storeu_ps(mem, mask.mask(), src);
-            }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(double* mem, batch<double, A> const& src, batch_bool_constant<double, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm_mask_store_pd(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm_mask_storeu_pd(mem, mask.mask(), src);
-            }
+            detail::maskstore128(mem, src, mask.mask(), Mode {});
         }
 
         // max

--- a/include/xsimd/arch/xsimd_avx512vl_128.hpp
+++ b/include/xsimd/arch/xsimd_avx512vl_128.hpp
@@ -212,92 +212,124 @@ namespace xsimd
             XSIMD_INLINE __m128i maskload128(T const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm_maskz_load_epi32((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm_maskz_loadu_epi32((__mmask8)m, mem);
+                }
             }
             template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
             XSIMD_INLINE __m128i maskload128(T const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm_maskz_load_epi64((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm_maskz_loadu_epi64((__mmask8)m, mem);
+                }
             }
             template <class Mode>
             XSIMD_INLINE __m128 maskload128(float const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm_maskz_load_ps((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm_maskz_loadu_ps((__mmask8)m, mem);
+                }
             }
             template <class Mode>
             XSIMD_INLINE __m128d maskload128(double const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm_maskz_load_pd((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm_maskz_loadu_pd((__mmask8)m, mem);
+                }
             }
 
             template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
             XSIMD_INLINE void maskstore128(T* mem, __m128i src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm_mask_store_epi32(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm_mask_storeu_epi32(mem, (__mmask8)m, src);
+                }
             }
             template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
             XSIMD_INLINE void maskstore128(T* mem, __m128i src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm_mask_store_epi64(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm_mask_storeu_epi64(mem, (__mmask8)m, src);
+                }
             }
             template <class Mode>
             XSIMD_INLINE void maskstore128(float* mem, __m128 src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm_mask_store_ps(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm_mask_storeu_ps(mem, (__mmask8)m, src);
+                }
             }
             template <class Mode>
             XSIMD_INLINE void maskstore128(double* mem, __m128d src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm_mask_store_pd(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm_mask_storeu_pd(mem, (__mmask8)m, src);
+                }
             }
         }
 
         template <class A, class T, bool... V, class Mode,
-                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+                  typename>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, V...> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept
         {
             return detail::maskload128(mem, mask.mask(), Mode {});
         }
 
         template <class A, class T, class Mode,
-                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+                  typename>
         XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512vl_128>) noexcept
         {
             return detail::maskload128(mem, mask.mask(), Mode {});
         }
 
         template <class A, class T, bool... V, class Mode,
-                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+                  typename>
         XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, V...> mask, Mode, requires_arch<avx512vl_128>) noexcept
         {
             detail::maskstore128(mem, src, mask.mask(), Mode {});
         }
 
         template <class A, class T, class Mode,
-                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+                  typename>
         XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512vl_128>) noexcept
         {
             detail::maskstore128(mem, src, mask.mask(), Mode {});

--- a/include/xsimd/arch/xsimd_avx512vl_256.hpp
+++ b/include/xsimd/arch/xsimd_avx512vl_256.hpp
@@ -26,6 +26,14 @@ namespace xsimd
 
         namespace detail
         {
+            // Defined in xsimd_avx512f.hpp. This header is included before it so
+            // that avx512f.hpp's masked load/store forwarder can resolve the
+            // avx512vl_256 overloads below by ordinary lookup; forward-declare
+            // the two helpers it borrows from there.
+            XSIMD_INLINE uint32_t morton(uint16_t x, uint16_t y) noexcept;
+            template <size_t N>
+            XSIMD_INLINE unsigned char tobitset(unsigned char unpacked[N]);
+
             template <class A, class T, int Cmp>
             XSIMD_INLINE batch_bool<T, A> compare_int_avx512vl_256(batch<T, A> const& self, batch<T, A> const& other) noexcept
             {
@@ -188,125 +196,110 @@ namespace xsimd
             return _mm256_abs_epi64(self);
         }
 
-        // Per-type masked load/store — partial ordering picks these over the
-        // avx2 bridges this arch inherits. Unsigned overloads reinterpret to
-        // the signed EVEX intrinsic.
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<int32_t, A> load_masked(int32_t const* mem, batch_bool_constant<int32_t, A, V...> mask, convert<int32_t>, Mode, requires_arch<avx512vl_256>) noexcept
+        // Masked load/store: native 256-bit EVEX predication shared by the
+        // constant (batch_bool_constant) and runtime (batch_bool) overloads.
+        // Partial ordering picks the avx512vl_256 tag over the avx2 bridges this
+        // arch inherits — crucial because the k-register mask cannot feed the
+        // avx2 vpmaskmov path. 8/16-bit elements fall back to the common scalar
+        // path. Unsigned element types reinterpret to the signed EVEX intrinsic.
+        namespace detail
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            // One core per native register type; signed and unsigned integrals
+            // share an overload (the EVEX intrinsic is sign-agnostic). Mode
+            // selects aligned vs unaligned.
+            template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
+            XSIMD_INLINE __m256i maskload256(T const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_load_epi32(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm256_maskz_load_epi32((__mmask8)m, mem);
+                else
+                    return _mm256_maskz_loadu_epi32((__mmask8)m, mem);
             }
-            else
+            template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
+            XSIMD_INLINE __m256i maskload256(T const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_loadu_epi32(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm256_maskz_load_epi64((__mmask8)m, mem);
+                else
+                    return _mm256_maskz_loadu_epi64((__mmask8)m, mem);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<uint32_t, A> load_masked(uint32_t const* mem, batch_bool_constant<uint32_t, A, V...>, convert<uint32_t>, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            return bitwise_cast<uint32_t>(load_masked(reinterpret_cast<int32_t const*>(mem), batch_bool_constant<int32_t, A, V...> {}, convert<int32_t> {}, Mode {}, avx512vl_256 {}));
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<int64_t, A> load_masked(int64_t const* mem, batch_bool_constant<int64_t, A, V...> mask, convert<int64_t>, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            template <class Mode>
+            XSIMD_INLINE __m256 maskload256(float const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_load_epi64(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm256_maskz_load_ps((__mmask8)m, mem);
+                else
+                    return _mm256_maskz_loadu_ps((__mmask8)m, mem);
             }
-            else
+            template <class Mode>
+            XSIMD_INLINE __m256d maskload256(double const* mem, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_loadu_epi64(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    return _mm256_maskz_load_pd((__mmask8)m, mem);
+                else
+                    return _mm256_maskz_loadu_pd((__mmask8)m, mem);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<uint64_t, A> load_masked(uint64_t const* mem, batch_bool_constant<uint64_t, A, V...>, convert<uint64_t>, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            return bitwise_cast<uint64_t>(load_masked(reinterpret_cast<int64_t const*>(mem), batch_bool_constant<int64_t, A, V...> {}, convert<int64_t> {}, Mode {}, avx512vl_256 {}));
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<float, A> load_masked(float const* mem, batch_bool_constant<float, A, V...> mask, convert<float>, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+
+            template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
+            XSIMD_INLINE void maskstore256(T* mem, __m256i src, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_load_ps(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm256_mask_store_epi32(mem, (__mmask8)m, src);
+                else
+                    _mm256_mask_storeu_epi32(mem, (__mmask8)m, src);
             }
-            else
+            template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
+            XSIMD_INLINE void maskstore256(T* mem, __m256i src, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_loadu_ps(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm256_mask_store_epi64(mem, (__mmask8)m, src);
+                else
+                    _mm256_mask_storeu_epi64(mem, (__mmask8)m, src);
             }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE batch<double, A> load_masked(double const* mem, batch_bool_constant<double, A, V...> mask, convert<double>, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+            template <class Mode>
+            XSIMD_INLINE void maskstore256(float* mem, __m256 src, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_load_pd(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm256_mask_store_ps(mem, (__mmask8)m, src);
+                else
+                    _mm256_mask_storeu_ps(mem, (__mmask8)m, src);
             }
-            else
+            template <class Mode>
+            XSIMD_INLINE void maskstore256(double* mem, __m256d src, uint64_t m, Mode) noexcept
             {
-                return _mm256_maskz_loadu_pd(mask.mask(), mem);
+                XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                    _mm256_mask_store_pd(mem, (__mmask8)m, src);
+                else
+                    _mm256_mask_storeu_pd(mem, (__mmask8)m, src);
             }
         }
 
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(int32_t* mem, batch<int32_t, A> const& src, batch_bool_constant<int32_t, A, V...> mask, Mode, requires_arch<avx512vl_256>) noexcept
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, V...> mask, convert<T>, Mode, requires_arch<avx512vl_256>) noexcept
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm256_mask_store_epi32(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm256_mask_storeu_epi32(mem, mask.mask(), src);
-            }
+            return detail::maskload256(mem, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(uint32_t* mem, batch<uint32_t, A> const& src, batch_bool_constant<uint32_t, A, V...>, Mode, requires_arch<avx512vl_256>) noexcept
+
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx512vl_256>) noexcept
         {
-            store_masked(reinterpret_cast<int32_t*>(mem), bitwise_cast<int32_t>(src), batch_bool_constant<int32_t, A, V...> {}, Mode {}, avx512vl_256 {});
+            return detail::maskload256(mem, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(int64_t* mem, batch<int64_t, A> const& src, batch_bool_constant<int64_t, A, V...> mask, Mode, requires_arch<avx512vl_256>) noexcept
+
+        template <class A, class T, bool... V, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, V...> mask, Mode, requires_arch<avx512vl_256>) noexcept
         {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm256_mask_store_epi64(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm256_mask_storeu_epi64(mem, mask.mask(), src);
-            }
+            detail::maskstore256(mem, src, mask.mask(), Mode {});
         }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(uint64_t* mem, batch<uint64_t, A> const& src, batch_bool_constant<uint64_t, A, V...>, Mode, requires_arch<avx512vl_256>) noexcept
+
+        template <class A, class T, class Mode,
+                  typename = std::enable_if_t<std::is_arithmetic<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx512vl_256>) noexcept
         {
-            store_masked(reinterpret_cast<int64_t*>(mem), bitwise_cast<int64_t>(src), batch_bool_constant<int64_t, A, V...> {}, Mode {}, avx512vl_256 {});
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(float* mem, batch<float, A> const& src, batch_bool_constant<float, A, V...> mask, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm256_mask_store_ps(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm256_mask_storeu_ps(mem, mask.mask(), src);
-            }
-        }
-        template <class A, bool... V, class Mode>
-        XSIMD_INLINE void store_masked(double* mem, batch<double, A> const& src, batch_bool_constant<double, A, V...> mask, Mode, requires_arch<avx512vl_256>) noexcept
-        {
-            XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
-            {
-                _mm256_mask_store_pd(mem, mask.mask(), src);
-            }
-            else
-            {
-                _mm256_mask_storeu_pd(mem, mask.mask(), src);
-            }
+            detail::maskstore256(mem, src, mask.mask(), Mode {});
         }
 
         // max

--- a/include/xsimd/arch/xsimd_avx512vl_256.hpp
+++ b/include/xsimd/arch/xsimd_avx512vl_256.hpp
@@ -211,66 +211,98 @@ namespace xsimd
             XSIMD_INLINE __m256i maskload256(T const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm256_maskz_load_epi32((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm256_maskz_loadu_epi32((__mmask8)m, mem);
+                }
             }
             template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
             XSIMD_INLINE __m256i maskload256(T const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm256_maskz_load_epi64((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm256_maskz_loadu_epi64((__mmask8)m, mem);
+                }
             }
             template <class Mode>
             XSIMD_INLINE __m256 maskload256(float const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm256_maskz_load_ps((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm256_maskz_loadu_ps((__mmask8)m, mem);
+                }
             }
             template <class Mode>
             XSIMD_INLINE __m256d maskload256(double const* mem, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     return _mm256_maskz_load_pd((__mmask8)m, mem);
+                }
                 else
+                {
                     return _mm256_maskz_loadu_pd((__mmask8)m, mem);
+                }
             }
 
             template <class T, class Mode, enable_sized_integral_t<T, 4> = 0>
             XSIMD_INLINE void maskstore256(T* mem, __m256i src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm256_mask_store_epi32(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm256_mask_storeu_epi32(mem, (__mmask8)m, src);
+                }
             }
             template <class T, class Mode, enable_sized_integral_t<T, 8> = 0>
             XSIMD_INLINE void maskstore256(T* mem, __m256i src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm256_mask_store_epi64(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm256_mask_storeu_epi64(mem, (__mmask8)m, src);
+                }
             }
             template <class Mode>
             XSIMD_INLINE void maskstore256(float* mem, __m256 src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm256_mask_store_ps(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm256_mask_storeu_ps(mem, (__mmask8)m, src);
+                }
             }
             template <class Mode>
             XSIMD_INLINE void maskstore256(double* mem, __m256d src, uint64_t m, Mode) noexcept
             {
                 XSIMD_IF_CONSTEXPR(std::is_same<Mode, aligned_mode>::value)
+                {
                     _mm256_mask_store_pd(mem, (__mmask8)m, src);
+                }
                 else
+                {
                     _mm256_mask_storeu_pd(mem, (__mmask8)m, src);
+                }
             }
         }
 

--- a/include/xsimd/arch/xsimd_avx_128.hpp
+++ b/include/xsimd/arch/xsimd_avx_128.hpp
@@ -115,6 +115,22 @@ namespace xsimd
             return _mm_maskload_pd(mem, mask.as_batch());
         }
 
+        // Runtime-mask load for float/double on AVX-128. Both aligned_mode and
+        // unaligned_mode map to _mm_maskload_* — the intrinsic does not fault
+        // on masked-off lanes, so partial loads across page boundaries are safe.
+        template <class A, class Mode>
+        XSIMD_INLINE batch<float, A>
+        load_masked(float const* mem, batch_bool<float, A> mask, convert<float>, Mode, requires_arch<avx_128>) noexcept
+        {
+            return _mm_maskload_ps(mem, _mm_castps_si128(mask));
+        }
+        template <class A, class Mode>
+        XSIMD_INLINE batch<double, A>
+        load_masked(double const* mem, batch_bool<double, A> mask, convert<double>, Mode, requires_arch<avx_128>) noexcept
+        {
+            return _mm_maskload_pd(mem, _mm_castpd_si128(mask));
+        }
+
         // store_masked
         template <class A, bool... Values, class Mode>
         XSIMD_INLINE void store_masked(float* mem, batch<float, A> const& src, batch_bool_constant<float, A, Values...> mask, Mode, requires_arch<avx_128>) noexcept
@@ -126,6 +142,21 @@ namespace xsimd
         XSIMD_INLINE void store_masked(double* mem, batch<double, A> const& src, batch_bool_constant<double, A, Values...> mask, Mode, requires_arch<avx_128>) noexcept
         {
             return _mm_maskstore_pd(mem, mask.as_batch(), src);
+        }
+
+        // Runtime-mask store for float/double on AVX-128. Same fault-suppression
+        // semantics as the masked loads above; alignment mode is irrelevant.
+        template <class A, class Mode>
+        XSIMD_INLINE void
+        store_masked(float* mem, batch<float, A> const& src, batch_bool<float, A> mask, Mode, requires_arch<avx_128>) noexcept
+        {
+            _mm_maskstore_ps(mem, _mm_castps_si128(mask), src);
+        }
+        template <class A, class Mode>
+        XSIMD_INLINE void
+        store_masked(double* mem, batch<double, A> const& src, batch_bool<double, A> mask, Mode, requires_arch<avx_128>) noexcept
+        {
+            _mm_maskstore_pd(mem, _mm_castpd_si128(mask), src);
         }
 
         // swizzle (dynamic mask)

--- a/include/xsimd/arch/xsimd_avx_128.hpp
+++ b/include/xsimd/arch/xsimd_avx_128.hpp
@@ -115,9 +115,7 @@ namespace xsimd
             return _mm_maskload_pd(mem, mask.as_batch());
         }
 
-        // Runtime-mask load for float/double on AVX-128. Both aligned_mode and
-        // unaligned_mode map to _mm_maskload_* — the intrinsic does not fault
-        // on masked-off lanes, so partial loads across page boundaries are safe.
+        // Runtime-mask load (float/double).
         template <class A, class Mode>
         XSIMD_INLINE batch<float, A>
         load_masked(float const* mem, batch_bool<float, A> mask, convert<float>, Mode, requires_arch<avx_128>) noexcept
@@ -144,8 +142,7 @@ namespace xsimd
             return _mm_maskstore_pd(mem, mask.as_batch(), src);
         }
 
-        // Runtime-mask store for float/double on AVX-128. Same fault-suppression
-        // semantics as the masked loads above; alignment mode is irrelevant.
+        // Runtime-mask store (float/double).
         template <class A, class Mode>
         XSIMD_INLINE void
         store_masked(float* mem, batch<float, A> const& src, batch_bool<float, A> mask, Mode, requires_arch<avx_128>) noexcept

--- a/include/xsimd/arch/xsimd_avx_128.hpp
+++ b/include/xsimd/arch/xsimd_avx_128.hpp
@@ -103,16 +103,11 @@ namespace xsimd
             return _mm_cmp_pd(self, other, _CMP_NEQ_UQ);
         }
 
-        // load_masked
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<float, A> load_masked(float const* mem, batch_bool_constant<float, A, Values...> mask, convert<float>, Mode, requires_arch<avx_128>) noexcept
+        // constant masks gain nothing on a single register; forward to runtime
+        template <class A, class T, bool... Values, class Mode, class = std::enable_if_t<std::is_floating_point<T>::value>>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode, requires_arch<avx_128>) noexcept
         {
-            return _mm_maskload_ps(mem, mask.as_batch());
-        }
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE batch<double, A> load_masked(double const* mem, batch_bool_constant<double, A, Values...> mask, convert<double>, Mode, requires_arch<avx_128>) noexcept
-        {
-            return _mm_maskload_pd(mem, mask.as_batch());
+            return load_masked(mem, mask.as_batch_bool(), convert<T> {}, Mode {}, avx_128 {});
         }
 
         // Runtime-mask load (float/double).
@@ -129,17 +124,25 @@ namespace xsimd
             return _mm_maskload_pd(mem, _mm_castpd_si128(mask));
         }
 
-        // store_masked
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(float* mem, batch<float, A> const& src, batch_bool_constant<float, A, Values...> mask, Mode, requires_arch<avx_128>) noexcept
+        // 4/8-byte ints: bitcast to same-width float, reuse the vmaskmov path.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), batch<T, A>>
+        load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<avx_128>) noexcept
         {
-            return _mm_maskstore_ps(mem, mask.as_batch(), src);
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                return bitwise_cast<T>(batch<float, A>(_mm_maskload_ps(reinterpret_cast<float const*>(mem), __m128i(mask))));
+            }
+            else
+            {
+                return bitwise_cast<T>(batch<double, A>(_mm_maskload_pd(reinterpret_cast<double const*>(mem), __m128i(mask))));
+            }
         }
 
-        template <class A, bool... Values, class Mode>
-        XSIMD_INLINE void store_masked(double* mem, batch<double, A> const& src, batch_bool_constant<double, A, Values...> mask, Mode, requires_arch<avx_128>) noexcept
+        template <class A, class T, bool... Values, class Mode, class = std::enable_if_t<std::is_floating_point<T>::value>>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode, requires_arch<avx_128>) noexcept
         {
-            return _mm_maskstore_pd(mem, mask.as_batch(), src);
+            store_masked(mem, src, mask.as_batch_bool(), Mode {}, avx_128 {});
         }
 
         // Runtime-mask store (float/double).
@@ -154,6 +157,21 @@ namespace xsimd
         store_masked(double* mem, batch<double, A> const& src, batch_bool<double, A> mask, Mode, requires_arch<avx_128>) noexcept
         {
             _mm_maskstore_pd(mem, _mm_castpd_si128(mask), src);
+        }
+
+        // 4/8-byte ints: bitcast to same-width float, reuse the vmaskmov path.
+        template <class A, class T, class Mode>
+        XSIMD_INLINE std::enable_if_t<std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), void>
+        store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<avx_128>) noexcept
+        {
+            XSIMD_IF_CONSTEXPR(sizeof(T) == 4)
+            {
+                _mm_maskstore_ps(reinterpret_cast<float*>(mem), __m128i(mask), bitwise_cast<float>(src));
+            }
+            else
+            {
+                _mm_maskstore_pd(reinterpret_cast<double*>(mem), __m128i(mask), bitwise_cast<double>(src));
+            }
         }
 
         // swizzle (dynamic mask)

--- a/include/xsimd/arch/xsimd_common_fwd.hpp
+++ b/include/xsimd/arch/xsimd_common_fwd.hpp
@@ -88,8 +88,12 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> load(T const* mem, unaligned_mode, requires_arch<A>) noexcept;
         template <class A, class T_in, class T_out, bool... Values, class alignment>
         XSIMD_INLINE batch<T_out, A> load_masked(T_in const* mem, batch_bool_constant<T_out, A, Values...> mask, convert<T_out>, alignment, requires_arch<common>) noexcept;
+        template <class A, class T, class Mode>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<common>) noexcept;
         template <class A, class T_in, class T_out, bool... Values, class alignment>
         XSIMD_INLINE void store_masked(T_out* mem, batch<T_in, A> const& src, batch_bool_constant<T_in, A, Values...> mask, alignment, requires_arch<common>) noexcept;
+        template <class A, class T, class Mode>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<common>) noexcept;
 
         // Forward declarations for pack-level helpers
         namespace detail

--- a/include/xsimd/arch/xsimd_isa.hpp
+++ b/include/xsimd/arch/xsimd_isa.hpp
@@ -74,14 +74,23 @@
 #include "./xsimd_fma3_avx2.hpp"
 #endif
 
+#if XSIMD_WITH_AVX512VL
+// The 128/256-bit AVX512VL sub-arches derive from the AVX2 lineage (not AVX512F)
+// and carry the k-register masked load/store overloads. avx512f.hpp's masked
+// load/store forwards to the 256-bit sized-batch arch (avx512vl_256) via an
+// unqualified dependent call, which clang only resolves through ordinary lookup
+// at the point of definition (ADL cannot reach xsimd::kernel from xsimd-namespace
+// arguments). The sub-arch overloads must therefore be declared beforehand.
+#include "./xsimd_avx512vl_128.hpp"
+#include "./xsimd_avx512vl_256.hpp"
+#endif
+
 #if XSIMD_WITH_AVX512F
 #include "./xsimd_avx512f.hpp"
 #endif
 
 #if XSIMD_WITH_AVX512VL
 #include "./xsimd_avx512vl.hpp"
-#include "./xsimd_avx512vl_128.hpp"
-#include "./xsimd_avx512vl_256.hpp"
 #endif
 
 #if XSIMD_WITH_AVX512DQ

--- a/include/xsimd/arch/xsimd_isa.hpp
+++ b/include/xsimd/arch/xsimd_isa.hpp
@@ -81,16 +81,15 @@
 // unqualified dependent call, which clang only resolves through ordinary lookup
 // at the point of definition (ADL cannot reach xsimd::kernel from xsimd-namespace
 // arguments). The sub-arch overloads must therefore be declared beforehand.
+// clang-format off
 #include "./xsimd_avx512vl_128.hpp"
 #include "./xsimd_avx512vl_256.hpp"
+#include "./xsimd_avx512vl.hpp"
+// clang-format on
 #endif
 
 #if XSIMD_WITH_AVX512F
 #include "./xsimd_avx512f.hpp"
-#endif
-
-#if XSIMD_WITH_AVX512VL
-#include "./xsimd_avx512vl.hpp"
 #endif
 
 #if XSIMD_WITH_AVX512DQ

--- a/include/xsimd/arch/xsimd_rvv.hpp
+++ b/include/xsimd/arch/xsimd_rvv.hpp
@@ -409,6 +409,11 @@ namespace xsimd
         {
             XSIMD_RVV_OVERLOAD(rvvle, (__riscv_vle XSIMD_RVV_S _v_ XSIMD_RVV_TSM), , vec(T const*))
             XSIMD_RVV_OVERLOAD(rvvse, (__riscv_vse XSIMD_RVV_S _v_ XSIMD_RVV_TSM), , void(T*, vec))
+            // Masked load (mask-undisturbed with zero passthrough): inactive lanes read as 0,
+            // no memory access is performed for inactive lanes (page-fault safe).
+            XSIMD_RVV_OVERLOAD(rvvle_mu, (__riscv_vle XSIMD_RVV_S _v_ XSIMD_RVV_TSM _mu), , vec(bvec, vec, T const*))
+            // Masked store: inactive lanes are not written.
+            XSIMD_RVV_OVERLOAD(rvvse_m, (__riscv_vse XSIMD_RVV_S _v_ XSIMD_RVV_TSM _m), , void(bvec, T*, vec))
         }
 
         template <class A, class T, detail::enable_arithmetic_t<T> = 0>
@@ -421,6 +426,16 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> load_unaligned(T const* src, convert<T>, requires_arch<rvv>) noexcept
         {
             return load_aligned<A>(src, convert<T>(), rvv {});
+        }
+
+        // load_masked (runtime mask): native vle*.v vd, (rs1), v0.t with zero-init
+        // passthrough so inactive lanes read as 0, matching xsimd's contract.
+        template <class A, class T, class Mode, detail::enable_arithmetic_t<T> = 0>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<rvv>) noexcept
+        {
+            using proj_t = map_to_sized_type_t<T>;
+            const auto zero = detail_rvv::rvvmv_splat(proj_t {});
+            return detail_rvv::rvvle_mu(mask, zero, reinterpret_cast<proj_t const*>(mem));
         }
 
         // load_complex
@@ -498,6 +513,15 @@ namespace xsimd
         XSIMD_INLINE void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<rvv>) noexcept
         {
             store_aligned<A>(dst, src, rvv {});
+        }
+
+        // store_masked (runtime mask): native vse*.v vd, (rs1), v0.t — inactive lanes
+        // are not written (page-fault safe).
+        template <class A, class T, class Mode, detail::enable_arithmetic_t<T> = 0>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<rvv>) noexcept
+        {
+            using proj_t = map_to_sized_type_t<T>;
+            detail_rvv::rvvse_m(mask, reinterpret_cast<proj_t*>(mem), src);
         }
 
         /******************

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -101,11 +101,28 @@ namespace xsimd
             return load_aligned<A>(src, convert<T>(), sve {});
         }
 
-        // load_masked
-        template <class A, class T, bool... Values, class Mode, detail::enable_arithmetic_t<T> = 0>
-        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<float, A, Values...>, Mode, requires_arch<sve>) noexcept
+        // load_masked (compile-time mask): build a runtime predicate from
+        // the constant mask and reuse the runtime-mask path. ``pmask`` only
+        // constructs a 128-bit chunk predicate (svdupq_b{8,16,32,64}), which
+        // is replication-based and does not correctly express a per-lane
+        // mask on SVE wider than 128 bits — going through ``as_batch_bool``
+        // gives the right predicate for every vector width. ``int32``/
+        // ``int64``/``uint32``/``uint64`` are excluded so the common-arch
+        // dispatchers that reinterpret to ``float``/``double`` win partial
+        // ordering (otherwise we'd be ambiguous with ``requires_arch<A>``).
+        template <class A, class T, bool... Values, class Mode,
+                  detail::enable_arithmetic_t<T> = 0,
+                  std::enable_if_t<!(std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)), int> = 0>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool_constant<T, A, Values...> mask, convert<T>, Mode m, requires_arch<sve>) noexcept
         {
-            return svld1(detail_sve::pmask<Values...>(), reinterpret_cast<map_to_sized_type_t<T> const*>(mem));
+            return load_masked<A>(mem, mask.as_batch_bool(), convert<T> {}, m, sve {});
+        }
+
+        // load_masked (runtime mask)
+        template <class A, class T, class Mode, detail::enable_arithmetic_t<T> = 0>
+        XSIMD_INLINE batch<T, A> load_masked(T const* mem, batch_bool<T, A> mask, convert<T>, Mode, requires_arch<sve>) noexcept
+        {
+            return svld1(mask, reinterpret_cast<map_to_sized_type_t<T> const*>(mem));
         }
 
         // load_complex
@@ -139,6 +156,24 @@ namespace xsimd
         XSIMD_INLINE void store_unaligned(T* dst, batch<T, A> const& src, requires_arch<sve>) noexcept
         {
             store_aligned<A>(dst, src, sve {});
+        }
+
+        // store_masked (compile-time mask): forward to the runtime-mask
+        // path for the same reason as load_masked above; same exclusion of
+        // 32/64-bit integers to defer to the common dispatchers.
+        template <class A, class T, bool... Values, class Mode,
+                  detail::enable_arithmetic_t<T> = 0,
+                  std::enable_if_t<!(std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)), int> = 0>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool_constant<T, A, Values...> mask, Mode m, requires_arch<sve>) noexcept
+        {
+            store_masked<A>(mem, src, mask.as_batch_bool(), m, sve {});
+        }
+
+        // store_masked (runtime mask)
+        template <class A, class T, class Mode, detail::enable_arithmetic_t<T> = 0>
+        XSIMD_INLINE void store_masked(T* mem, batch<T, A> const& src, batch_bool<T, A> mask, Mode, requires_arch<sve>) noexcept
+        {
+            svst1(mask, reinterpret_cast<map_to_sized_type_t<T>*>(mem), src);
         }
 
         // store_complex

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -49,17 +49,6 @@ namespace xsimd
                 template <class T>
                 XSIMD_INLINE svbool_t ptrue() noexcept { return ptrue_impl(index<sizeof(T)> {}); }
 
-                // predicate loading
-                template <bool M0, bool M1>
-                XSIMD_INLINE svbool_t pmask() noexcept { return svdupq_b64(M0, M1); }
-                template <bool M0, bool M1, bool M2, bool M3>
-                XSIMD_INLINE svbool_t pmask() noexcept { return svdupq_b32(M0, M1, M2, M3); }
-                template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7>
-                XSIMD_INLINE svbool_t pmask() noexcept { return svdupq_b16(M0, M1, M2, M3, M4, M5, M6, M7); }
-                template <bool M0, bool M1, bool M2, bool M3, bool M4, bool M5, bool M6, bool M7,
-                          bool M8, bool M9, bool M10, bool M11, bool M12, bool M13, bool M14, bool M15>
-                XSIMD_INLINE svbool_t pmask() noexcept { return svdupq_b8(M0, M1, M2, M3, M4, M5, M6, M7, M8, M9, M10, M11, M12, M13, M14, M15); }
-
                 // count active lanes in a predicate
                 XSIMD_INLINE uint64_t pcount_impl(svbool_t p, index<1>) noexcept { return svcntp_b8(p, p); }
                 XSIMD_INLINE uint64_t pcount_impl(svbool_t p, index<2>) noexcept { return svcntp_b16(p, p); }
@@ -101,15 +90,10 @@ namespace xsimd
             return load_aligned<A>(src, convert<T>(), sve {});
         }
 
-        // load_masked (compile-time mask): build a runtime predicate from
-        // the constant mask and reuse the runtime-mask path. ``pmask`` only
-        // constructs a 128-bit chunk predicate (svdupq_b{8,16,32,64}), which
-        // is replication-based and does not correctly express a per-lane
-        // mask on SVE wider than 128 bits — going through ``as_batch_bool``
-        // gives the right predicate for every vector width. ``int32``/
-        // ``int64``/``uint32``/``uint64`` are excluded so the common-arch
-        // dispatchers that reinterpret to ``float``/``double`` win partial
-        // ordering (otherwise we'd be ambiguous with ``requires_arch<A>``).
+        // load_masked (compile-time mask): forward to the runtime path; the
+        // as_batch_bool predicate is correct at every SVE width. 32/64-bit ints
+        // are excluded so the common float/double-reinterpreting dispatchers win
+        // partial ordering (else ambiguous with requires_arch<A>).
         template <class A, class T, bool... Values, class Mode,
                   detail::enable_arithmetic_t<T> = 0,
                   std::enable_if_t<!(std::is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8)), int> = 0>

--- a/include/xsimd/types/xsimd_api.hpp
+++ b/include/xsimd/types/xsimd_api.hpp
@@ -1554,6 +1554,27 @@ namespace xsimd
     /**
      * @ingroup batch_data_transfer
      *
+     * Creates a batch from the buffer \c ptr using a runtime mask. Elements
+     * corresponding to \c false in the mask are not accessed in memory and are
+     * zero-initialized in the resulting batch. No type conversion is performed:
+     * \c ptr must point to \c T. Prefer the \c batch_bool_constant overload
+     * whenever the mask is known at compile time.
+     * @param ptr the memory buffer to read
+     * @param mask runtime selection mask for the elements to load
+     * @return a new batch instance
+     */
+    template <class T, class A = default_arch>
+    XSIMD_INLINE batch<T, A> load(T const* ptr,
+                                  batch_bool<T, A> mask,
+                                  aligned_mode = {}) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return batch<T, A>::load(ptr, mask, aligned_mode {});
+    }
+
+    /**
+     * @ingroup batch_data_transfer
+     *
      * Creates a batch from the buffer \c ptr using a mask. Elements
      * corresponding to \c false in the mask are not accessed in memory and are
      * zero-initialized in the resulting batch.
@@ -1565,6 +1586,16 @@ namespace xsimd
     template <class T, class A = default_arch, bool... Values, class From>
     XSIMD_INLINE batch<T, A> load(From const* ptr,
                                   batch_bool_constant<T, A, Values...> const& mask,
+                                  unaligned_mode) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return batch<T, A>::load(ptr, mask, unaligned_mode {});
+    }
+
+    /// \overload
+    template <class T, class A = default_arch>
+    XSIMD_INLINE batch<T, A> load(T const* ptr,
+                                  batch_bool<T, A> mask,
                                   unaligned_mode) noexcept
     {
         detail::static_check_supported_config<T, A>();
@@ -2715,6 +2746,28 @@ namespace xsimd
     /**
      * @ingroup batch_data_transfer
      *
+     * Copy selected elements of batch \c val to the buffer \c mem using a
+     * runtime mask. Elements corresponding to \c false in the mask are not
+     * written and leave the contents of \c mem untouched. No type conversion
+     * is performed: \c mem must point to \c T. Prefer the \c
+     * batch_bool_constant overload whenever the mask is known at compile time.
+     * @param mem the memory buffer to write to
+     * @param val the batch to copy from
+     * @param mask runtime selection mask for the elements to store
+     */
+    template <class T, class A = default_arch>
+    XSIMD_INLINE void store(T* mem,
+                            batch<T, A> const& val,
+                            batch_bool<T, A> mask,
+                            aligned_mode = {}) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        val.store(mem, mask, aligned_mode {});
+    }
+
+    /**
+     * @ingroup batch_data_transfer
+     *
      * Copy selected elements of batch \c val to the buffer \c mem using a mask.
      * Elements corresponding to \c false in the mask are not written to memory.
      * @param mem the memory buffer to write to. The buffer does not need to be
@@ -2726,6 +2779,17 @@ namespace xsimd
     XSIMD_INLINE void store(T* mem,
                             batch<T, A> const& val,
                             batch_bool_constant<T, A, Values...> const& mask,
+                            unaligned_mode) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        val.store(mem, mask, unaligned_mode {});
+    }
+
+    /// \overload
+    template <class T, class A = default_arch>
+    XSIMD_INLINE void store(T* mem,
+                            batch<T, A> const& val,
+                            batch_bool<T, A> mask,
                             unaligned_mode) noexcept
     {
         detail::static_check_supported_config<T, A>();

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -168,9 +168,12 @@ namespace xsimd
         template <class U>
         XSIMD_INLINE void store(U* mem, stream_mode) const noexcept;
 
-        // Compile-time mask overloads
+        // Masked overloads
         template <class U, bool... Values, class Mode = aligned_mode>
         XSIMD_INLINE void store(U* mem, batch_bool_constant<T, A, Values...> mask, Mode) const noexcept;
+        /** \brief Runtime-mask store; see xsimd::store(T*, batch const&, batch_bool<T,A>, Mode). */
+        template <class Mode = aligned_mode>
+        XSIMD_INLINE void store(T* mem, batch_bool<T, A> mask, Mode = {}) const noexcept;
 
         template <class U>
         XSIMD_NO_DISCARD static XSIMD_INLINE batch load_aligned(U const* mem) noexcept;
@@ -180,9 +183,12 @@ namespace xsimd
         XSIMD_NO_DISCARD static XSIMD_INLINE batch load(U const* mem, aligned_mode) noexcept;
         template <class U>
         XSIMD_NO_DISCARD static XSIMD_INLINE batch load(U const* mem, unaligned_mode) noexcept;
-        // Compile-time mask overloads
+        // Masked overloads
         template <class U, bool... Values, class Mode = aligned_mode>
         XSIMD_NO_DISCARD static XSIMD_INLINE batch load(U const* mem, batch_bool_constant<T, A, Values...> mask, Mode = {}) noexcept;
+        /** \brief Runtime-mask load; see xsimd::load(T const*, batch_bool<T,A>, Mode). */
+        template <class Mode = aligned_mode>
+        XSIMD_NO_DISCARD static XSIMD_INLINE batch load(T const* mem, batch_bool<T, A> mask, Mode = {}) noexcept;
         template <class U>
         XSIMD_NO_DISCARD static XSIMD_INLINE batch load(U const* mem, stream_mode) noexcept;
 
@@ -757,6 +763,14 @@ namespace xsimd
     }
 
     template <class T, class A>
+    template <class Mode>
+    XSIMD_INLINE batch<T, A> batch<T, A>::load(T const* mem, batch_bool<T, A> mask, Mode mode) noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        return kernel::load_masked<A>(mem, mask, kernel::convert<T> {}, mode, A {});
+    }
+
+    template <class T, class A>
     template <class U, bool... Values, class Mode>
     XSIMD_INLINE void batch<T, A>::store(U* mem,
                                          batch_bool_constant<T, A, Values...> mask,
@@ -777,6 +791,16 @@ namespace xsimd
         {
             kernel::store_masked<A>(mem, *this, mask, mode, A {});
         }
+    }
+
+    template <class T, class A>
+    template <class Mode>
+    XSIMD_INLINE void batch<T, A>::store(T* mem,
+                                         batch_bool<T, A> mask,
+                                         Mode mode) const noexcept
+    {
+        detail::static_check_supported_config<T, A>();
+        kernel::store_masked<A>(mem, *this, mask, mode, A {});
     }
 
     template <class T, class A>

--- a/include/xsimd/types/xsimd_batch.hpp
+++ b/include/xsimd/types/xsimd_batch.hpp
@@ -24,6 +24,108 @@
 
 namespace xsimd
 {
+    namespace detail
+    {
+        // Does batch<T, A> have a real predicated masked load/store, vs. the
+        // emulated scalar `requires_arch<common>` fallback? Compile-time signal to
+        // pick a masked single-loop over a vector+trailer loop. Size-keyed.
+        // Internal/undocumented for now; promote once the dispatch API settles.
+        template <class B>
+        struct has_mask_load : std::false_type
+        {
+        };
+        template <class B>
+        struct has_mask_store : std::false_type
+        {
+        };
+
+        template <class B>
+        constexpr bool has_mask_load_v = has_mask_load<B>::value;
+        template <class B>
+        constexpr bool has_mask_store_v = has_mask_store<B>::value;
+
+#define XSIMD_DECLARE_MASK_MEMORY(ARCH, SIZE_PREDICATE)                                  \
+    template <class T>                                                                   \
+    struct has_mask_load<batch<T, ARCH>>                                                 \
+        : std::integral_constant<bool, std::is_arithmetic<T>::value && (SIZE_PREDICATE)> \
+    {                                                                                    \
+    };                                                                                   \
+    template <class T>                                                                   \
+    struct has_mask_store<batch<T, ARCH>>                                                \
+        : std::integral_constant<bool, std::is_arithmetic<T>::value && (SIZE_PREDICATE)> \
+    {                                                                                    \
+    }
+
+#define XSIMD_DECLARE_MASK_MEMORY_ALIAS(ARCH, BASE)                        \
+    template <class T>                                                     \
+    struct has_mask_load<batch<T, ARCH>> : has_mask_load<batch<T, BASE>>   \
+    {                                                                      \
+    };                                                                     \
+    template <class T>                                                     \
+    struct has_mask_store<batch<T, ARCH>> : has_mask_store<batch<T, BASE>> \
+    {                                                                      \
+    }
+
+        XSIMD_DECLARE_MASK_MEMORY(avx, sizeof(T) == 4 || sizeof(T) == 8);
+        XSIMD_DECLARE_MASK_MEMORY(avx_128, sizeof(T) == 4 || sizeof(T) == 8);
+        XSIMD_DECLARE_MASK_MEMORY(avx512f, sizeof(T) == 4 || sizeof(T) == 8);
+        XSIMD_DECLARE_MASK_MEMORY(avx512bw, sizeof(T) >= 1 && sizeof(T) <= 8);
+        XSIMD_DECLARE_MASK_MEMORY(avx512vl_128, sizeof(T) == 4 || sizeof(T) == 8);
+        XSIMD_DECLARE_MASK_MEMORY(avx512vl_256, sizeof(T) == 4 || sizeof(T) == 8);
+
+        // sve / rvv: width-templated, predicate-native at every lane size
+        template <class T, size_t W>
+        struct has_mask_load<batch<T, sve<W>>> : std::integral_constant<bool, std::is_arithmetic<T>::value>
+        {
+        };
+        template <class T, size_t W>
+        struct has_mask_store<batch<T, sve<W>>> : std::integral_constant<bool, std::is_arithmetic<T>::value>
+        {
+        };
+        template <class T, size_t W>
+        struct has_mask_load<batch<T, rvv<W>>> : std::integral_constant<bool, std::is_arithmetic<T>::value>
+        {
+        };
+        template <class T, size_t W>
+        struct has_mask_store<batch<T, rvv<W>>> : std::integral_constant<bool, std::is_arithmetic<T>::value>
+        {
+        };
+
+        // descendants inherit their base
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx2, avx);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avxvnni, avx2);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx2_128, avx_128);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512cd, avx512f);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512dq, avx512cd);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512er, avx512cd);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512pf, avx512er);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512vl, avx512cd);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512ifma, avx512bw);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512vbmi, avx512ifma);
+        XSIMD_DECLARE_MASK_MEMORY_ALIAS(avx512vbmi2, avx512vbmi);
+
+        // wrapper arches follow their parameter
+        template <class T, class A>
+        struct has_mask_load<batch<T, fma3<A>>> : has_mask_load<batch<T, A>>
+        {
+        };
+        template <class T, class A>
+        struct has_mask_store<batch<T, fma3<A>>> : has_mask_store<batch<T, A>>
+        {
+        };
+        template <class T, class A>
+        struct has_mask_load<batch<T, avx512vnni<A>>> : has_mask_load<batch<T, A>>
+        {
+        };
+        template <class T, class A>
+        struct has_mask_store<batch<T, avx512vnni<A>>> : has_mask_store<batch<T, A>>
+        {
+        };
+
+#undef XSIMD_DECLARE_MASK_MEMORY
+#undef XSIMD_DECLARE_MASK_MEMORY_ALIAS
+    }
+
     namespace types
     {
         template <class T, class A>

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -457,6 +457,16 @@ namespace xsimd
 
     template <class B>
     using complex_batch_type_t = typename complex_batch_type<B>::type;
+
+    namespace details
+    {
+        // Returns a bitmask with the lowest \c size bits set. Used by masked
+        // load/store fast paths to detect "all lanes active".
+        inline constexpr uint64_t full_mask(std::size_t size) noexcept
+        {
+            return size >= 64 ? ~uint64_t(0) : ((uint64_t(1) << size) - 1);
+        }
+    }
 }
 
 #endif

--- a/include/xsimd/types/xsimd_utils.hpp
+++ b/include/xsimd/types/xsimd_utils.hpp
@@ -457,16 +457,6 @@ namespace xsimd
 
     template <class B>
     using complex_batch_type_t = typename complex_batch_type<B>::type;
-
-    namespace details
-    {
-        // Returns a bitmask with the lowest \c size bits set. Used by masked
-        // load/store fast paths to detect "all lanes active".
-        inline constexpr uint64_t full_mask(std::size_t size) noexcept
-        {
-            return size >= 64 ? ~uint64_t(0) : ((uint64_t(1) << size) - 1);
-        }
-    }
 }
 
 #endif

--- a/test/test_load_store.cpp
+++ b/test/test_load_store.cpp
@@ -23,6 +23,7 @@ struct load_store_test
 {
     using batch_type = B;
     using value_type = typename B::value_type;
+    using batch_bool_type = typename B::batch_bool_type;
     using index_type = typename xsimd::as_integer_t<batch_type>;
     template <class T>
     using allocator = xsimd::default_allocator<T, typename B::arch_type>;
@@ -65,22 +66,6 @@ struct load_store_test
         static constexpr bool get(std::size_t index, std::size_t size) noexcept { return index >= (size / 2); }
     };
 
-    struct mask_first_n
-    {
-        static constexpr bool get(std::size_t index, std::size_t size) noexcept
-        {
-            return index < (size > 2 ? size / 3 : std::size_t(1));
-        }
-    };
-
-    struct mask_last_n
-    {
-        static constexpr bool get(std::size_t index, std::size_t size) noexcept
-        {
-            return index >= size - (size > 2 ? size / 3 : std::size_t(1));
-        }
-    };
-
     struct mask_even
     {
         static constexpr bool get(std::size_t index, std::size_t) noexcept { return (index % 2) == 0; }
@@ -102,6 +87,41 @@ struct load_store_test
     struct mask_all
     {
         static constexpr bool get(std::size_t, std::size_t) noexcept { return true; }
+    };
+
+    template <class Generator>
+    static batch_bool_type make_runtime_mask() noexcept
+    {
+        uint64_t bits = 0;
+        for (std::size_t i = 0; i < size; ++i)
+        {
+            if (Generator::get(i, size))
+            {
+                bits |= uint64_t(1) << i;
+            }
+        }
+        return batch_bool_type::from_mask(bits);
+    }
+
+    struct compile_time_mask
+    {
+        static constexpr const char* tag = "";
+        template <class Generator>
+        static auto make() noexcept
+            -> decltype(xsimd::make_batch_bool_constant<value_type, Generator, typename batch_type::arch_type>())
+        {
+            return xsimd::make_batch_bool_constant<value_type, Generator, typename batch_type::arch_type>();
+        }
+    };
+
+    struct runtime_mask
+    {
+        static constexpr const char* tag = " runtime";
+        template <class Generator>
+        static batch_bool_type make() noexcept
+        {
+            return make_runtime_mask<Generator>();
+        }
     };
 
     int8_vector_type i8_vec;
@@ -366,16 +386,22 @@ private:
     template <class V>
     void run_mask_tests(const V& v, const std::string& name, batch_type& b, const array_type& expected, std::true_type)
     {
-        run_load_mask_pattern<mask_none>(v, name, b, expected, " masked none");
-        run_load_mask_pattern<mask_first>(v, name, b, expected, " masked first element");
-        run_load_mask_pattern<mask_first_half>(v, name, b, expected, " masked first half");
-        run_load_mask_pattern<mask_last_half>(v, name, b, expected, " masked last half");
-        run_load_mask_pattern<mask_first_n>(v, name, b, expected, " masked first N");
-        run_load_mask_pattern<mask_last_n>(v, name, b, expected, " masked last N");
-        run_load_mask_pattern<mask_even>(v, name, b, expected, " masked even elements");
-        run_load_mask_pattern<mask_odd>(v, name, b, expected, " masked odd elements");
-        run_load_mask_pattern<mask_pseudo_random>(v, name, b, expected, " masked pseudo random");
-        run_load_mask_pattern<mask_all>(v, name, b, expected, " masked all elements");
+        run_load_mask_patterns<compile_time_mask>(v, name, b, expected);
+        run_load_mask_patterns<runtime_mask>(v, name, b, expected);
+    }
+
+    template <class MaskKind, class V>
+    void run_load_mask_patterns(const V& v, const std::string& name, batch_type& b, const array_type& expected)
+    {
+        const std::string p = std::string(MaskKind::tag) + " masked";
+        run_load_mask_pattern<MaskKind, mask_none>(v, name, b, expected, p + " none");
+        run_load_mask_pattern<MaskKind, mask_first>(v, name, b, expected, p + " first element");
+        run_load_mask_pattern<MaskKind, mask_first_half>(v, name, b, expected, p + " first half");
+        run_load_mask_pattern<MaskKind, mask_last_half>(v, name, b, expected, p + " last half");
+        run_load_mask_pattern<MaskKind, mask_even>(v, name, b, expected, p + " even elements");
+        run_load_mask_pattern<MaskKind, mask_odd>(v, name, b, expected, p + " odd elements");
+        run_load_mask_pattern<MaskKind, mask_pseudo_random>(v, name, b, expected, p + " pseudo random");
+        run_load_mask_pattern<MaskKind, mask_all>(v, name, b, expected, p + " all elements");
     }
 
     template <class V>
@@ -383,10 +409,10 @@ private:
     {
     }
 
-    template <class Generator, class V>
+    template <class MaskKind, class Generator, class V>
     void run_load_mask_pattern(const V& v, const std::string& name, batch_type& b, const array_type& expected, const std::string& label)
     {
-        constexpr auto mask = xsimd::make_batch_bool_constant<value_type, Generator, typename batch_type::arch_type>();
+        const auto mask = MaskKind::template make<Generator>();
         array_type expected_masked { 0 };
 
         for (std::size_t i = 0; i < size; ++i)
@@ -403,10 +429,10 @@ private:
         CHECK_BATCH_EQ(b, expected_masked);
     }
 
-    template <class Generator, class V>
+    template <class MaskKind, class Generator, class V>
     void run_store_mask_pattern(const V& v, const std::string& name, batch_type& b, V& res, V& expected_masked, const std::string& label)
     {
-        auto mask = xsimd::make_batch_bool_constant<value_type, Generator, typename batch_type::arch_type>();
+        const auto mask = MaskKind::template make<Generator>();
         for (std::size_t i = 0; i < size; ++i)
         {
             expected_masked[i] = Generator::get(i, size) ? v[i] : value_type();
@@ -424,15 +450,21 @@ private:
     template <class V>
     void run_store_mask_tests(const V& v, const std::string& name, batch_type& b, V& res, V& expected_masked, std::true_type)
     {
-        run_store_mask_pattern<mask_first>(v, name, b, res, expected_masked, " masked first element");
-        run_store_mask_pattern<mask_first_half>(v, name, b, res, expected_masked, " masked first half");
-        run_store_mask_pattern<mask_last_half>(v, name, b, res, expected_masked, " masked last half");
-        run_store_mask_pattern<mask_first_n>(v, name, b, res, expected_masked, " masked first N");
-        run_store_mask_pattern<mask_last_n>(v, name, b, res, expected_masked, " masked last N");
-        run_store_mask_pattern<mask_even>(v, name, b, res, expected_masked, " masked even elements");
-        run_store_mask_pattern<mask_odd>(v, name, b, res, expected_masked, " masked odd elements");
-        run_store_mask_pattern<mask_pseudo_random>(v, name, b, res, expected_masked, " masked pseudo random");
-        run_store_mask_pattern<mask_all>(v, name, b, res, expected_masked, " masked all elements");
+        run_store_mask_patterns<compile_time_mask>(v, name, b, res, expected_masked);
+        run_store_mask_patterns<runtime_mask>(v, name, b, res, expected_masked);
+    }
+
+    template <class MaskKind, class V>
+    void run_store_mask_patterns(const V& v, const std::string& name, batch_type& b, V& res, V& expected_masked)
+    {
+        const std::string p = std::string(MaskKind::tag) + " masked";
+        run_store_mask_pattern<MaskKind, mask_first>(v, name, b, res, expected_masked, p + " first element");
+        run_store_mask_pattern<MaskKind, mask_first_half>(v, name, b, res, expected_masked, p + " first half");
+        run_store_mask_pattern<MaskKind, mask_last_half>(v, name, b, res, expected_masked, p + " last half");
+        run_store_mask_pattern<MaskKind, mask_even>(v, name, b, res, expected_masked, p + " even elements");
+        run_store_mask_pattern<MaskKind, mask_odd>(v, name, b, res, expected_masked, p + " odd elements");
+        run_store_mask_pattern<MaskKind, mask_pseudo_random>(v, name, b, res, expected_masked, p + " pseudo random");
+        run_store_mask_pattern<MaskKind, mask_all>(v, name, b, res, expected_masked, p + " all elements");
     }
 
     template <class V>
@@ -452,6 +484,7 @@ private:
         V sentinel_expected(size, sentinel);
 
         auto zero_mask = xsimd::make_batch_bool_constant<value_type, mask_none, typename batch_type::arch_type>();
+        auto runtime_zero_mask = make_runtime_mask<mask_none>();
         std::fill(res.begin(), res.end(), sentinel);
         b.store(res.data(), zero_mask, xsimd::aligned_mode());
         INFO(name, " masked none aligned store");
@@ -464,6 +497,19 @@ private:
         INFO(name, " masked none unaligned store");
 
         V scratch_slice(res.size());
+        std::copy(scratch_ptr, scratch_ptr + scratch_slice.size(), scratch_slice.begin());
+        CHECK_VECTOR_EQ(scratch_slice, sentinel_expected);
+        CHECK(std::all_of(scratch.begin(), scratch.end(), [](const value_type v)
+                          { return v == sentinel; }));
+
+        std::fill(res.begin(), res.end(), sentinel);
+        xsimd::store(res.data(), b, runtime_zero_mask, xsimd::aligned_mode());
+        INFO(name, " runtime masked none aligned store");
+        CHECK_VECTOR_EQ(res, sentinel_expected);
+
+        std::fill(scratch.begin(), scratch.end(), sentinel);
+        xsimd::store(scratch_ptr, b, runtime_zero_mask, xsimd::unaligned_mode());
+        INFO(name, " runtime masked none unaligned store");
         std::copy(scratch_ptr, scratch_ptr + scratch_slice.size(), scratch_slice.begin());
         CHECK_VECTOR_EQ(scratch_slice, sentinel_expected);
         CHECK(std::all_of(scratch.begin(), scratch.end(), [](const value_type v)

--- a/test/test_load_store.cpp
+++ b/test/test_load_store.cpp
@@ -18,6 +18,42 @@
 #include <random>
 #include <type_traits>
 
+// Anti-rot guard for the internal has_mask_load_v / has_mask_store_v trait. It is
+// a pure type-level computation (no batch instantiation), and every arch tag is
+// always declared, so the value is build-independent -- the whole (size x arch)
+// matrix is asserted unconditionally, no XSIMD_WITH_* guards. Capability is per
+// size and load == store, so one helper checks both ops at all four sizes
+// (float/double track int32/int64). Each line mirrors a row of the matrix.
+namespace test_has_mask_trait
+{
+    using xsimd::batch;
+    using xsimd::detail::has_mask_load_v;
+    using xsimd::detail::has_mask_store_v;
+
+    template <class A>
+    constexpr bool caps(bool b1, bool b2, bool b4, bool b8)
+    {
+        return has_mask_load_v<batch<int8_t, A>> == b1 && has_mask_store_v<batch<int8_t, A>> == b1
+            && has_mask_load_v<batch<int16_t, A>> == b2 && has_mask_store_v<batch<int16_t, A>> == b2
+            && has_mask_load_v<batch<int32_t, A>> == b4 && has_mask_store_v<batch<int32_t, A>> == b4
+            && has_mask_load_v<batch<int64_t, A>> == b8 && has_mask_store_v<batch<int64_t, A>> == b8;
+    }
+
+    //                                            i8     i16    i32    i64
+    static_assert(caps<xsimd::sse2>(false, false, false, false), "sse2: scalar fallback");
+    static_assert(caps<xsimd::sse4_2>(false, false, false, false), "sse4.2: scalar fallback");
+    static_assert(caps<xsimd::avx>(false, false, true, true), "avx: 4/8 via vmaskmov");
+    static_assert(caps<xsimd::avx_128>(false, false, true, true), "avx_128: 4/8 via vmaskmov");
+    static_assert(caps<xsimd::avx2>(false, false, true, true), "avx2: 4/8 native");
+    static_assert(caps<xsimd::fma3<xsimd::avx2>>(false, false, true, true), "fma3<avx2> follows avx2");
+    static_assert(caps<xsimd::avx512f>(false, false, true, true), "avx512f: 4/8");
+    static_assert(caps<xsimd::avx512bw>(true, true, true, true), "avx512bw: all sizes");
+    static_assert(caps<xsimd::neon>(false, false, false, false), "neon: scalar fallback");
+    static_assert(caps<xsimd::neon64>(false, false, false, false), "neon64: scalar fallback");
+    static_assert(caps<xsimd::sve>(true, true, true, true), "sve: predicate-native");
+    static_assert(caps<xsimd::rvv>(true, true, true, true), "rvv: predicate-native");
+}
+
 template <class B>
 struct load_store_test
 {


### PR DESCRIPTION
Add runtime-mask overloads of xsimd::load_masked and xsimd::store_masked across AVX2, AVX-512, SSE, SVE, RVV, and NEON. The generic common-path fallback is collapsed to a whole-vector select, and the unaligned page-cross fast path is dropped since the underlying intrinsics suppress faults on masked-off lanes regardless of alignment.