### PR TITLE
fix: route avx512vl_128 FMA ops through fma3<avx2_128>

### DIFF
--- a/include/xsimd/arch/xsimd_fma3_avx2_128.hpp
+++ b/include/xsimd/arch/xsimd_fma3_avx2_128.hpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+ * Copyright (c) Johan Mabille, Sylvain Corlay, Wolf Vollprecht and         *
+ * Martin Renou                                                             *
+ * Copyright (c) QuantStack                                                 *
+ * Copyright (c) Serge Guelton                                              *
+ * Copyright (c) Marco Barbone                                              *
+ *                                                                          *
+ * Distributed under the terms of the BSD 3-Clause License.                 *
+ *                                                                          *
+ * The full license is in the file LICENSE, distributed with this software. *
+ ****************************************************************************/
+
+#ifndef XSIMD_FMA3_AVX2_128_HPP
+#define XSIMD_FMA3_AVX2_128_HPP
+
+#include "../types/xsimd_fma3_avx2_128_register.hpp"
+
+// Allow inclusion of xsimd_fma3_sse.hpp
+#ifdef XSIMD_FMA3_SSE_HPP
+#undef XSIMD_FMA3_SSE_HPP
+#define XSIMD_FORCE_FMA3_SSE_HPP
+#endif
+
+// Disallow inclusion of ./xsimd_fma3_sse_register.hpp
+#ifndef XSIMD_FMA3_SSE_REGISTER_HPP
+#define XSIMD_FMA3_SSE_REGISTER_HPP
+#define XSIMD_FORCE_FMA3_SSE_REGISTER_HPP
+#endif
+
+// Include ./xsimd_fma3_sse.hpp but s/sse4_2/avx2_128
+#define sse4_2 avx2_128
+#include "./xsimd_fma3_sse.hpp"
+#undef sse4_2
+#undef XSIMD_FMA3_SSE_HPP
+
+// Carefully restore guards
+#ifdef XSIMD_FORCE_FMA3_SSE_HPP
+#define XSIMD_FMA3_SSE_HPP
+#undef XSIMD_FORCE_FMA3_SSE_HPP
+#endif
+
+#ifdef XSIMD_FORCE_FMA3_SSE_REGISTER_HPP
+#undef XSIMD_FMA3_SSE_REGISTER_HPP
+#undef XSIMD_FORCE_FMA3_SSE_REGISTER_HPP
+#endif
+
+#endif

--- a/include/xsimd/arch/xsimd_isa.hpp
+++ b/include/xsimd/arch/xsimd_isa.hpp
@@ -3,6 +3,7 @@
  * Martin Renou                                                             *
  * Copyright (c) QuantStack                                                 *
  * Copyright (c) Serge Guelton                                              *
+ * Copyright (c) Marco Barbone                                              *
  *                                                                          *
  * Distributed under the terms of the BSD 3-Clause License.                 *
  *                                                                          *
@@ -72,6 +73,7 @@
 
 #if XSIMD_WITH_FMA3_AVX2
 #include "./xsimd_fma3_avx2.hpp"
+#include "./xsimd_fma3_avx2_128.hpp"
 #endif
 
 #if XSIMD_WITH_AVX512F

--- a/include/xsimd/types/xsimd_all_registers.hpp
+++ b/include/xsimd/types/xsimd_all_registers.hpp
@@ -3,6 +3,7 @@
  * Martin Renou                                                             *
  * Copyright (c) QuantStack                                                 *
  * Copyright (c) Serge Guelton                                              *
+ * Copyright (c) Marco Barbone                                              *
  *                                                                          *
  * Distributed under the terms of the BSD 3-Clause License.                 *
  *                                                                          *
@@ -24,6 +25,7 @@
 #include "./xsimd_avx512vnni_avx512vbmi2_register.hpp"
 #include "./xsimd_avx_register.hpp"
 #include "./xsimd_avxvnni_register.hpp"
+#include "./xsimd_fma3_avx2_128_register.hpp"
 #include "./xsimd_fma3_avx2_register.hpp"
 #include "./xsimd_fma3_avx_register.hpp"
 #include "./xsimd_fma3_sse_register.hpp"

--- a/include/xsimd/types/xsimd_avx512vl_register.hpp
+++ b/include/xsimd/types/xsimd_avx512vl_register.hpp
@@ -3,6 +3,7 @@
  * Martin Renou                                                             *
  * Copyright (c) QuantStack                                                 *
  * Copyright (c) Serge Guelton                                              *
