### PR TITLE
Add CMakePresets for target micro arch

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,46 +10,50 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: '${{ matrix.sys.compiler }} ${{ matrix.sys.version }} - ${{ matrix.sys.flags }}'
+    name: '${{ matrix.sys.compiler }} ${{ matrix.sys.version }} - ${{ matrix.sys.preset }} - ${{ matrix.sys.flags }}'
     strategy:
       matrix:
         sys:
-          - { compiler: 'gcc',   version: '12', flags: 'force_no_instr_set' }
-          - { compiler: 'gcc',   version: '13', flags: 'enable_xtl_complex' }
-          - { compiler: 'gcc',   version: '14', flags: 'avx' }
-          - { compiler: 'gcc',   version: '14', flags: 'avx2' }
-          - { compiler: 'gcc',   version: '13', flags: 'avx512' }
-          - { compiler: 'gcc',   version: '10', flags: 'avx512' }
-          - { compiler: 'gcc',   version: '12', flags: 'i386' }
-          - { compiler: 'gcc',   version: '13', flags: 'avx512pf' }
-          - { compiler: 'gcc',   version: '13', flags: 'avx512vbmi' }
-          - { compiler: 'gcc',   version: '14', flags: 'avx512vbmi2' }
-          - { compiler: 'gcc',   version: '13', flags: 'avx512vnni' }
-          - { compiler: 'clang', version: '16', flags: 'force_no_instr_set' }
-          - { compiler: 'clang', version: '16', flags: 'enable_xtl_complex' }
-          - { compiler: 'clang', version: '17', flags: 'avx' }
-          - { compiler: 'clang', version: '17', flags: 'sse3' }
-          - { compiler: 'clang', version: '18', flags: 'avx512' }
-          - { compiler: 'clang', version: '18', flags: 'avx_128' }
-          - { compiler: 'clang', version: '18', flags: 'avx2_128' }
-          - { compiler: 'clang', version: '18', flags: 'avx512vl_128' }
-          - { compiler: 'clang', version: '18', flags: 'avx512vl_256' }
+          - { compiler: 'gcc',   version: '12', flags: 'force_no_instr_set', preset: 'native' }
+          - { compiler: 'gcc',   version: '13', flags: 'enable_xtl_complex', preset: 'native' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx2' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512f' }
+          - { compiler: 'gcc',   version: '10', flags: '',                   preset: 'avx512f' }
+          - { compiler: 'gcc',   version: '12', flags: 'i386',               preset: 'native' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512pf' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512vbmi' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx512vbmi2' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512vnni_avx512bw' }
+          - { compiler: 'clang', version: '16', flags: 'force_no_instr_set', preset: 'native' }
+          - { compiler: 'clang', version: '16', flags: 'enable_xtl_complex', preset: 'native' }
+          - { compiler: 'clang', version: '17', flags: '',                   preset: 'avx' }
+          - { compiler: 'clang', version: '17', flags: '',                   preset: 'sse3' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512f' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx2_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512vl_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512vl_256' }
     steps:
-    - name: Setup compiler
+    - name: Setup GCC compiler
       if: ${{ matrix.sys.compiler == 'gcc' }}
       run: |
         GCC_VERSION=${{ matrix.sys.version }}
         sudo apt-get update
         sudo apt-get --no-install-suggests --no-install-recommends install g++-$GCC_VERSION
