### PR TITLE
[neon] Fix incorrect guard for system headers on Windows

### DIFF
--- a/include/xsimd/types/xsimd_neon_register.hpp
+++ b/include/xsimd/types/xsimd_neon_register.hpp
@@ -18,7 +18,7 @@
 #include "./xsimd_register.hpp"
 
 #if XSIMD_WITH_NEON
-#if defined(_WIN32) && XSIMD_WITH_NEON64
+#if defined(_MSC_VER) && !defined(__clang__) && XSIMD_WITH_NEON64
 #include <arm64_neon.h>
 #else
 #include <arm_neon.h>


### PR DESCRIPTION
One need to cope with windows/non-windows header as well as clang-cl/msvc compatibility.

Courtesy to @komainu8 and @mtl1979 for the patch.

Fix #1346