### PR TITLE
Fix comilation of neon/shifts_all_positive on msvc.

### DIFF
--- a/include/xsimd/arch/xsimd_neon.hpp
+++ b/include/xsimd/arch/xsimd_neon.hpp
@@ -2645,7 +2645,7 @@ namespace xsimd
             XSIMD_INLINE bool shifts_all_positive(batch<T, A> const& b) noexcept
             {
                 std::array<T, batch<T, A>::size> tmp = {};
-                b.store_unaligned(tmp.begin());
+                b.store_unaligned(tmp.data());
                 return std::all_of(tmp.begin(), tmp.end(), [](T x)
                                    { return x >= 0; });
             }


### PR DESCRIPTION
This fixes a regression since b8f7ebef1a5197cb2df4856d133d2c8b236988e4

However this seems to only affects debug builds...