-        sudo dpkg --add-architecture i386
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
-        sudo apt-get --no-install-suggests --no-install-recommends install gcc-$GCC_VERSION-multilib g++-$GCC_VERSION-multilib linux-libc-dev:i386
-        CC=gcc-$GCC_VERSION
-        echo "CC=$CC" >> $GITHUB_ENV
-        CXX=g++-$GCC_VERSION
-        echo "CXX=$CXX" >> $GITHUB_ENV
-    - name: Setup compiler
+        # Setup i386 as needed
+        if [[ '${{ matrix.sys.flags }}' == 'i386' ]]; then
+          sudo dpkg --add-architecture i386
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get --no-install-suggests --no-install-recommends install \
+            gcc-$GCC_VERSION-multilib g++-$GCC_VERSION-multilib linux-libc-dev:i386
+        fi
+        # Export compiler as environment var
+        echo "CC=gcc-$GCC_VERSION" >> $GITHUB_ENV
+        echo "CXX=g++-$GCC_VERSION" >> $GITHUB_ENV
+
+    - name: Setup Clang compiler
       if: ${{ matrix.sys.compiler == 'clang' }}
       run: |
         LLVM_VERSION=${{ matrix.sys.version }}
@@ -57,91 +61,49 @@ jobs:
         sudo apt-get --no-install-suggests --no-install-recommends install clang-$LLVM_VERSION || exit 1
         sudo apt-get --no-install-suggests --no-install-recommends install g++ g++-multilib || exit 1
         sudo ln -s /usr/include/asm-generic /usr/include/asm
-        CC=clang-$LLVM_VERSION
-        echo "CC=$CC" >> $GITHUB_ENV
-        CXX=clang++-$LLVM_VERSION
-        echo "CXX=$CXX" >> $GITHUB_ENV
+        # Export compiler as environment var
+        echo "CC=clang-$LLVM_VERSION" >> $GITHUB_ENV
+        echo "CXX=clang++-$LLVM_VERSION" >> $GITHUB_ENV
+
     - name: Checkout xsimd
       uses: actions/checkout@v6
+
     - name: Install mamba
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: environment.yml
+
     - name: Setup SDE
-      if: startswith(matrix.sys.flags, 'avx512')
+      if: startswith(matrix.sys.preset, 'avx512')
       run: sh install_sde.sh
+
     - name: Configure build
-      env:
-        CC: ${{ env.CC }}
-        CXX: ${{ env.CXX }}
       run: |
         if [[ '${{ matrix.sys.flags }}' == 'enable_xtl_complex' ]]; then
           CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DENABLE_XTL_COMPLEX=ON"
         fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=sandybridge"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx_128' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=sandybridge"
-          CXXFLAGS="$CXXFLAGS -DXSIMD_DEFAULT_ARCH=avx_128"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx2' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=haswell"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx2_128' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=haswell"
-          CXXFLAGS="$CXXFLAGS -DXSIMD_DEFAULT_ARCH=avx2_128"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'sse3' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=nocona"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=skylake-avx512"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512vl_128' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=skylake-avx512"
-          CXXFLAGS="$CXXFLAGS -DXSIMD_DEFAULT_ARCH=avx512vl_128"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512vl_256' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=skylake-avx512"
-          CXXFLAGS="$CXXFLAGS -DXSIMD_DEFAULT_ARCH=avx512vl_256"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512pf' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=knl"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512vbmi' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=cannonlake"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512vbmi2' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=icelake-server"
-        fi
-        if [[ '${{ matrix.sys.flags }}' == 'avx512vnni' ]]; then
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DTARGET_ARCH=knm"
-        fi
         if [[ '${{ matrix.sys.flags }}' == 'i386' ]]; then
-          CXX_FLAGS="$CXX_FLAGS -m32"
+          export CXXFLAGS="$CXXFLAGS -m32"
         fi
-        if [[ '${{ matrix.sys.flags }}' == 'force_no_instr_set' ]]; then
-          :
-        else
+        if [[ '${{ matrix.sys.flags }}' != 'force_no_instr_set' ]]; then
           CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DXSIMD_ENABLE_WERROR=ON"
         fi
 
-        # Cheap way of spotting uninitialized read
-        CXX_FLAGS="$CXX_FLAGS -ftrivial-auto-var-init=pattern"
-
         cmake -B _build \