+ * Copyright (c) Marco Barbone                                              *
  *                                                                          *
  * Distributed under the terms of the BSD 3-Clause License.                 *
  *                                                                          *
@@ -13,6 +14,7 @@
 #define XSIMD_AVX512VL_REGISTER_HPP
 
 #include "./xsimd_avx512cd_register.hpp"
+#include "./xsimd_fma3_avx2_128_register.hpp"
 
 namespace xsimd
 {
@@ -34,7 +36,7 @@ namespace xsimd
      *
      * AVX512VL instructions extension for 128 bits registers
      */
-    struct avx512vl_128 : avx2_128
+    struct avx512vl_128 : fma3<avx2_128>
     {
         static constexpr bool supported() noexcept { return XSIMD_WITH_AVX512VL; }
         static constexpr bool available() noexcept { return true; }

--- a/include/xsimd/types/xsimd_fma3_avx2_128_register.hpp
+++ b/include/xsimd/types/xsimd_fma3_avx2_128_register.hpp
@@ -10,42 +10,42 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#ifndef XSIMD_AVXVNNI_REGISTER_HPP
-#define XSIMD_AVXVNNI_REGISTER_HPP
+#ifndef XSIMD_FMA3_AVX2_128_REGISTER_HPP
+#define XSIMD_FMA3_AVX2_128_REGISTER_HPP
 
 #include "./xsimd_avx2_register.hpp"
-#include "./xsimd_fma3_avx2_register.hpp"
 
 namespace xsimd
 {
+    template <typename arch>
+    struct fma3;
+
     /**
      * @ingroup architectures
      *
-     * AVXVNNI instructions
+     * AVX2 + FMA instructions, for 128 bits registers
      */
-    // Derive from fma3<avx2> rather than avx2 so the FMA3 kernels (fnma/fnms ->
-    // vfnmadd) are in avxvnni's dispatch chain instead of the generic neg(x*y)+z
-    // fallback. fma3<avx2> always derives from avx2 and its kernels are only
-    // registered when XSIMD_WITH_FMA3_AVX2, so when FMA is disabled this base is
-    // transparent (dispatch falls straight through to avx2).
-    struct avxvnni : fma3<avx2>
+    template <>
+    struct fma3<avx2_128> : avx2_128
     {
-        static constexpr bool supported() noexcept { return XSIMD_WITH_AVXVNNI; }
+        static constexpr bool supported() noexcept { return XSIMD_WITH_FMA3_AVX2; }
         static constexpr bool available() noexcept { return true; }
-        static constexpr char const* name() noexcept { return "avxvnni"; }
+        static constexpr char const* name() noexcept { return "fma3+avx2/128"; }
     };
 
-#if XSIMD_WITH_AVXVNNI
+#if XSIMD_WITH_FMA3_AVX2
 
 #if !XSIMD_WITH_AVX2
-#error "architecture inconsistency: avxvnni requires avx2"
+#error "architecture inconsistency: fma3+avx2/128 requires avx2"
 #endif
 
     namespace types
     {
-        XSIMD_DECLARE_SIMD_REGISTER_ALIAS(avxvnni, avx2);
+
+        XSIMD_DECLARE_SIMD_REGISTER_ALIAS(fma3<avx2_128>, avx2_128);
+
     }
 #endif
-}
 
+}
 #endif


### PR DESCRIPTION
avx512vl_128 derived from avx2_128, whose dispatch chain reaches no FMA3 kernel provider, so fnma/fnms fell back to the generic neg(x*y)+/-z form (an extra vxorpd ahead of vfmadd) even on a real AVX-512 build. Its 256-bit sibling avx512vl_256 already derives from fma3<avx2> and was unaffected.

Apply the same fma3<> inheritance pattern as avxvnni and avx512vl_256: introduce fma3<avx2_128> (a strict superset of avx2_128 that adds the 128-bit FMA3 kernels.

Validated under Intel SDE -skx: avx512vl_128 fnma/fnms/fma/fms/fmas emit 128-bit vf* (no vxorpd) and match scalar std::fma for float and double; avxvnni and fma3<avx2> codegen unchanged; all FMA-capable x86 arches compile across sse/avx2/avxvnni/avx512 flag sets.