### PR TITLE
endian.h not present on AIX

### DIFF
--- a/include/xsimd/arch/xsimd_vsx.hpp
+++ b/include/xsimd/arch/xsimd_vsx.hpp
@@ -16,8 +16,6 @@
 #include "../types/xsimd_vsx_register.hpp"
 #include "./common/xsimd_common_cast.hpp"
 
-#include <endian.h>
-
 #include <complex>
 #include <type_traits>
 


### PR DESCRIPTION
endian.h header file is not present on AIX, hence skipping its inclusion on AIX