-              -DBUILD_TESTS=ON \
-              -DBUILD_BENCHMARK=ON \
-              -DBUILD_EXAMPLES=ON \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_C_COMPILER=$CC \
-              -DCMAKE_CXX_COMPILER=$CXX \
-              $CMAKE_EXTRA_ARGS \
-              -DCMAKE_CXX_FLAGS='$CXX_FLAGS' \
+              --preset ${{ matrix.sys.preset }} \
+              -D BUILD_TESTS=ON \
+              -D BUILD_BENCHMARK=ON \
+              -D BUILD_EXAMPLES=ON \
+              -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_C_COMPILER="${CC}" \
+              -D CMAKE_CXX_COMPILER="${CXX}" \
+              -D TARGET_ARCH="x86-64" \
+              -D XSIMD_HARDEN_TRIVIAL_AUTO_VAR_INIT=ON \
+              "${CMAKE_EXTRA_ARGS}" \
               -G Ninja
+
     - name: Build
-      run: cmake --build _build
+      run: cmake --build _build --parallel
     - name: Test
       run: |
         # Set CPU feature test expectations, 0 is explicit absence of the feature
@@ -149,15 +111,15 @@ jobs:
         export XSIMD_TEST_CPU_ASSUME_RVV="0"
         export XSIMD_TEST_CPU_ASSUME_VSX="0"
         export XSIMD_TEST_CPU_ASSUME_VXE="0"
-        cd _build/test
-        if echo '${{ matrix.sys.flags }}' | grep -q 'avx512' ; then
+
+        if echo '${{ matrix.sys.preset }}' | grep -q 'avx512' ; then
           # Running with emulation, must have AVX512, lower tier are checked by implications in tests
           export XSIMD_TEST_CPU_ASSUME_AVX512F="1"
-          ../../sde-external-9.48.0-2024-11-25-lin/sde64 -tgl -- ./test_xsimd
+          ./sde-external-9.48.0-2024-11-25-lin/sde64 -spr -- ./_build/test/test_xsimd
         else
           export XSIMD_TEST_CPU_ASSUME_SSE4_2=$(grep -q 'sse4_2' /proc/cpuinfo && echo "1" || echo "0")
           export XSIMD_TEST_CPU_ASSUME_AVX=$(grep -q 'avx' /proc/cpuinfo && echo "1" || echo "0")
           export XSIMD_TEST_CPU_ASSUME_AVX512F=$(grep -q 'avx512f' /proc/cpuinfo && echo "1" || echo "0")
           export XSIMD_TEST_CPU_ASSUME_MANUFACTURER="intel,amd"
-          ./test_xsimd
+          ./_build/test/test_xsimd
         fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,26 +14,26 @@ jobs:
     strategy:
       matrix:
         sys:
