### PR TITLE
fix: make the avx512vl_128 and avx512vl_256 arches build and pass

### DIFF
--- a/include/xsimd/arch/xsimd_avx.hpp
+++ b/include/xsimd/arch/xsimd_avx.hpp
@@ -1477,10 +1477,10 @@ namespace xsimd
         {
             if (std::is_signed_v<T>)
             {
-                auto mask = (other >> (8 * sizeof(T) - 1));
+                auto negative = other < batch<T, A>(T(0));
                 auto self_pos_branch = min(std::numeric_limits<T>::max() - other, self);
                 auto self_neg_branch = max(std::numeric_limits<T>::min() - other, self);
-                return other + select(batch_bool<T, A>(mask.data), self_neg_branch, self_pos_branch);
+                return other + select(negative, self_neg_branch, self_pos_branch);
             }
             else
             {
@@ -1728,10 +1728,10 @@ namespace xsimd
             }
             else if (std::is_signed_v<T>)
             {
-                auto mask = (other >> (8 * sizeof(T) - 1));
+                auto negative = other < batch<T, A>(T(0));
                 auto self_overflow_branch = min(std::numeric_limits<T>::max() + other, self);
                 auto self_underflow_branch = max(std::numeric_limits<T>::min() + other, self);
-                return select(batch_bool<T, A>(mask.data), self_overflow_branch, self_underflow_branch) - other;
+                return select(negative, self_overflow_branch, self_underflow_branch) - other;
             }
             else
             {

--- a/include/xsimd/arch/xsimd_avx512f.hpp
+++ b/include/xsimd/arch/xsimd_avx512f.hpp
@@ -1544,6 +1544,8 @@ namespace xsimd
             XSIMD_INLINE unsigned char tobitset(unsigned char unpacked[N])
             {
                 static_assert(N == 8 || N == 4 || N == 2, "valid pack size");
+                // The multiply gathers the N selected bits into the top N bits
+                // of the 8 * N bit product, so the shift is 8 * N - N.
                 if constexpr (N == 8)
                 {
                     uint64_t data;
@@ -1561,7 +1563,7 @@ namespace xsimd
 
                     const uint32_t magic = (0x80 + 0x4000 + 0x200000 + 0x10000000);
 
-                    unsigned char res = ((data * magic) >> 24) & 0xFF;
+                    unsigned char res = ((data * magic) >> 28) & 0xFF;
                     return res;
                 }
                 else if constexpr (N == 2)
@@ -1571,7 +1573,7 @@ namespace xsimd
 
                     const uint16_t magic = (0x80 + 0x4000);
 
-                    unsigned char res = ((data * magic) >> 8) & 0xFF;
+                    unsigned char res = ((data * magic) >> 14) & 0xFF;
                     return res;
                 }
             }

--- a/include/xsimd/arch/xsimd_common_fwd.hpp
+++ b/include/xsimd/arch/xsimd_common_fwd.hpp
@@ -60,8 +60,12 @@ namespace xsimd
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
         template <size_t shift, class A, class T, class = std::enable_if_t<std::is_integral_v<T>>>
         XSIMD_INLINE batch<T, A> bitwise_rshift(batch<T, A> const& self, requires_arch<common>) noexcept;
+        template <class A, class T, class Mask>
+        XSIMD_INLINE batch<T, A> decr_if(batch<T, A> const& self, Mask const& mask, requires_arch<common>) noexcept;
         template <class A, class T>
         XSIMD_INLINE batch_bool<T, A> gt(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
+        template <class A, class T, class Mask>
+        XSIMD_INLINE batch<T, A> incr_if(batch<T, A> const& self, Mask const& mask, requires_arch<common>) noexcept;
         template <class A, class T, class = std::enable_if_t<std::is_integral_v<T>>>
         XSIMD_INLINE batch<T, A> mul(batch<T, A> const& self, batch<T, A> const& other, requires_arch<common>) noexcept;
         template <class A, class T, class = std::enable_if_t<std::is_integral_v<T>>>


### PR DESCRIPTION
1. xsimd_common_fwd.hpp — forward-declare incr_if/decr_if. The VL sub-arches call the common versions unqualified from headers included before xsimd_common.hpp; dependent lookup can't find them. 16 compile errors on vl_128.
2. xsimd_avx512f.hpp — tobitset<4> shift 24→28, tobitset<2> 8→14 (correct shift is 8N-N). Only reachable for batch_bool of size 4 and 2, i.e. only those two arches.
4. xsimd_avx.hpp — sadd/ssub build the sign mask with other < 0 instead of reinterpreting a shifted vector as batch_bool, which breaks on k-register booleans. Also drops sadd<int64_t> 24→14 and ssub<int64_t> 21→11 instructions on AVX2.