### PR TITLE
Resolve xtl in user cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ cmake_minimum_required(VERSION 3.13)
 
 project(xsimd)
 
+OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
+OPTION(BUILD_TESTS "xsimd test suite" OFF)
+
 # Versioning
 # ==========
 
@@ -37,14 +40,18 @@ target_include_directories(xsimd INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-OPTION(ENABLE_XTL_COMPLEX "enables support for xcomplex defined in xtl" OFF)
-OPTION(BUILD_TESTS "xsimd test suite" OFF)
-
 target_compile_features(xsimd INTERFACE cxx_std_14)
+
+# Only add xtl build option to the build tree, that is, if xsimd being locally
+# developed or is vendored.
+# Otherwise (if an install is performed), this will be handled in the user
+# cmake script (xsimdConfig.cmake).
 if(ENABLE_XTL_COMPLEX)
     find_package(xtl 0.8.0 REQUIRED)
-    target_compile_definitions(xsimd INTERFACE XSIMD_ENABLE_XTL_COMPLEX=1)
-    target_link_libraries(xsimd INTERFACE xtl)
+    target_link_libraries(xsimd INTERFACE $<BUILD_INTERFACE:xtl>)
+    target_compile_definitions(xsimd INTERFACE
+        $<BUILD_INTERFACE:XSIMD_ENABLE_XTL_COMPLEX=1>
+    )
 endif()
 
 if(BUILD_TESTS)

--- a/xsimdConfig.cmake.in
+++ b/xsimdConfig.cmake.in
@@ -18,12 +18,37 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET @PROJECT_NAME@)
-    set(@PROJECT_NAME@_ENABLE_XTL_COMPLEX @ENABLE_XTL_COMPLEX@)
-    if(@PROJECT_NAME@_ENABLE_XTL_COMPLEX)
-        include(CMakeFindDependencyMacro)
-        find_dependency(xtl REQUIRED)
+    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+    get_target_property(
+        @PROJECT_NAME@_INCLUDE_DIRS
+        @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES
+    )
+
+    # xsimd <= 14 behaviour.
+    # Packagers that configured xsimd for their users with ENABLE_XTL_COMPLEX
+    # have it automatically enabled.
+    # Can be removed in xsimd 15. Keeping it with a version check so we do not
+    # miss the opportunity to remove it in the next major release.
+    # Compared to legacy version, users can now override the check
+    # with XSIMD_ENABLE_XTL_COMPLEX.
+    if(
+        @ENABLE_XTL_COMPLEX@
+        AND @XSIMD_VERSION_MAJOR@ LESS_EQUAL 14
+        AND NOT DEFINED XSIMD_ENABLE_XTL_COMPLEX
+    )
+        # The next check will handle adding it to the target
+        set(XSIMD_ENABLE_XTL_COMPLEX @ENABLE_XTL_COMPLEX@)
     endif()
 
-    include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-    get_target_property(@PROJECT_NAME@_INCLUDE_DIRS @PROJECT_NAME@ INTERFACE_INCLUDE_DIRECTORIES)
+    # Final users of xsimd in a package manager control whether or not to
+    # enable xtl with this variable.
+    if(XSIMD_ENABLE_XTL_COMPLEX)
+        include(CMakeFindDependencyMacro)
+        find_dependency(xtl 0.8.0 REQUIRED)
+        target_link_libraries(@PROJECT_NAME@ INTERFACE xtl)
+        target_compile_definitions(
+            @PROJECT_NAME@
+            INTERFACE XSIMD_ENABLE_XTL_COMPLEX=1
+        )
+    endif()
 endif()


### PR DESCRIPTION
Instead of having the packager (Debian, Conda recipe) decide on xtl support, let the final user decide on wheter to use it.

The current behaviour is maintained and overridable until xsim 15.
In xsimd 15, the configure time option has no effect for installed targets.

Close #1338
