### PR TITLE
Fix VSX clang build

### DIFF
--- a/include/xsimd/arch/xsimd_vsx.hpp
+++ b/include/xsimd/arch/xsimd_vsx.hpp
@@ -33,6 +33,37 @@ namespace xsimd
 
     namespace kernel
     {
+        // builtin_t<T> - the scalar type as it would be used for a vector intrinsic
+        // VSX vector intrinsics do not support long, unsigned long, and char
+        // The builtin<T> definition can be used to map the incoming
+        // type to the right one to be used with the intrinsics.
+        template <typename T>
+        struct builtin_scalar
+        {
+            using type = T;
+        };
+
+        template <>
+        struct builtin_scalar<unsigned long>
+        {
+            using type = unsigned long long;
+        };
+
+        template <>
+        struct builtin_scalar<long>
+        {
+            using type = long long;
+        };
+
+        template <>
+        struct builtin_scalar<char>
+        {
+            using type = typename std::conditional<std::is_signed<char>::value, signed char, unsigned char>::type;
+        };
+
+        template <typename T>
+        using builtin_t = typename builtin_scalar<T>::type;
+
         template <class A, class T>
         XSIMD_INLINE batch<T, A> avg(batch<T, A> const&, batch<T, A> const&, requires_arch<common>) noexcept;
         template <class A, class T>
@@ -218,7 +249,7 @@ namespace xsimd
         template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
         XSIMD_INLINE batch<T, A> broadcast(T val, requires_arch<vsx>) noexcept
         {
-            return vec_splats(val);
+            return vec_splats(static_cast<builtin_t<T>>(val));
         }
 
         // ceil
@@ -421,18 +452,18 @@ namespace xsimd
             return ~vec_cmpeq(self.data, self.data);
         }
 
-        // load_aligned
-        template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
-        XSIMD_INLINE batch<T, A> load_aligned(T const* mem, convert<T>, requires_arch<vsx>) noexcept
-        {
-            return vec_ld(0, reinterpret_cast<const typename batch<T, A>::register_type*>(mem));
-        }
-
         // load_unaligned
         template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
         XSIMD_INLINE batch<T, A> load_unaligned(T const* mem, convert<T>, requires_arch<vsx>) noexcept
         {
-            return vec_vsx_ld(0, (typename batch<T, A>::register_type const*)mem);
+            return (typename batch<T, A>::register_type)vec_xl(0, (builtin_t<T>*)mem);
+        }
+
+        // load_aligned
+        template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
+        XSIMD_INLINE batch<T, A> load_aligned(T const* mem, convert<T>, requires_arch<vsx>) noexcept
+        {
+            return load_unaligned<A>(mem, kernel::convert<T> {}, vsx {});
         }
 
         // load_complex
@@ -758,14 +789,14 @@ namespace xsimd
         template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
         XSIMD_INLINE void store_aligned(T* mem, batch<T, A> const& self, requires_arch<vsx>) noexcept
         {
-            return vec_st(self.data, 0, reinterpret_cast<typename batch<T, A>::register_type*>(mem));
+            vec_xst((typename batch<T, A>::register_type)self.data, 0, (builtin_t<T>*)mem);
         }
 
         // store_unaligned
         template <class A, class T, class = std::enable_if_t<std::is_scalar<T>::value>>
         XSIMD_INLINE void store_unaligned(T* mem, batch<T, A> const& self, requires_arch<vsx>) noexcept
         {
-            return vec_vsx_st(self.data, 0, reinterpret_cast<typename batch<T, A>::register_type*>(mem));
+            store_aligned<A>(mem, self, vsx {});
         }
 
         // sub

--- a/include/xsimd/types/xsimd_vsx_register.hpp
+++ b/include/xsimd/types/xsimd_vsx_register.hpp
@@ -39,7 +39,7 @@ namespace xsimd
     namespace types
     {
 
-#define XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(T, Tb)                  \
+#define XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(T, Tv, Tb)              \
     template <>                                                      \
     struct get_bool_simd_register<T, vsx>                            \
     {                                                                \
@@ -55,19 +55,26 @@ namespace xsimd
             operator register_type() const noexcept { return data; } \
         };                                                           \
     };                                                               \
-    XSIMD_DECLARE_SIMD_REGISTER(T, vsx, __vector T)
+    XSIMD_DECLARE_SIMD_REGISTER(T, vsx, __vector Tv)
 
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(signed char, char);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned char, char);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(char, char);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned short, short);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(short, short);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned int, int);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(int, int);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned long, long);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(long, long);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(float, int);
-        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(double, long);
+        // The VSX vector intrinsics do not support long, unsigned long,
+        // and char data types.  batches of these types are vectors of
+        // equivalent types.
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(signed char, signed char, char);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned char, unsigned char, char);
+#ifdef __CHAR_UNSIGNED__
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(char, unsigned char, char);
+#else
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(char, signed char, char);
+#endif
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned short, unsigned short, short);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(short, short, short);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned int, unsigned int, int);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(int, int, int);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(unsigned long, unsigned long long, long long);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(long, long long, long long);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(float, float, int);
+        XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER(double, double, long long);
 
 #undef XSIMD_DECLARE_SIMD_BOOL_VSX_REGISTER
     }


### PR DESCRIPTION
This fixes issue #1257. 
Clang appears to be somewhat stricter when it comes to checking which types are allowed with the `__vector` keyword. In order to fix this I've copied what I did for IBM Z (s390x) VXE support. The element types used in `batch<T, A>` are mapped to a matching register_type which is accepted by the compiler intrinsics.

With this tests run clean with GCC and Clang for me.

The clang build, however, still shows some warnings on code like this:
`kernel::store_aligned(mem, (batch<int>)in, vsx {});`

```` 
xcast.cpp:8:42: warning: implicit conversion between vector types (''register_type' (aka 'xsimd::types::get_bool_simd_register<int, xsimd::vsx>::type::register_type')'
      and ''register_type' (aka 'xsimd::types::simd_register<int, xsimd::vsx>::register_type')') is deprecated; in the future, the behavior implied by '-fno-lax-vector-conversions' will be
      the default [-Wdeprecate-lax-vec-conv-all]
    8 |   kernel::store_aligned(mem, (batch<int>)in, vsx {});
      |                                          ^
1 warning generated
````
I think the reason for that is that clang does not accept implicit casts between `__vector bool int `to `__vector int`. 