### PR TITLE
perf: double fast_cast

### DIFF
--- a/include/xsimd/arch/common/xsimd_common_details.hpp
+++ b/include/xsimd/arch/common/xsimd_common_details.hpp
@@ -251,6 +251,26 @@ namespace xsimd
                 return bitwise_cast<int64_t>(self);
             }
 
+            // Common double -> int64_t cast.  Adding 1.5 * 2^52 puts an integer
+            // |v| < 2^51 exactly in the mantissa, so subtracting the bit patterns
+            // reads it back out.  trunc first, then split into halves that small.
+            // An architecture reaching this overload needs a non-common trunc:
+            // the common one goes through to_int and would recurse into here.
+            template <class A>
+            XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& x, batch<int64_t, A> const&, requires_arch<common>) noexcept
+            {
+                using batch_type = batch<double, A>;
+                batch_type magic(0x1.8p52);
+                batch<int64_t, A> magic_i = bitwise_cast<int64_t>(magic);
+                batch_type t = trunc(x);
+                batch_type hi = trunc(t * batch_type(0x1p-32)); // |hi| <= 2^31
+                batch_type lo = t - hi * batch_type(0x1p32); // exact, |lo| < 2^32
+                detail::reassociation_barrier(lo, "keep lo below 2^32 before the magic add");
+                batch<int64_t, A> hi_i = bitwise_cast<int64_t>(hi + magic) - magic_i;
+                batch<int64_t, A> lo_i = bitwise_cast<int64_t>(lo + magic) - magic_i;
+                return (hi_i << 32) + lo_i;
+            }
+
             // Provide a common uint32_t -> float cast only if we have a
             // non-common int32_t -> float fast_cast
             template <class A, class = decltype(fast_cast(std::declval<batch<int32_t, A> const&>(), std::declval<batch<float, A> const&>(), A {}))>

--- a/include/xsimd/arch/xsimd_rvv.hpp
+++ b/include/xsimd/arch/xsimd_rvv.hpp
@@ -1254,16 +1254,22 @@ namespace xsimd
             using rvv_enable_ftoi_t = std::enable_if_t<(sizeof(T) == sizeof(U) && std::is_floating_point_v<T> && !std::is_floating_point_v<U>), int>;
             template <class T, class U>
             using rvv_enable_itof_t = std::enable_if_t<(sizeof(T) == sizeof(U) && !std::is_floating_point_v<T> && std::is_floating_point_v<U>), int>;
+        }
 
-            template <class A, class T, class U, rvv_enable_ftoi_t<T, U> = 0>
+        // The dispatcher looks fast_cast up from kernel::detail, so both overloads have
+        // to live there: in detail_rvv neither ADL nor unqualified lookup reaches them
+        // and every conversion falls back to the scalar loop.
+        namespace detail
+        {
+            template <class A, class T, class U, detail_rvv::rvv_enable_ftoi_t<T, U> = 0>
             XSIMD_INLINE batch<U, A> fast_cast(batch<T, A> const& arg, batch<U, A> const&, requires_arch<rvv>) noexcept
             {
-                return rvvfcvt_rtz(U {}, arg);
+                return detail_rvv::rvvfcvt_rtz(U {}, arg);
             }
-            template <class A, class T, class U, rvv_enable_itof_t<T, U> = 0>
+            template <class A, class T, class U, detail_rvv::rvv_enable_itof_t<T, U> = 0>
             XSIMD_INLINE batch<U, A> fast_cast(batch<T, A> const& arg, batch<U, A> const&, requires_arch<rvv>) noexcept
             {
-                return rvvfcvt_f(arg);
+                return detail_rvv::rvvfcvt_f(arg);
             }
         }
 

--- a/include/xsimd/arch/xsimd_sse2.hpp
+++ b/include/xsimd/arch/xsimd_sse2.hpp
@@ -2259,6 +2259,26 @@ namespace xsimd
             transpose(reinterpret_cast<batch<double, A>*>(matrix_begin), reinterpret_cast<batch<double, A>*>(matrix_end), A {});
         }
 