-          - { compiler: 'gcc',   version: '12', flags: 'force_no_instr_set', preset: 'native' }
-          - { compiler: 'gcc',   version: '13', flags: 'enable_xtl_complex', preset: 'native' }
-          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx' }
-          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx2' }
-          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512f' }
-          - { compiler: 'gcc',   version: '10', flags: '',                   preset: 'avx512f' }
-          - { compiler: 'gcc',   version: '12', flags: 'i386',               preset: 'native' }
-          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512pf' }
-          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512vbmi' }
-          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'avx512vbmi2' }
-          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'avx512vnni_avx512bw' }
-          - { compiler: 'clang', version: '16', flags: 'force_no_instr_set', preset: 'native' }
-          - { compiler: 'clang', version: '16', flags: 'enable_xtl_complex', preset: 'native' }
-          - { compiler: 'clang', version: '17', flags: '',                   preset: 'avx' }
-          - { compiler: 'clang', version: '17', flags: '',                   preset: 'sse3' }
-          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512f' }
-          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx_128' }
-          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx2_128' }
-          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512vl_128' }
-          - { compiler: 'clang', version: '18', flags: '',                   preset: 'avx512vl_256' }
+          - { compiler: 'gcc',   version: '12', flags: 'force_no_instr_set', preset: 'dev-native' }
+          - { compiler: 'gcc',   version: '13', flags: 'enable_xtl_complex', preset: 'dev-native' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'dev-avx' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'dev-avx2' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'dev-avx512f' }
+          - { compiler: 'gcc',   version: '10', flags: '',                   preset: 'dev-avx512f' }
+          - { compiler: 'gcc',   version: '12', flags: 'i386',               preset: 'dev-native' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'dev-avx512pf' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'dev-avx512vbmi' }
+          - { compiler: 'gcc',   version: '14', flags: '',                   preset: 'dev-avx512vbmi2' }
+          - { compiler: 'gcc',   version: '13', flags: '',                   preset: 'dev-avx512vnni_avx512bw' }
+          - { compiler: 'clang', version: '16', flags: 'force_no_instr_set', preset: 'dev-native' }
+          - { compiler: 'clang', version: '16', flags: 'enable_xtl_complex', preset: 'dev-native' }
+          - { compiler: 'clang', version: '17', flags: '',                   preset: 'dev-avx' }
+          - { compiler: 'clang', version: '17', flags: '',                   preset: 'dev-sse3' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'dev-avx512f' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'dev-avx_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'dev-avx2_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'dev-avx512vl_128' }
+          - { compiler: 'clang', version: '18', flags: '',                   preset: 'dev-avx512vl_256' }
     steps:
     - name: Setup GCC compiler
       if: ${{ matrix.sys.compiler == 'gcc' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,7 +99,7 @@ jobs:
               -D CMAKE_CXX_COMPILER="${CXX}" \
               -D TARGET_ARCH="x86-64" \
               -D XSIMD_HARDEN_TRIVIAL_AUTO_VAR_INIT=ON \
-              "${CMAKE_EXTRA_ARGS}" \
+              ${CMAKE_EXTRA_ARGS} \
               -G Ninja
 
     - name: Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,7 +74,7 @@ jobs:
         environment-file: environment.yml
 
     - name: Setup SDE
-      if: startswith(matrix.sys.preset, 'avx512')
+      if: contains(matrix.sys.preset, 'avx512')
       run: sh install_sde.sh
 
     - name: Configure build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,21 @@ if(ENABLE_XTL_COMPLEX OR XSIMD_ENABLE_XTL_COMPLEX)
     )
 endif()
 
+# Dev options
+# ===========
+
+include (cmake/Hardening.cmake)
+
+option(
+    XSIMD_HARDEN_TRIVIAL_AUTO_VAR_INIT
+    "Enable -ftrivial-auto-var-init hardening flag if supported"
+    OFF
+)
+
+if(XSIMD_HARDEN_TRIVIAL_AUTO_VAR_INIT)
+    xsimd_harden_trivial_auto_var_init(xsimd INTERFACE)
+endif()
+
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -135,13 +135,13 @@
         {
             "name": "avx512vl_128",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_128"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_128"
             }
         },
         {
             "name": "avx512vl_256",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_256"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_256"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,214 @@
+{
+    "version": 5,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "native",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=native"
+            }
+        },
+        {
+            "name": "sse2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse2 -mno-sse3"
+            }
+        },
+        {
+            "name": "sse3",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse3 -mno-ssse3"
+            }
+        },
+        {
+            "name": "ssse3",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -mssse3 -mno-sse4.1"
+            }
+        },
+        {
+            "name": "sse4.1",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse4.1 -mno-sse4.2"
+            }
+        },
+        {
+            "name": "sse4.2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse4.2 -mno-avx"
+            }
+        },
+        {
+            "name": "avx",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mno-avx2"
+            }
+        },
+        {
+            "name": "avx_128",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mno-avx2 -DXSIMD_DEFAULT_ARCH=avx_128"
+            }
+        },
+        {
+            "name": "avx2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx2 -mno-avx512f"
+            }
+        },
+        {
+            "name": "avx2_128",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx2 -mno-avx512f -DXSIMD_DEFAULT_ARCH=avx2_128"
+            }
+        },
+        {
+            "name": "avx512f",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mno-avx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512cd",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512dq",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512bw",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512er",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512pf",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mavx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512ifma",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512vbmi",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512vbmi2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mno-avx512vnni"
+            }
+        },
+        {
+            "name": "avx512vnni_avx512bw",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mavx512vnni"
+            }
+        },
+        {
+            "name": "avx512vnni_avx512vbmi2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vnni"
+            }
+        },
+        {
+            "name": "avx512vl_128",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_128"
+            }
+        },
+        {
+            "name": "avx512vl_256",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_256"
+            }
+        },
+        {
+            "name": "neon",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv7-a -mfpu=neon -mfloat-abi=softfp"
+            }
+        },
+        {
+            "name": "neon64",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8-a"
+            }
+        },
+        {
+            "name": "sve128",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=128"
+            }
+        },
+        {
+            "name": "sve256",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=256"
+            }
+        },
+        {
+            "name": "sve512",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=512"
+            }
+        },
+        {
+            "name": "rvv128",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl128b_zba_zbb_zbs -mrvv-vector-bits=zvl"
+            }
+        },
+        {
+            "name": "rvv256",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl256b_zba_zbb_zbs -mrvv-vector-bits=zvl"
+            }
+        },
+        {
+            "name": "rvv512",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl512b_zba_zbb_zbs -mrvv-vector-bits=zvl"
+            }
+        },
+        {
+            "name": "vsx2",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power8 -maltivec -mvsx"
+            }
+        },
+        {
+            "name": "vsx3",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power9 -maltivec -mvsx"
+            }
+        },
+        {
+            "name": "vsx4",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power10 -maltivec -mvsx"
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,208 +7,525 @@
     },
     "configurePresets": [
         {
-            "name": "native",
+            "name": "xsimd-all",
+            "cacheVariables": {
+                "ENABLE_XTL_COMPLEX": "ON",
+                "BUILD_TESTS": "ON",
+                "BUILD_BENCHMARK": "ON"
+            }
+        },
+
+
+        {
+            "name": "base",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_EXTENSIONS": "OFF",
+                "CMAKE_CXX_STANDARD": "17",
+                "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+            }
+        },
+        {
+            "name": "debug-base",
+            "hidden": true,
+            "inherits": ["base"],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "release-base",
+            "hidden": true,
+            "inherits": ["base"],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+
+        {
+            "name": "native-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=native"
             }
         },
         {
-            "name": "sse2",
+            "name": "sse2-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse2 -mno-sse3"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -msse2 -mno-sse3"
             }
         },
         {
-            "name": "sse3",
+            "name": "sse3-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse3 -mno-ssse3"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -msse3 -mno-ssse3"
             }
         },
         {
-            "name": "ssse3",
+            "name": "ssse3-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -mssse3 -mno-sse4.1"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mssse3 -mno-sse4.1"
             }
         },
         {
-            "name": "sse4.1",
+            "name": "sse4.1-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse4.1 -mno-sse4.2"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -msse4.1 -mno-sse4.2"
             }
         },
         {
-            "name": "sse4.2",
+            "name": "sse4.2-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mno-sse4a -msse4.2 -mno-avx"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -msse4.2 -mno-avx"
             }
         },
         {
-            "name": "avx",
+            "name": "avx-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mno-avx2"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mno-avx2"
             }
         },
         {
-            "name": "avx_128",
+            "name": "avx2-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mno-avx2 -DXSIMD_DEFAULT_ARCH=avx_128"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx2 -mno-avx512f"
             }
         },
         {
-            "name": "avx2",
+            "name": "avx_128-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx2 -mno-avx512f"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mno-avx2 -DXSIMD_DEFAULT_ARCH=avx_128"
             }
         },
         {
-            "name": "avx2_128",
+            "name": "avx2_128-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx2 -mno-avx512f -DXSIMD_DEFAULT_ARCH=avx2_128"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx2 -mno-avx512f -DXSIMD_DEFAULT_ARCH=avx2_128"
             }
         },
         {
-            "name": "avx512f",
+            "name": "avx512f-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mno-avx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mno-avx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512cd",
+            "name": "avx512cd-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mno-avx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512dq",
+            "name": "avx512dq-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512bw",
+            "name": "avx512bw-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512er",
+            "name": "avx512er-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512pf",
+            "name": "avx512pf-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mavx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mno-avx512bw -mavx512er -mavx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512ifma",
+            "name": "avx512ifma-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512vbmi",
+            "name": "avx512vbmi-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mno-avx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512vbmi2",
+            "name": "avx512vbmi2-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mno-avx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mno-avx512vnni"
             }
         },
         {
-            "name": "avx512vnni_avx512bw",
+            "name": "avx512vnni_avx512bw-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mavx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mavx512vnni"
             }
         },
         {
-            "name": "avx512vnni_avx512vbmi2",
+            "name": "avx512vnni_avx512vbmi2-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vnni"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vnni"
             }
         },
         {
-            "name": "avx512vl_128",
+            "name": "avx512vl_128-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_128"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_128"
             }
         },
         {
-            "name": "avx512vl_256",
+            "name": "avx512vl_256-base",
+            "hidden": true,
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64-v2 -mno-sse4a -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_256"
+                "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=x86-64 -mavx -mavx2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mno-avx512er -mno-avx512pf -mno-avx512ifma -mno-avx512vbmi -mno-avx512vbmi2 -mno-avx512vnni -DXSIMD_DEFAULT_ARCH=avx512vl_256"
             }
         },
         {
-            "name": "neon",
+            "name": "neon-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv7-a -mfpu=neon -mfloat-abi=softfp"
             }
         },
         {
-            "name": "neon64",
+            "name": "neon64-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8-a"
             }
         },
         {
-            "name": "sve128",
+            "name": "sve128-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=128"
             }
         },
         {
-            "name": "sve256",
+            "name": "sve256-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=256"
             }
         },
         {
-            "name": "sve512",
+            "name": "sve512-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=armv8.2-a+sve -msve-vector-bits=512"
             }
         },
         {
-            "name": "rvv128",
+            "name": "rvv128-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl128b_zba_zbb_zbs -mrvv-vector-bits=zvl"
             }
         },
         {
-            "name": "rvv256",
+            "name": "rvv256-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl256b_zba_zbb_zbs -mrvv-vector-bits=zvl"
             }
         },
         {
-            "name": "rvv512",
+            "name": "rvv512-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -march=rv64gcv_zvl512b_zba_zbb_zbs -mrvv-vector-bits=zvl"
             }
         },
         {
-            "name": "vsx2",
+            "name": "vsx2-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power8 -maltivec -mvsx"
             }
         },
         {
-            "name": "vsx3",
+            "name": "vsx3-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power9 -maltivec -mvsx"
             }
         },
         {
-            "name": "vsx4",
+            "name": "vsx4-base",
+            "hidden": true,
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "$env{CXXFLAGS} -mcpu=power10 -maltivec -mvsx"
             }
