### PR TITLE
Fix gcc-15 'must be an 8-bit immediate' in avx_128 swizzle

### DIFF
--- a/include/xsimd/arch/xsimd_avx_128.hpp
+++ b/include/xsimd/arch/xsimd_avx_128.hpp
@@ -210,13 +210,15 @@ namespace xsimd
         template <class A, uint32_t V0, uint32_t V1, uint32_t V2, uint32_t V3>
         XSIMD_INLINE batch<float, A> swizzle(batch<float, A> const& self, batch_constant<uint32_t, A, V0, V1, V2, V3>, requires_arch<avx_128>) noexcept
         {
-            return _mm_permute_ps(self, detail::mod_shuffle(V0, V1, V2, V3));
+            constexpr auto mask = detail::mod_shuffle(V0, V1, V2, V3);
+            return _mm_permute_ps(self, mask);
         }
 
         template <class A, uint32_t V0, uint32_t V1>
         XSIMD_INLINE batch<double, A> swizzle(batch<double, A> const& self, batch_constant<uint64_t, A, V0, V1>, requires_arch<avx_128>) noexcept
         {
-            return _mm_permute_pd(self, detail::mod_shuffle(V0, V1));
+            constexpr auto mask = detail::mod_shuffle(V0, V1);
+            return _mm_permute_pd(self, mask);
         }
 
     }


### PR DESCRIPTION
g++-15 rejects a `constexpr` helper call passed inline to `_mm_permute_ps`/`_mm_permute_pd`:

```
error: the last argument must be an 8-bit immediate
```

It refuses to constant-fold a `constexpr` *function call* directly at a builtin immediate operand unless the value is first bound to a `constexpr` object. Every other `detail::mod_shuffle` / `detail::shuffle` call site in the codebase already does this; these two `swizzle` overloads in `xsimd_avx_128.hpp` were the only inline exceptions.