+        // trunc
+        template <class A>
+        XSIMD_INLINE batch<double, A> trunc(batch<double, A> const& self, requires_arch<sse2>) noexcept
+        {
+            // The common implementation goes through batch_cast<int64_t>, which on sse2
+            // is itself built on trunc.  Adding 2^52 rounds |self| to an integer whatever
+            // the rounding mode is; one conditional decrement turns that into floor.
+            __m128d signmask = _mm_set1_pd(-0.);
+            __m128d t2n = _mm_set1_pd(4503599627370496.); //  2^52
+            __m128d s = _mm_and_pd(self, signmask);
+            __m128d v = _mm_andnot_pd(signmask, self); // |self|
+            __m128d d0 = _mm_add_pd(v, t2n);
+            detail::reassociation_barrier(d0, "prevent collapsing (v + 2^52) - 2^52 back to v");
+            __m128d d = _mm_sub_pd(d0, t2n);
+            d = _mm_sub_pd(d, _mm_and_pd(_mm_cmpgt_pd(d, v), _mm_set1_pd(1.))); // floor(|self|)
+            d = _mm_andnot_pd(signmask, d); // roundTowardNegative makes 2^52 - 2^52 negative
+            __m128d small = _mm_cmplt_pd(v, t2n);
+            return _mm_or_pd(s, _mm_or_pd(_mm_and_pd(small, d), _mm_andnot_pd(small, v)));
+        }
+
         // zip_hi
         template <class A>
         XSIMD_INLINE batch<float, A> zip_hi(batch<float, A> const& self, batch<float, A> const& other, requires_arch<sse2>) noexcept

--- a/include/xsimd/arch/xsimd_sve.hpp
+++ b/include/xsimd/arch/xsimd_sve.hpp
@@ -905,47 +905,48 @@ namespace xsimd
          ******************************/
 
         // fast_cast
-        namespace detail_sve
+        // The dispatcher looks these up from kernel::detail, so they have to live there:
+        // in detail_sve neither ADL nor unqualified lookup reaches them and every
+        // conversion falls back to the scalar loop.  Each overload is keyed on
+        // requires_arch<sve>, which carries XSIMD_SVE_BITS, so no ODR issue arises.
+        namespace detail
         {
-            inline namespace XSIMD_SVE_NAMESPACE
+            template <class A, class T, enable_sized_integral_t<T, 4> = 0>
+            XSIMD_INLINE batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
             {
-                template <class A, class T, detail::enable_sized_integral_t<T, 4> = 0>
-                XSIMD_INLINE batch<float, A> fast_cast(batch<T, A> const& arg, batch<float, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_f32_x(detail_sve::ptrue<T>(), arg);
-                }
+                return svcvt_f32_x(detail_sve::ptrue<T>(), arg);
+            }
 
-                template <class A, class T, detail::enable_sized_integral_t<T, 8> = 0>
-                XSIMD_INLINE batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_f64_x(detail_sve::ptrue<T>(), arg);
-                }
+            template <class A, class T, enable_sized_integral_t<T, 8> = 0>
+            XSIMD_INLINE batch<double, A> fast_cast(batch<T, A> const& arg, batch<double, A> const&, requires_arch<sve>) noexcept
+            {
+                return svcvt_f64_x(detail_sve::ptrue<T>(), arg);
+            }
 
-                template <class A>
-                XSIMD_INLINE batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_s32_x(detail_sve::ptrue<float>(), arg);
-                }
+            template <class A>
+            XSIMD_INLINE batch<int32_t, A> fast_cast(batch<float, A> const& arg, batch<int32_t, A> const&, requires_arch<sve>) noexcept
+            {
+                return svcvt_s32_x(detail_sve::ptrue<float>(), arg);
+            }
 
