### PR TITLE
Add clang workflow for PPC

### DIFF
--- a/.github/toolchains/clang-powerpc64-linux-gnu.cmake
+++ b/.github/toolchains/clang-powerpc64-linux-gnu.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_PROCESSOR powerpc64)
+set(triple powerpc64-linux-gnu)
+
+include(${CMAKE_CURRENT_LIST_DIR}/clang.cmake)
+

--- a/.github/toolchains/clang-powerpc64le-linux-gnu.cmake
+++ b/.github/toolchains/clang-powerpc64le-linux-gnu.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_PROCESSOR powerpc64le)
+set(triple powerpc64le-linux-gnu)
+
+include(${CMAKE_CURRENT_LIST_DIR}/clang.cmake)
+

--- a/.github/workflows/cross-ppc.yml
+++ b/.github/workflows/cross-ppc.yml
@@ -15,16 +15,27 @@ jobs:
           - { platform: 'ppc64',     dir: 'powerpc64-linux-gnu',   flags: '-maltivec -mvsx -mcpu=power10', full: 'OFF' }
         sys:
           - { compiler: 'gcc',   version: '12' }
+          - { compiler: 'clang', version: '20', gcc_runtime: '12' }
     steps:
-    - name: Setup compiler
+    - name: Setup GCC
       if: ${{ matrix.sys.compiler == 'gcc' }}
       run: |
         sudo apt-get update || exit 1
-        sudo apt-get --no-install-suggests --no-install-recommends install g++-${{ matrix.sys.version }}-${{ matrix.target.dir }} g++-${{ matrix.sys.version }}-multilib || exit 1
+        sudo apt-get -y --no-install-suggests --no-install-recommends install g++-${{ matrix.sys.version }}-${{ matrix.target.dir }} g++-${{ matrix.sys.version }}-multilib cmake || exit 1
         sudo update-alternatives --remove-all ${{ matrix.target.dir }}-gcc || true
         sudo update-alternatives --remove-all ${{ matrix.target.dir }}-g++ || true
         sudo update-alternatives --install /usr/bin/${{ matrix.target.dir }}-gcc ${{ matrix.target.dir }}-gcc /usr/bin/${{ matrix.target.dir }}-gcc-${{ matrix.sys.version }} 20
         sudo update-alternatives --install /usr/bin/${{ matrix.target.dir }}-g++ ${{ matrix.target.dir }}-g++ /usr/bin/${{ matrix.target.dir }}-g++-${{ matrix.sys.version }} 20
+    - name: Setup LLVM
+      if: ${{ matrix.sys.compiler == 'clang' }}
+      run: |
+        sudo apt-get update || exit 1
+        sudo apt-get -y --no-install-suggests --no-install-recommends install g++-${{ matrix.sys.gcc_runtime }}-${{ matrix.target.dir }} g++-${{ matrix.sys.gcc_runtime }}-multilib cmake || exit 1
+        sudo apt-get -y --no-install-suggests --no-install-recommends install clang-${{ matrix.sys.version }} || exit 1
+        sudo update-alternatives --remove-all /usr/bin/clang || true
+        sudo update-alternatives --remove-all /usr/bin/clang++ || true
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ matrix.sys.version }} 20
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.sys.version }} 20
     - name: Setup QEMU
       run: |
         sudo apt-get --no-install-suggests --no-install-recommends install qemu-user
@@ -45,13 +56,14 @@ jobs:
     - name: Build
       run: cmake --build build/ --verbose -j1
     - name: Set CPU feature test expectations
-      run: |
+      run: /bin/true
     - name: Testing xsimd
       run: |
         # Set CPU feature test expectations, 0 is explicit absence of the feature
         export XSIMD_TEST_CPU_ASSUME_SSE4_2="0"
         export XSIMD_TEST_CPU_ASSUME_NEON64="0"
         export XSIMD_TEST_CPU_ASSUME_RVV="0"
+        export XSIMD_TEST_CPU_ASSUME_VXE="0"
         export XSIMD_TEST_CPU_ASSUME_VSX="1"
 
         qemu-${{ matrix.target.platform }} -cpu power10 -L /usr/${{ matrix.target.dir}}/ ./build/test/test_xsimd


### PR DESCRIPTION
Trying to test this locally did not finish. The qemu process running the clang built test_xsimd binaries didn't finish. However, I could not reproduce it on real hardware. So this one is only to let the real github runners run against it.