+        },
+
+        {
+            "name": "dev-base",
+            "hidden": true,
+            "inherits": [
+                "debug-base",
+                "xsimd-all"
+            ]
+        },
+        {
+            "name": "dev-native",
+            "inherits": [
+                "dev-base",
+                "native-base"
+            ]
+        },
+        {
+            "name": "dev-sse2",
+            "inherits": [
+                "dev-base",
+                "sse2-base"
+            ]
+        },
+        {
+            "name": "dev-sse3",
+            "inherits": [
+                "dev-base",
+                "sse3-base"
+            ]
+        },
+        {
+            "name": "dev-ssse3",
+            "inherits": [
+                "dev-base",
+                "ssse3-base"
+            ]
+        },
+        {
+            "name": "dev-sse4.1",
+            "inherits": [
+                "dev-base",
+                "sse4.1-base"
+            ]
+        },
+        {
+            "name": "dev-sse4.2",
+            "inherits": [
+                "dev-base",
+                "sse4.2-base"
+            ]
+        },
+        {
+            "name": "dev-avx",
+            "inherits": [
+                "dev-base",
+                "avx-base"
+            ]
+        },
+        {
+            "name": "dev-avx2",
+            "inherits": [
+                "dev-base",
+                "avx2-base"
+            ]
+        },
+        {
+            "name": "dev-avx_128",
+            "inherits": [
+                "dev-base",
+                "avx_128-base"
+            ]
+        },
+        {
+            "name": "dev-avx2_128",
+            "inherits": [
+                "dev-base",
+                "avx2_128-base"
+            ]
+        },
+        {
+            "name": "dev-avx512f",
+            "inherits": [
+                "dev-base",
+                "avx512f-base"
+            ]
+        },
+        {
+            "name": "dev-avx512cd",
+            "inherits": [
+                "dev-base",
+                "avx512cd-base"
+            ]
+        },
+        {
+            "name": "dev-avx512dq",
+            "inherits": [
+                "dev-base",
+                "avx512dq-base"
+            ]
+        },
+        {
+            "name": "dev-avx512bw",
+            "inherits": [
+                "dev-base",
+                "avx512bw-base"
+            ]
+        },
+        {
+            "name": "dev-avx512er",
+            "inherits": [
+                "dev-base",
+                "avx512er-base"
+            ]
+        },
+        {
+            "name": "dev-avx512pf",
+            "inherits": [
+                "dev-base",
+                "avx512pf-base"
+            ]
+        },
+        {
+            "name": "dev-avx512ifma",
+            "inherits": [
+                "dev-base",
+                "avx512ifma-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vbmi",
+            "inherits": [
+                "dev-base",
+                "avx512vbmi-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vbmi2",
+            "inherits": [
+                "dev-base",
+                "avx512vbmi2-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vnni_avx512bw",
+            "inherits": [
+                "dev-base",
+                "avx512vnni_avx512bw-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vnni_avx512vbmi2",
+            "inherits": [
+                "dev-base",
+                "avx512vnni_avx512vbmi2-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vl_128",
+            "inherits": [
+                "dev-base",
+                "avx512vl_128-base"
+            ]
+        },
+        {
+            "name": "dev-avx512vl_256",
+            "inherits": [
+                "dev-base",
+                "avx512vl_256-base"
+            ]
+        },
+        {
+            "name": "dev-neon",
+            "inherits": [
+                "dev-base",
+                "neon-base"
+            ]
+        },
+        {
+            "name": "dev-neon64",
+            "inherits": [
+                "dev-base",
+                "neon64-base"
+            ]
+        },
+        {
+            "name": "dev-sve128",
+            "inherits": [
+                "dev-base",
+                "sve128-base"
+            ]
+        },
+        {
+            "name": "dev-sve256",
+            "inherits": [
+                "dev-base",
+                "sve256-base"
+            ]
+        },
+        {
+            "name": "dev-sve512",
+            "inherits": [
+                "dev-base",
+                "sve512-base"
+            ]
+        },
+        {
+            "name": "dev-rvv128",
+            "inherits": [
+                "dev-base",
+                "rvv128-base"
+            ]
+        },
+        {
+            "name": "dev-rvv256",
+            "inherits": [
+                "dev-base",
+                "rvv256-base"
+            ]
+        },
+        {
+            "name": "dev-rvv512",
+            "inherits": [
+                "dev-base",
+                "rvv512-base"
+            ]
+        },
+        {
+            "name": "dev-vsx2",
+            "inherits": [
+                "dev-base",
+                "vsx2-base"
+            ]
+        },
+        {
+            "name": "dev-vsx3",
+            "inherits": [
+                "dev-base",
+                "vsx3-base"
+            ]
+        },
+        {
+            "name": "dev-vsx4",
+            "inherits": [
+                "dev-base",
+                "vsx4-base"
+            ]
         }
     ]
 }

--- a/cmake/Hardening.cmake
+++ b/cmake/Hardening.cmake
@@ -1,0 +1,37 @@
+include(CheckCXXCompilerFlag)
+
+
+function(xsimd_harden_trivial_auto_var_init target scope)
+    # Names of option parameters (without arguments)
+    set(options)
+    # Names of named parameters with a single argument
+    set(one_value_args PATTERN)
+    # Names of named parameters with a multiple arguments
+    set(multi_values_args)
+    cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_values_args}" ${ARGN})
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(
+            AUTHOR_WARNING
+            "Unrecoginzed options passed to ${CMAKE_CURRENT_FUNCTION}: "
+            "${ARG_UNPARSED_ARGUMENTS}"
+        )
+    endif()
+
+    if(NOT scope STREQUAL "PUBLIC" AND NOT scope STREQUAL "PRIVATE" AND NOT scope STREQUAL "INTERFACE")
+        message(FATAL_ERROR "scope must be PUBLIC, PRIVATE, or INTERFACE, got: ${scope}")
+    endif()
+
+    if(NOT XSIMD_HARDEN_TRIVIAL_AUTO_VAR_INIT)
+        return()
+    endif()
+
+    if(NOT ARG_PATTERN)
+        set(ARG_PATTERN "pattern")
+    endif()
+
+    set(flag "-ftrivial-auto-var-init=${ARG_PATTERN}")
+    check_cxx_compiler_flag("${flag}" XSIMD_HAS_FTRIVIAL_AUTO_VAR_INIT_${ARG_PATTERN})
+    if(XSIMD_HAS_FTRIVIAL_AUTO_VAR_INIT_${ARG_PATTERN})
+        target_compile_options(${target} ${scope} "${flag}")
+    endif()
+endfunction()

--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1726,12 +1726,12 @@ namespace xsimd
                                           { return ssub(batch<T, sse4_2>(s), batch<T, sse4_2>(o)); },
                                           self, other);
             }