-                template <class A>
-                XSIMD_INLINE batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_u32_x(detail_sve::ptrue<float>(), arg);
-                }
+            template <class A>
+            XSIMD_INLINE batch<uint32_t, A> fast_cast(batch<float, A> const& arg, batch<uint32_t, A> const&, requires_arch<sve>) noexcept
+            {
+                return svcvt_u32_x(detail_sve::ptrue<float>(), arg);
+            }
 
-                template <class A>
-                XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_s64_x(detail_sve::ptrue<double>(), arg);
-                }
+            template <class A>
+            XSIMD_INLINE batch<int64_t, A> fast_cast(batch<double, A> const& arg, batch<int64_t, A> const&, requires_arch<sve>) noexcept
+            {
+                return svcvt_s64_x(detail_sve::ptrue<double>(), arg);
+            }
 
-                template <class A>
-                XSIMD_INLINE batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
-                {
-                    return svcvt_u64_x(detail_sve::ptrue<double>(), arg);
-                }
-            } // namespace XSIMD_SVE_NAMESPACE
-        } // namespace detail_sve
+            template <class A>
+            XSIMD_INLINE batch<uint64_t, A> fast_cast(batch<double, A> const& arg, batch<uint64_t, A> const&, requires_arch<sve>) noexcept
+            {
+                return svcvt_u64_x(detail_sve::ptrue<double>(), arg);
+            }
+        } // namespace detail
 
         /*********
          * Miscs *

--- a/test/test_batch_cast.cpp
+++ b/test/test_batch_cast.cpp
@@ -396,7 +396,10 @@ TYPED_TEST(batch_cast_test, cast_sizeshift2)
 }
 #endif
 
-#if XSIMD_WITH_SSE2
+// sve and rvv used to declare fast_cast in detail_sve / detail_rvv, where the
+// dispatcher in kernel::detail cannot see it, so every conversion silently fell back
+// to the scalar loop.  Assert on those two arches as well as on sse2.
+#if XSIMD_WITH_SSE2 || XSIMD_WITH_SVE || XSIMD_WITH_RVV
 TEST_CASE_TEMPLATE("[xsimd cast tests]", B, CONVERSION_TYPES)
 {
     SUBCASE("use fastcast")

--- a/test/test_batch_cast.cpp
+++ b/test/test_batch_cast.cpp
@@ -14,6 +14,8 @@
 
 #include "test_utils.hpp"
 
+#include <random>
+
 #if !XSIMD_WITH_NEON || XSIMD_WITH_NEON64
 namespace detail
 {
@@ -150,6 +152,12 @@ struct batch_cast_test
             -9223372036854775808.0,
             18446744073709550591.0
         };
+    }
+
+    void test_cast_all_lanes() const
+    {
+        test_cast_all_lanes_impl<float_batch, int32_batch>("batch cast float -> int32");
+        test_cast_all_lanes_impl<double_batch, int64_batch>("batch cast double -> int64");
     }
 
     void test_bool_cast() const
@@ -345,6 +353,56 @@ private:
         }
     }
 
+    // A float -> same-width-int cast can recombine per-lane data, so every lane has to
+    // carry a different value; the other cast tests are splats and only look at lane 0.
+    template <class B_in, class B_out>
+    void test_cast_all_lanes_impl(const std::string& name) const
+    {
+        using T_in = typename B_in::value_type;
+        using T_out = typename B_out::value_type;
+        constexpr int digits = std::numeric_limits<T_out>::digits; // 31 or 63
+        const T_in beyond = std::ldexp(T_in(1), digits); // one past the top of T_out
+        const T_in top = std::nextafter(beyond, T_in(0)); // the largest T_in that fits
+        // The ends of the range, then every power of two the cast can reach probed on
+        // both sides: those are where a carry between halves and the end of the
+        // mantissa live, and a random draw never lands on one of them.
+        std::vector<T_in> values = { T_in(0), -T_in(0), -beyond, top, -top };
+        for (int e = 0; e < digits; ++e)
+        {
+            const T_in p = std::ldexp(T_in(1), e);
+            for (const T_in v : { p - T_in(1.5), p - T_in(1), p - T_in(.5), std::nextafter(p, T_in(0)),
+                                  p, std::nextafter(p, beyond), p + T_in(.5), p + T_in(1) })
+            {
+                values.push_back(v);
+                values.push_back(-v);
+            }
+        }
+        // Eight random values in every binade the cast can reach, both signs.  The
+        // engine is default seeded, so a failure reproduces.
+        std::default_random_engine generator;
+        std::uniform_real_distribution<T_in> mantissa(T_in(1), T_in(2));
+        for (int e = -1; e < digits; ++e)
+            for (int k = 0; k < 8; ++k)
+            {
+                const T_in v = std::ldexp(mantissa(generator), e);
+                values.push_back(v);
+                values.push_back(-v);
+            }
+        constexpr size_t n = B_in::size;
+        T_in buffer[n];
+        for (size_t i = 0; i < values.size(); i += n)
+        {
+            for (size_t l = 0; l < n; ++l)
+                buffer[l] = values[(i + l) % values.size()];
+            B_out res = xsimd::batch_cast<T_out>(B_in::load_unaligned(buffer));
+            for (size_t l = 0; l < n; ++l)
+            {
+                INFO(name, ", lane ", l, " holding ", buffer[l]);
+                CHECK_SCALAR_EQ(static_cast<T_out>(buffer[l]), res.get(l));
+            }
+        }
+    }
+
     template <class B_in, class B_out>
     void test_bool_cast_impl(const std::string& name) const
     {
@@ -380,6 +438,11 @@ TEST_CASE_TEMPLATE("[xsimd cast tests]", B, CONVERSION_TYPES)
     {
         Test.test_cast();
     }
+
+    SUBCASE("cast all lanes")
+    {
+        Test.test_cast_all_lanes();
+    }
 }
 #endif
 #if 0 && XSIMD_X86_INSTR_SET > D_X86_AVX_VERSION
@@ -396,19 +459,27 @@ TYPED_TEST(batch_cast_test, cast_sizeshift2)
 }
 #endif
 
+// neon32 has no batch<double>, and detail::uses_fast_cast_v lives inside the guard
+// that excludes it, so the whole block needs the same guard.
+#if !XSIMD_WITH_NEON || XSIMD_WITH_NEON64
 // sve and rvv used to declare fast_cast in detail_sve / detail_rvv, where the
 // dispatcher in kernel::detail cannot see it, so every conversion silently fell back
-// to the scalar loop.  Assert on those two arches as well as on sse2.
-#if XSIMD_WITH_SSE2 || XSIMD_WITH_SVE || XSIMD_WITH_RVV
+// to the scalar loop.  int32 <-> float has no common overload, so both asserts below
+// fail if an architecture declares its fast_cast outside kernel::detail again.
 TEST_CASE_TEMPLATE("[xsimd cast tests]", B, CONVERSION_TYPES)
 {
     SUBCASE("use fastcast")
     {
         using A = xsimd::default_arch;
+#if XSIMD_WITH_SSE2 || XSIMD_WITH_SVE || XSIMD_WITH_RVV
         static_assert(detail::uses_fast_cast_v<A, int32_t, float>,
                       "expected int32 to float conversion to use fast_cast");
         static_assert(detail::uses_fast_cast_v<A, float, int32_t>,
                       "expected float to int32 conversion to use fast_cast");
+#endif
+        // the common overload answers double -> int64_t on every architecture
+        static_assert(detail::uses_fast_cast_v<A, double, int64_t>,
+                      "expected double to int64 conversion to use fast_cast");
     }
 }
 #endif


### PR DESCRIPTION
Common double -> int64_t cast.  Adding 1.5 * 2^52 puts an integer |v| < 2^51 exactly in the mantissa so subtracting the bit patterns reads it back out.

3.743 -> 0.551 ns/element on a 128 KB L2-resident loop (Xeon w5-3435X, gcc 13.3
-O3, min of 300 reps).
