### PR TITLE
fix( #1375 ): under-aligned buffers in large-arg range reduction

### DIFF
--- a/include/xsimd/arch/common/xsimd_common_trigo.hpp
+++ b/include/xsimd/arch/common/xsimd_common_trigo.hpp
@@ -596,9 +596,9 @@ namespace xsimd
                     {
                         static constexpr std::size_t size = B::size;
                         using value_type = typename B::value_type;
-                        alignas(B) std::array<value_type, size> tmp;
-                        alignas(B) std::array<value_type, size> txr;
-                        alignas(B) std::array<value_type, size> args;
+                        alignas(B::arch_type::alignment()) std::array<value_type, size> tmp;
+                        alignas(B::arch_type::alignment()) std::array<value_type, size> txr;
+                        alignas(B::arch_type::alignment()) std::array<value_type, size> args;
                         x.store_aligned(args.data());
 
                         for (std::size_t i = 0; i < size; ++i)


### PR DESCRIPTION
The generic trigonometric range-reduction kernel stored the batch into std::array buffers declared alignas(B). alignof(B) equals the alignment of the underlying SIMD register, which on some ABIs is smaller than the alignment store_aligned/load_aligned require (A::alignment()). On armhf NEON alignof(batch<float>) is 8 while neon::alignment() is 16, so the buffer was only 8-byte aligned and store_aligned tripped its alignment assertion whenever the stack happened to place it at an 8-mod-16 address.

This is exactly what broke the Debian armhf build of 14.2.0 (test '[complex power] pow real complex' -> SIGABRT in store_aligned).