-            else if (std::is_signed_v<T>)
+            else if constexpr (std::is_signed_v<T>)
             {
-                auto mask = (other >> (8 * sizeof(T) - 1));
+                auto other_is_negative = other < batch<T, A>(T(0));
                 auto self_overflow_branch = min(std::numeric_limits<T>::max() + other, self);
                 auto self_underflow_branch = max(std::numeric_limits<T>::min() + other, self);
-                return select(batch_bool<T, A>(mask.data), self_overflow_branch, self_underflow_branch) - other;
+                return select(other_is_negative, self_overflow_branch, self_underflow_branch) - other;
             }
             else
             {

--- a/include/xsimd/arch/xsimd_common_fwd.hpp
+++ b/include/xsimd/arch/xsimd_common_fwd.hpp
@@ -60,6 +60,10 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
         template <size_t shift, class A, class T, class = std::enable_if_t<std::is_integral_v<T>>>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, requires_arch<common>) noexcept;
+        template <class A, class T, class Mask>
+        XSIMD_INLINE batch<T, A> decr_if(batch<T, A> const& self, Mask const& mask, requires_arch<common>) noexcept;
+        template <class A, class T, class Mask>
+        XSIMD_INLINE batch<T, A> incr_if(batch<T, A> const& self, Mask const& mask, requires_arch<common>) noexcept;
         template <class A, class T>
         XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
         template <class A, class T, class = std::enable_if_t<std::is_integral_v<T>>>


### PR DESCRIPTION
I've taken the direction of explicit flags such as `-mavx -mno-avx2`.
This is IMHO less error prone and more accurate that using architecture name such as `haswell`.
The main difference is that this does not add other feature flags or change the `-mtune` model.
For a test setting accuracy is more important IMHO.