### PR TITLE
fix: avoid atan branch cut in complex trigonometric test (musl CI)

### DIFF
--- a/test/test_complex_trigonometric.cpp
+++ b/test/test_complex_trigonometric.cpp
@@ -43,7 +43,11 @@ struct complex_trigonometric_test
                                   real_value_type(0.1) + i * real_value_type(56.) / nb_input);
             ainput[i] = value_type(real_value_type(-1.) + real_value_type(2.) * i / nb_input,
                                    real_value_type(-1.1) + real_value_type(2.1) * i / nb_input);
-            atan_input[i] = value_type(real_value_type(-10.) + i * real_value_type(20.) / nb_input,
+            // Avoid sampling the branch cut of complex atan at (Re=0, |Im|>=1):
+            // the sign of Re(catan(+/-0 + i*y)) for |y|>1 is implementation-defined
+            // (C99 7.3.4.1), and glibc and musl disagree there. Starting Re at -9.5
+            // makes Re=0 occur at i=19/40 of the range, where |Im|<1 (analytic).
+            atan_input[i] = value_type(real_value_type(-9.5) + i * real_value_type(20.) / nb_input,
                                        real_value_type(-9.) + i * real_value_type(21.) / nb_input);
         }
         expected.resize(nb_input);


### PR DESCRIPTION
## Summary (I used claude to reproduce locally, as it is a hassle to handle docker for this)

`test_complex_trigonometric.cpp` fails on musl-based CI (e.g. void-linux x86_64-musl, see [void-packages CI run](https://github.com/void-linux/void-packages/actions/runs/25115040710/job/73599498280?pr=58127)) with two mismatches in `[complex trigonometric]` for `complex<float>` and `complex<double>`.

### Root cause

`atan_input[i] = (-10 + i*20/N, -9 + i*21/N)` lands on `z = (0, 1.5)` at `i = N/2`, which is on the branch cut of complex `atan` (`Re=0, |Im|>=1`). Per **C99 §7.3.4.1**, the sign of `Re(catan(±0 + iy))` for `|y|>1` is implementation-defined:

- glibc: `atan(0 + 1.5i) = (+π/2, 0.8047…)`
- musl:  `atan(0 + 1.5i) = (-π/2, 0.8047…)`

xsimd's `atan` implementation matches glibc, so `CHECK_BATCH_EQ(ref, out)` against the musl reference fails. The previous test code used `get_nb_diff` which was lossy; commit ae3822f1 replaced it with per-element `CHECK_BATCH_EQ`, exposing this latent issue.

### Fix

Shift the real start from `-10` to `-9.5` so `Re=0` occurs at `i = 19000` where `|Im| ≈ 0.975 < 1` — analytic territory where `atan` is uniquely defined and all libcs agree. Symmetric negative/positive real coverage is preserved; only the single sample on a region of unspecified behavior is dropped.

## Verification

- Reproduced the libc divergence with a standalone snippet calling `std::atan(std::complex<T>)` on glibc vs alpine/musl: confirmed `Re` sign flip at `(0, 1.5)`.
- Pre-fix on alpine/musl: `[complex trigonometric]` 2/2 cases fail.
- Post-fix on glibc and alpine/musl: 2/2 cases pass.
